### PR TITLE
Fix: reset career now clears pilot name and portrait

### DIFF
--- a/cargo-lander/game.js
+++ b/cargo-lander/game.js
@@ -12,7 +12,7 @@
 // game.js → game/* → render.js + render/* (render.js instantiates window.game).
 
 class CargoGame {
-    static VERSION = '0.10.2';
+    static VERSION = '0.10.3';
 
     constructor() {
         this.canvas = null;

--- a/cargo-lander/game/menu.js
+++ b/cargo-lander/game/menu.js
@@ -271,12 +271,12 @@ Object.assign(CargoGame.prototype, {
             hullPlating: 0,
             shieldRegen: 0
         };
-        this.career = { 
-            pilotName: this.career.pilotName, 
-            portrait: this.career.portrait,
-            totalDeliveries: 0, 
-            missionsComplete: 0, 
-            crashes: 0 
+        this.career = {
+            pilotName: '',
+            portrait: null,
+            totalDeliveries: 0,
+            missionsComplete: 0,
+            crashes: 0
         };
         this.highscores = {};
 

--- a/cargo-lander/index.html
+++ b/cargo-lander/index.html
@@ -2376,42 +2376,42 @@
     <!-- Matter.js physics engine -->
     <script src="vendor/matter.min.js"></script>
     <!-- Level registry: defines registerLevel(), levels[], upgradeCatalog, quest helpers -->
-    <script src="upgrades.js?v=0.10.2"></script>
-    <script src="levels.js?v=0.10.2"></script>
-    <script src="levelGenerator.js?v=0.10.2"></script>
+    <script src="upgrades.js?v=0.10.3"></script>
+    <script src="levels.js?v=0.10.3"></script>
+    <script src="levelGenerator.js?v=0.10.3"></script>
     <!-- Individual level configs (each calls registerLevel) -->
 
-    <script src="level1.js?v=0.10.2"></script>
-    <script src="level2.js?v=0.10.2"></script>
-    <script src="level3.js?v=0.10.2"></script>
-    <script src="level4.js?v=0.10.2"></script>
-    <script src="level5.js?v=0.10.2"></script>
-    <script src="level6.js?v=0.10.2"></script>
-    <script src="level7.js?v=0.10.2"></script>
-    <script src="level8.js?v=0.10.2"></script>
-    <script src="level9.js?v=0.10.2"></script>
-    <script src="level10.js?v=0.10.2"></script>
-    <script src="levelTest.js?v=0.10.2"></script>
+    <script src="level1.js?v=0.10.3"></script>
+    <script src="level2.js?v=0.10.3"></script>
+    <script src="level3.js?v=0.10.3"></script>
+    <script src="level4.js?v=0.10.3"></script>
+    <script src="level5.js?v=0.10.3"></script>
+    <script src="level6.js?v=0.10.3"></script>
+    <script src="level7.js?v=0.10.3"></script>
+    <script src="level8.js?v=0.10.3"></script>
+    <script src="level9.js?v=0.10.3"></script>
+    <script src="level10.js?v=0.10.3"></script>
+    <script src="levelTest.js?v=0.10.3"></script>
     <!-- Engine -->
-    <script src="audio.js?v=0.10.2"></script>
-    <script src="shaders.js?v=0.10.2"></script>
-    <script src="physics.js?v=0.10.2"></script>
-    <script src="physics/collision.js?v=0.10.2"></script>
-    <script src="physics/mechanics.js?v=0.10.2"></script>
-    <script src="physics/entities.js?v=0.10.2"></script>
-    <script src="physics/atmosphere.js?v=0.10.2"></script>
-    <script src="game.js?v=0.10.2"></script>
-    <script src="game/input.js?v=0.10.2"></script>
-    <script src="game/menu.js?v=0.10.2"></script>
-    <script src="game/hud.js?v=0.10.2"></script>
-    <script src="game/cargo.js?v=0.10.2"></script>
-    <script src="render.js?v=0.10.2"></script>
-    <script src="render/background.js?v=0.10.2"></script>
-    <script src="render/terrain.js?v=0.10.2"></script>
-    <script src="render/entities.js?v=0.10.2"></script>
-    <script src="render/effects.js?v=0.10.2"></script>
-    <script src="render/night.js?v=0.10.2"></script>
-    <script src="render/ui.js?v=0.10.2"></script>
+    <script src="audio.js?v=0.10.3"></script>
+    <script src="shaders.js?v=0.10.3"></script>
+    <script src="physics.js?v=0.10.3"></script>
+    <script src="physics/collision.js?v=0.10.3"></script>
+    <script src="physics/mechanics.js?v=0.10.3"></script>
+    <script src="physics/entities.js?v=0.10.3"></script>
+    <script src="physics/atmosphere.js?v=0.10.3"></script>
+    <script src="game.js?v=0.10.3"></script>
+    <script src="game/input.js?v=0.10.3"></script>
+    <script src="game/menu.js?v=0.10.3"></script>
+    <script src="game/hud.js?v=0.10.3"></script>
+    <script src="game/cargo.js?v=0.10.3"></script>
+    <script src="render.js?v=0.10.3"></script>
+    <script src="render/background.js?v=0.10.3"></script>
+    <script src="render/terrain.js?v=0.10.3"></script>
+    <script src="render/entities.js?v=0.10.3"></script>
+    <script src="render/effects.js?v=0.10.3"></script>
+    <script src="render/night.js?v=0.10.3"></script>
+    <script src="render/ui.js?v=0.10.3"></script>
 
     <script>
         // Start the game!

--- a/cargo-lander/tests.html
+++ b/cargo-lander/tests.html
@@ -295,23 +295,23 @@ window.confirm = () => true;
   'game' singleton is created but init() is NOT called here — tests call it explicitly.
 -->
 <script src="vendor/matter.min.js"></script>
-<script src="levelSchema.js?v=0.10.2"></script>
-<script src="upgrades.js?v=0.10.2"></script>
-<script src="levels.js?v=0.10.2"></script>
-<script src="levelGenerator.js?v=0.10.2"></script>
-<script src="level1.js?v=0.10.2"></script>
-<script src="level2.js?v=0.10.2"></script>
-<script src="level3.js?v=0.10.2"></script>
-<script src="level4.js?v=0.10.2"></script>
-<script src="level5.js?v=0.10.2"></script>
-<script src="level6.js?v=0.10.2"></script>
-<script src="level7.js?v=0.10.2"></script>
-<script src="level8.js?v=0.10.2"></script>
-<script src="level9.js?v=0.10.2"></script>
-<script src="level10.js?v=0.10.2"></script>
-<script src="levelTest.js?v=0.10.2"></script>
-<script src="audio.js?v=0.10.2"></script>
-<script src="shaders.js?v=0.10.2"></script>
+<script src="levelSchema.js?v=0.10.3"></script>
+<script src="upgrades.js?v=0.10.3"></script>
+<script src="levels.js?v=0.10.3"></script>
+<script src="levelGenerator.js?v=0.10.3"></script>
+<script src="level1.js?v=0.10.3"></script>
+<script src="level2.js?v=0.10.3"></script>
+<script src="level3.js?v=0.10.3"></script>
+<script src="level4.js?v=0.10.3"></script>
+<script src="level5.js?v=0.10.3"></script>
+<script src="level6.js?v=0.10.3"></script>
+<script src="level7.js?v=0.10.3"></script>
+<script src="level8.js?v=0.10.3"></script>
+<script src="level9.js?v=0.10.3"></script>
+<script src="level10.js?v=0.10.3"></script>
+<script src="levelTest.js?v=0.10.3"></script>
+<script src="audio.js?v=0.10.3"></script>
+<script src="shaders.js?v=0.10.3"></script>
 <script>
 // Patch ShaderOverlay so it gracefully handles null WebGL context.
 // top-level `class` in shaders.js creates a non-reassignable lexical binding,
@@ -348,23 +348,23 @@ window.confirm = () => true;
   };
 })();
 </script>
-<script src="physics.js?v=0.10.2"></script>
-<script src="physics/collision.js?v=0.10.2"></script>
-<script src="physics/mechanics.js?v=0.10.2"></script>
-<script src="physics/entities.js?v=0.10.2"></script>
-<script src="physics/atmosphere.js?v=0.10.2"></script>
-<script src="game.js?v=0.10.2"></script>
-<script src="game/input.js?v=0.10.2"></script>
-<script src="game/menu.js?v=0.10.2"></script>
-<script src="game/hud.js?v=0.10.2"></script>
-<script src="game/cargo.js?v=0.10.2"></script>
-<script src="render.js?v=0.10.2"></script>
-<script src="render/background.js?v=0.10.2"></script>
-<script src="render/terrain.js?v=0.10.2"></script>
-<script src="render/entities.js?v=0.10.2"></script>
-<script src="render/effects.js?v=0.10.2"></script>
-<script src="render/night.js?v=0.10.2"></script>
-<script src="render/ui.js?v=0.10.2"></script>
+<script src="physics.js?v=0.10.3"></script>
+<script src="physics/collision.js?v=0.10.3"></script>
+<script src="physics/mechanics.js?v=0.10.3"></script>
+<script src="physics/entities.js?v=0.10.3"></script>
+<script src="physics/atmosphere.js?v=0.10.3"></script>
+<script src="game.js?v=0.10.3"></script>
+<script src="game/input.js?v=0.10.3"></script>
+<script src="game/menu.js?v=0.10.3"></script>
+<script src="game/hud.js?v=0.10.3"></script>
+<script src="game/cargo.js?v=0.10.3"></script>
+<script src="render.js?v=0.10.3"></script>
+<script src="render/background.js?v=0.10.3"></script>
+<script src="render/terrain.js?v=0.10.3"></script>
+<script src="render/entities.js?v=0.10.3"></script>
+<script src="render/effects.js?v=0.10.3"></script>
+<script src="render/night.js?v=0.10.3"></script>
+<script src="render/ui.js?v=0.10.3"></script>
 
 <script>
 // ─── 3. HELPER: build a minimal input-state object for physics.update() ──────


### PR DESCRIPTION
## Summary
- `confirmResetCareer()` was explicitly carrying `career.pilotName` and `career.portrait` forward into the "reset" state, so the pilot avatar and name survived a full career wipe even though the confirm dialog promises to reset everything and a brand-new career never has a portrait set.
- Reset now clears both to `''` / `null`, matching a fresh career. `refreshMenuUI()` already treats a falsy portrait as "unset" and falls back to the 🚀 avatar with the nudge highlight, so no other UI code needed to change.
- Bumped `CargoGame.VERSION` to `0.10.3` and the matching `?v=` cache-busting query strings.

## Test plan
- [x] Standalone Node harness exercising `confirmResetCareer()` directly — confirmed `pilotName` and `portrait` are cleared after reset.
- [x] Full headless test suite (`tests.html`): 97 passed / 0 failed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FkfV5qYd7dUMeAsc3oPrhw)_