### PR TITLE
v1.10.0: dedicated research tree overlay + commit/merge/push workflow doc

### DIFF
--- a/supply-chain/CLAUDE.md
+++ b/supply-chain/CLAUDE.md
@@ -18,7 +18,14 @@ Don't couple the two again.)
 
 ## Standing instructions
 - After a code change, **run the test suite** (below), fix what breaks,
-  then commit and push without waiting to be asked.
+  then **commit**, **merge in the latest `origin/master`** (fetch + merge,
+  resolving any conflicts — this project runs several agent sessions in
+  parallel, hence the "Merge master: reconcile…" commits throughout
+  history), and **push**, all without waiting to be asked. Only skip the
+  merge/push step if the repo's git workflow for this session pins you to
+  a review branch instead (e.g. a PR-based harness) — in that case commit
+  and push to that branch and let the normal review/merge flow take it
+  from there.
 - Bump `SC.VERSION` (top of `js/config.js`) on every commit that ships a
   user-visible change, and update the `?v=X.Y.Z` cache-busting query on
   every local `<script>`/`<link>` tag in `index.html` AND `tests.html`
@@ -64,5 +71,20 @@ then (any headless Chromium works; on sandboxed Linux add `--no-sandbox`):
   hauls (the ×N badge over a truck) show up without a long probe.
   `&yard=1` builds a second truck yard near HQ, stations a truck there,
   and sets it as the active yard, for screenshotting the yard marker/
-  per-yard truck counts.
-- **Mobile layout**: same screenshot with `--window-size=390,844`.
+  per-yard truck counts. `&techtree=1` opens the 🔬 Research overlay
+  (its own menu, separate from the Shop panel's Build/Buy list) on load,
+  for screenshotting the tree layout.
+- **Mobile layout**: same screenshot with `--window-size=390,844`. Caveat
+  found while building the research-tree overlay: this Chromium build
+  enforces a **hard ~500px minimum layout viewport** in headless mode —
+  `document.documentElement.clientWidth` reads 500 for any `--window-size`
+  narrower than that (confirmed at 320/390/450/499, all clamp to 500;
+  501+ tracks the requested size), while `--screenshot` still crops to
+  the requested (e.g. 390×844) pixel dimensions. So a "mobile" screenshot
+  below ~500 wide shows a left-edge *crop* of the 500px-wide layout, not
+  a true narrow-viewport render — centered elements (`margin: auto` /
+  flex `justify-content: center`) will look like they overflow the right
+  edge even when they're correctly centered in the real (500px) layout.
+  Don't chase that as a CSS bug; verify centered/capped-width overlays at
+  `--window-size=500,844` or wider instead, or note the discrepancy and
+  reason about the real (unclamped) viewport port math by hand.

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -66,10 +66,14 @@ that ambient animation as its background — it now lives independently at
 - **Growth**: every 3 filled orders a locked supplier/factory site
   activates (buy factory sites with a tap-twice); this track never
   touches cities — see Orders above for how customer DCs unlock.
-- **Research** (Shop panel): one project at a time, paid upfront, takes
-  real time, then unlocks its effect — `SC.RESEARCH` in `config.js`.
-  Ships with Site Requisition (unlocks manual placement, below) and a
-  two-tier Credit Line II/III (each raises the credit limit, stacking).
+- **Research**: one project at a time, paid upfront, takes real time,
+  then unlocks its effect — `SC.RESEARCH` in `config.js`. Ships with Site
+  Requisition (unlocks manual placement, below) and a two-tier Credit
+  Line II/III (each raises the credit limit, stacking). The Shop panel
+  keeps a one-line shortcut (progress/available count); tapping it opens
+  the full tree in its own overlay, laid out left-to-right by
+  prerequisite depth with connecting lines to its `requires` (not a flat
+  list — see `updateResearchTree`/`researchTiers` in `ui.js`).
 - **Manual placement** (needs Site Requisition researched): pick a good
   in the Shop panel's Build section, then tap the map to drop that
   supplier/factory anywhere on land — at a premium over the free
@@ -123,7 +127,9 @@ sync with it):
   Inspect-mode hold gesture above uses the same long-press primitive).
 - More research nodes (order-pay boosts, faster milestones); a
   "promotions" tech that temporarily boosts demand for a chosen good,
-  per the plan's next-steps discussion.
+  per the plan's next-steps discussion. The tree UI (own overlay,
+  branching by tier) is built — it just has few branches to show until
+  these land.
 - Research cancel/refund (currently a started project can't be aborted).
 - Reassigning an existing truck to a different yard (today you choose a
   yard at purchase time only; there's no way to move a truck already

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Supply Chain Tycoon | Niklas Billgren</title>
-    <link rel="stylesheet" href="style.css?v=1.9.2">
+    <link rel="stylesheet" href="style.css?v=1.10.0">
 </head>
 <body>
     <canvas id="gameCanvas"></canvas>
@@ -67,8 +67,10 @@
                 <span class="price">$450</span>
             </button>
 
-            <div class="shop-section-title">🔬 Research</div>
-            <div id="research-list"></div>
+            <button class="shop-btn" id="btn-research-tree">
+                <span class="sname">🔬 Research</span>
+                <span class="price" id="research-shortcut-status">Open tree</span>
+            </button>
 
             <div class="shop-section-title hidden" id="build-title">📍 Build (premium placement)</div>
             <div id="build-list"></div>
@@ -76,6 +78,19 @@
     </div>
 
     <div id="toast"></div>
+
+    <div id="research-overlay" class="hidden">
+        <div class="research-tree-card">
+            <div class="research-tree-header">
+                <h1>🔬 Research Tree</h1>
+                <button class="icon-btn" id="research-tree-close" title="Close">✕</button>
+            </div>
+            <div class="research-tree-wrap">
+                <svg id="research-tree-edges"></svg>
+                <div id="research-tree-nodes"></div>
+            </div>
+        </div>
+    </div>
 
     <div id="menu-overlay" class="hidden">
         <div class="menu-card">
@@ -128,22 +143,22 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=1.9.2"></script>
-    <script src="js/state.js?v=1.9.2"></script>
-    <script src="js/save.js?v=1.9.2"></script>
-    <script src="js/sfx.js?v=1.9.2"></script>
-    <script src="js/map.js?v=1.9.2"></script>
-    <script src="js/camera.js?v=1.9.2"></script>
-    <script src="js/roads.js?v=1.9.2"></script>
-    <script src="js/factories.js?v=1.9.2"></script>
-    <script src="js/economy.js?v=1.9.2"></script>
-    <script src="js/vehicles.js?v=1.9.2"></script>
-    <script src="js/inspect.js?v=1.9.2"></script>
-    <script src="js/research.js?v=1.9.2"></script>
-    <script src="js/placement.js?v=1.9.2"></script>
-    <script src="js/render.js?v=1.9.2"></script>
-    <script src="js/input.js?v=1.9.2"></script>
-    <script src="js/ui.js?v=1.9.2"></script>
-    <script src="js/main.js?v=1.9.2"></script>
+    <script src="js/config.js?v=1.10.0"></script>
+    <script src="js/state.js?v=1.10.0"></script>
+    <script src="js/save.js?v=1.10.0"></script>
+    <script src="js/sfx.js?v=1.10.0"></script>
+    <script src="js/map.js?v=1.10.0"></script>
+    <script src="js/camera.js?v=1.10.0"></script>
+    <script src="js/roads.js?v=1.10.0"></script>
+    <script src="js/factories.js?v=1.10.0"></script>
+    <script src="js/economy.js?v=1.10.0"></script>
+    <script src="js/vehicles.js?v=1.10.0"></script>
+    <script src="js/inspect.js?v=1.10.0"></script>
+    <script src="js/research.js?v=1.10.0"></script>
+    <script src="js/placement.js?v=1.10.0"></script>
+    <script src="js/render.js?v=1.10.0"></script>
+    <script src="js/input.js?v=1.10.0"></script>
+    <script src="js/ui.js?v=1.10.0"></script>
+    <script src="js/main.js?v=1.10.0"></script>
 </body>
 </html>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -1,7 +1,7 @@
 // Supply Chain Tycoon — constants, materials, recipes, prices
 window.SC = window.SC || {};
 
-SC.VERSION = '1.9.2';
+SC.VERSION = '1.10.0';
 
 SC.CONFIG = {
     WORLD_W: 2200,

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -48,7 +48,8 @@ SC.ui = (function() {
                 btn.disabled = !SC.canAfford(price);
             }
         }
-        updateResearch();
+        updateResearchShortcut();
+        updateResearchTree();
         updateBuild();
     }
 
@@ -78,7 +79,22 @@ SC.ui = (function() {
     }
 
     // ── Research & Build (Shop panel sections) ──────
-    function researchRow(id) {
+    // The Shop panel keeps a one-line shortcut (bottom-left, always visible);
+    // the full branching tech tree lives in its own overlay (#research-overlay)
+    // so it has room to lay out prerequisite branches instead of a flat list.
+    function updateResearchShortcut() {
+        const st = SC.state;
+        const status = $('research-shortcut-status');
+        if (st.research.active) {
+            const id = st.research.active.id;
+            status.textContent = `${SC.RESEARCH[id].emoji} ${Math.round(SC.research.progress(id) * 100)}%`;
+        } else {
+            const available = SC.RESEARCH_ORDER.filter(SC.research.isAvailable).length;
+            status.textContent = available ? `${available} available` : 'Open tree';
+        }
+    }
+
+    function researchNodeHTML(id, pos) {
         const t = SC.RESEARCH[id];
         const done = SC.research.isDone(id);
         const active = SC.state.research.active && SC.state.research.active.id === id;
@@ -92,20 +108,82 @@ SC.ui = (function() {
             btn = `<div class="research-bar"><div style="width:${pct}%"></div></div>
                    <div class="research-desc" style="margin:0.3rem 0 0;text-align:center">${left}s left</div>`;
         } else if (locked) {
-            const reqNames = t.requires.map(r => SC.RESEARCH[r].name).join(', ');
-            btn = `<div class="research-btn" disabled style="cursor:default">🔒 Requires ${reqNames}</div>`;
+            btn = '<div class="research-btn" disabled style="cursor:default">🔒 Locked</div>';
         } else {
             btn = `<button class="research-btn" data-research="${id}" ${SC.state.research.active || !SC.canAfford(t.cost) ? 'disabled' : ''}>Research — ${fmt(t.cost)} · ${t.time}s</button>`;
         }
-        return `<div class="research-row ${done ? 'done' : ''} ${locked ? 'locked' : ''}">
+        return `<div class="rt-node research-row ${done ? 'done' : ''} ${locked ? 'locked' : ''}"
+                     style="left:${pos.x}px;top:${pos.y}px;width:${pos.w}px">
             <div class="research-top"><span class="research-name">${t.emoji} ${t.name}</span></div>
             <div class="research-desc">${t.desc}</div>
             ${btn}
         </div>`;
     }
 
-    function updateResearch() {
-        $('research-list').innerHTML = SC.RESEARCH_ORDER.map(researchRow).join('');
+    // Tier = longest prerequisite chain to a root (0 = no requires), so the
+    // tree reads left-to-right in dependency order regardless of RESEARCH_ORDER.
+    function researchTiers() {
+        const cache = {};
+        function tierOf(id) {
+            if (cache[id] !== undefined) return cache[id];
+            const reqs = SC.RESEARCH[id].requires;
+            return cache[id] = reqs.length ? 1 + Math.max(...reqs.map(tierOf)) : 0;
+        }
+        const byTier = {};
+        for (const id of SC.RESEARCH_ORDER) (byTier[tierOf(id)] = byTier[tierOf(id)] || []).push(id);
+        return byTier;
+    }
+
+    const RT_COL_W = 210, RT_ROW_H = 132, RT_NODE_W = 176, RT_NODE_H_HALF = 46, RT_PAD = 20;
+
+    function researchTreeOpen() { return !$('research-overlay').classList.contains('hidden'); }
+
+    function updateResearchTree() {
+        if (!researchTreeOpen()) return;
+        const byTier = researchTiers();
+        const tierKeys = Object.keys(byTier).map(Number).sort((a, b) => a - b);
+        const positions = {};
+        let maxRows = 1;
+        tierKeys.forEach(tier => {
+            byTier[tier].forEach((id, row) => {
+                positions[id] = { x: RT_PAD + tier * RT_COL_W, y: RT_PAD + row * RT_ROW_H, w: RT_NODE_W };
+            });
+            maxRows = Math.max(maxRows, byTier[tier].length);
+        });
+        const width = RT_PAD * 2 + tierKeys.length * RT_COL_W;
+        const height = RT_PAD * 2 + maxRows * RT_ROW_H;
+
+        const nodesEl = $('research-tree-nodes');
+        nodesEl.style.width = width + 'px';
+        nodesEl.style.height = height + 'px';
+        nodesEl.innerHTML = SC.RESEARCH_ORDER.map(id => researchNodeHTML(id, positions[id])).join('');
+
+        const svg = $('research-tree-edges');
+        svg.setAttribute('width', width);
+        svg.setAttribute('height', height);
+        let edges = '';
+        for (const id of SC.RESEARCH_ORDER) {
+            const to = positions[id];
+            for (const req of SC.RESEARCH[id].requires) {
+                const from = positions[req];
+                if (!from) continue;
+                const x1 = from.x + from.w, y1 = from.y + RT_NODE_H_HALF;
+                const x2 = to.x, y2 = to.y + RT_NODE_H_HALF;
+                const midX = (x1 + x2) / 2;
+                edges += `<path d="M${x1},${y1} C${midX},${y1} ${midX},${y2} ${x2},${y2}"
+                    class="rt-edge ${SC.research.isDone(req) ? 'rt-edge-done' : ''}" />`;
+            }
+        }
+        svg.innerHTML = edges;
+    }
+
+    function openResearchTree() {
+        $('research-overlay').classList.remove('hidden');
+        updateResearchTree();
+    }
+
+    function closeResearchTree() {
+        $('research-overlay').classList.add('hidden');
     }
 
     function buildRow(kind, good) {
@@ -380,7 +458,12 @@ SC.ui = (function() {
             });
         }
 
-        $('research-list').addEventListener('click', e => {
+        $('btn-research-tree').addEventListener('click', () => { SC.sfx.play('click'); openResearchTree(); });
+        $('research-tree-close').addEventListener('click', () => { SC.sfx.play('click'); closeResearchTree(); });
+        $('research-overlay').addEventListener('click', e => {
+            if (e.target === $('research-overlay')) closeResearchTree(); // tap outside the card
+        });
+        $('research-tree-nodes').addEventListener('click', e => {
             const btn = e.target.closest('[data-research]');
             if (!btn || btn.disabled) return;
             const res = SC.research.start(btn.dataset.research);
@@ -453,6 +536,8 @@ SC.ui = (function() {
         }
         // Headless verification hook (see CLAUDE.md): open the menu on load
         if (new URLSearchParams(location.search).has('menu')) openMenu();
+        // ...and/or the research tree overlay
+        if (new URLSearchParams(location.search).has('techtree')) openResearchTree();
     }
 
     return { init, update, toast };

--- a/supply-chain/style.css
+++ b/supply-chain/style.css
@@ -315,6 +315,50 @@ html, body {
 }
 .research-bar div { height: 100%; background: var(--accent-color); border-radius: 2px; }
 
+/* ── Research tree overlay ──────────────────────── */
+#research-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 300;
+    background: rgba(15, 23, 42, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+}
+#research-overlay.hidden { display: none; }
+.research-tree-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 18px;
+    padding: 1.2rem;
+    width: 760px;
+    max-width: 92vw;
+    max-height: 88vh;
+    display: flex;
+    flex-direction: column;
+}
+.research-tree-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.8rem;
+}
+.research-tree-header h1 { font-size: 1.1rem; }
+.research-tree-wrap {
+    position: relative;
+    overflow: auto;
+    border-radius: 10px;
+    background: rgba(15, 23, 42, 0.35);
+}
+#research-tree-nodes { position: relative; }
+.rt-node { position: absolute; box-sizing: border-box; margin-bottom: 0; }
+#research-tree-edges { position: absolute; top: 0; left: 0; pointer-events: none; }
+.rt-edge { fill: none; stroke: rgba(148, 163, 184, 0.35); stroke-width: 2; }
+.rt-edge.rt-edge-done { stroke: var(--good); stroke-width: 2.5; }
+
 /* ── Build (manual placement) ───────────────────────*/
 .build-btn.active {
     border-color: var(--accent-color);
@@ -508,4 +552,5 @@ html, body {
     .hud-item span:last-child { font-size: 0.8rem; }
     #orders-panel { top: 4rem; right: 0.5rem; width: 220px; }
     #shop-panel { bottom: 0.5rem; left: 0.5rem; width: 220px; }
+    .research-tree-card { padding: 0.8rem; }
 }

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -15,19 +15,19 @@
     <div id="results"></div>
 
     <!-- Pure logic only: no render/input/ui/main, no canvas needed -->
-    <script src="js/config.js?v=1.9.2"></script>
-    <script src="js/state.js?v=1.9.2"></script>
-    <script src="js/save.js?v=1.9.2"></script>
-    <script src="js/sfx.js?v=1.9.2"></script>
-    <script src="js/map.js?v=1.9.2"></script>
-    <script src="js/camera.js?v=1.9.2"></script>
-    <script src="js/roads.js?v=1.9.2"></script>
-    <script src="js/factories.js?v=1.9.2"></script>
-    <script src="js/economy.js?v=1.9.2"></script>
-    <script src="js/vehicles.js?v=1.9.2"></script>
-    <script src="js/inspect.js?v=1.9.2"></script>
-    <script src="js/research.js?v=1.9.2"></script>
-    <script src="js/placement.js?v=1.9.2"></script>
+    <script src="js/config.js?v=1.10.0"></script>
+    <script src="js/state.js?v=1.10.0"></script>
+    <script src="js/save.js?v=1.10.0"></script>
+    <script src="js/sfx.js?v=1.10.0"></script>
+    <script src="js/map.js?v=1.10.0"></script>
+    <script src="js/camera.js?v=1.10.0"></script>
+    <script src="js/roads.js?v=1.10.0"></script>
+    <script src="js/factories.js?v=1.10.0"></script>
+    <script src="js/economy.js?v=1.10.0"></script>
+    <script src="js/vehicles.js?v=1.10.0"></script>
+    <script src="js/inspect.js?v=1.10.0"></script>
+    <script src="js/research.js?v=1.10.0"></script>
+    <script src="js/placement.js?v=1.10.0"></script>
 
     <script>
     let passed = 0, failed = 0;


### PR DESCRIPTION
Split the Research section out of the combined Shop panel list into its
own overlay (#research-overlay), laid out left-to-right by prerequisite
tier with SVG connector lines to each tech's requires (done deps light
up green) instead of a flat list. The Shop panel keeps a one-line
shortcut (progress % or available-tech count) that opens it.

Also documents the commit/merge/push-after-tests workflow explicitly in
CLAUDE.md's standing instructions (matching the project's existing
"Merge master: reconcile..." history), and notes a headless-Chromium
~500px minimum viewport quirk discovered while verifying the overlay at
mobile widths.