### PR TITLE
v1.9.2: fix New Game reset being silently undone

### DIFF
--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Supply Chain Tycoon | Niklas Billgren</title>
-    <link rel="stylesheet" href="style.css?v=1.9.1">
+    <link rel="stylesheet" href="style.css?v=1.9.2">
 </head>
 <body>
     <canvas id="gameCanvas"></canvas>
@@ -119,22 +119,22 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=1.9.1"></script>
-    <script src="js/state.js?v=1.9.1"></script>
-    <script src="js/save.js?v=1.9.1"></script>
-    <script src="js/sfx.js?v=1.9.1"></script>
-    <script src="js/map.js?v=1.9.1"></script>
-    <script src="js/camera.js?v=1.9.1"></script>
-    <script src="js/roads.js?v=1.9.1"></script>
-    <script src="js/factories.js?v=1.9.1"></script>
-    <script src="js/economy.js?v=1.9.1"></script>
-    <script src="js/vehicles.js?v=1.9.1"></script>
-    <script src="js/inspect.js?v=1.9.1"></script>
-    <script src="js/research.js?v=1.9.1"></script>
-    <script src="js/placement.js?v=1.9.1"></script>
-    <script src="js/render.js?v=1.9.1"></script>
-    <script src="js/input.js?v=1.9.1"></script>
-    <script src="js/ui.js?v=1.9.1"></script>
-    <script src="js/main.js?v=1.9.1"></script>
+    <script src="js/config.js?v=1.9.2"></script>
+    <script src="js/state.js?v=1.9.2"></script>
+    <script src="js/save.js?v=1.9.2"></script>
+    <script src="js/sfx.js?v=1.9.2"></script>
+    <script src="js/map.js?v=1.9.2"></script>
+    <script src="js/camera.js?v=1.9.2"></script>
+    <script src="js/roads.js?v=1.9.2"></script>
+    <script src="js/factories.js?v=1.9.2"></script>
+    <script src="js/economy.js?v=1.9.2"></script>
+    <script src="js/vehicles.js?v=1.9.2"></script>
+    <script src="js/inspect.js?v=1.9.2"></script>
+    <script src="js/research.js?v=1.9.2"></script>
+    <script src="js/placement.js?v=1.9.2"></script>
+    <script src="js/render.js?v=1.9.2"></script>
+    <script src="js/input.js?v=1.9.2"></script>
+    <script src="js/ui.js?v=1.9.2"></script>
+    <script src="js/main.js?v=1.9.2"></script>
 </body>
 </html>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -1,7 +1,7 @@
 // Supply Chain Tycoon — constants, materials, recipes, prices
 window.SC = window.SC || {};
 
-SC.VERSION = '1.9.1';
+SC.VERSION = '1.9.2';
 
 SC.CONFIG = {
     WORLD_W: 2200,

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -314,6 +314,10 @@ SC.ui = (function() {
         });
         $('menu-newgame').addEventListener('click', () => {
             if (newGameArmed) {
+                // Reloading fires pagehide/beforeunload, whose autosave flush
+                // (main.js) would otherwise re-persist this still-in-memory
+                // state right after clear() and undo the reset.
+                SC.state.gameStarted = false;
                 SC.save.clear();
                 location.reload();
                 return;

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -15,19 +15,19 @@
     <div id="results"></div>
 
     <!-- Pure logic only: no render/input/ui/main, no canvas needed -->
-    <script src="js/config.js?v=1.9.1"></script>
-    <script src="js/state.js?v=1.9.1"></script>
-    <script src="js/save.js?v=1.9.1"></script>
-    <script src="js/sfx.js?v=1.9.1"></script>
-    <script src="js/map.js?v=1.9.1"></script>
-    <script src="js/camera.js?v=1.9.1"></script>
-    <script src="js/roads.js?v=1.9.1"></script>
-    <script src="js/factories.js?v=1.9.1"></script>
-    <script src="js/economy.js?v=1.9.1"></script>
-    <script src="js/vehicles.js?v=1.9.1"></script>
-    <script src="js/inspect.js?v=1.9.1"></script>
-    <script src="js/research.js?v=1.9.1"></script>
-    <script src="js/placement.js?v=1.9.1"></script>
+    <script src="js/config.js?v=1.9.2"></script>
+    <script src="js/state.js?v=1.9.2"></script>
+    <script src="js/save.js?v=1.9.2"></script>
+    <script src="js/sfx.js?v=1.9.2"></script>
+    <script src="js/map.js?v=1.9.2"></script>
+    <script src="js/camera.js?v=1.9.2"></script>
+    <script src="js/roads.js?v=1.9.2"></script>
+    <script src="js/factories.js?v=1.9.2"></script>
+    <script src="js/economy.js?v=1.9.2"></script>
+    <script src="js/vehicles.js?v=1.9.2"></script>
+    <script src="js/inspect.js?v=1.9.2"></script>
+    <script src="js/research.js?v=1.9.2"></script>
+    <script src="js/placement.js?v=1.9.2"></script>
 
     <script>
     let passed = 0, failed = 0;


### PR DESCRIPTION
Confirming the pause menu's New Game button cleared the save and
reloaded, but reload() fires pagehide/beforeunload, whose autosave
flush (main.js) re-serialized the still-in-memory old state and wrote
it right back to localStorage before the fresh load could take effect
— so the reset appeared to do nothing. Clear gameStarted before the
reload so the flush is skipped.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CoCrAwgDPqnHCkC5YGwA5e