### PR TITLE
v1.11.0: supplier stock, highways, per-yard truck prices, deeper research tree

### DIFF
--- a/supply-chain/CLAUDE.md
+++ b/supply-chain/CLAUDE.md
@@ -71,7 +71,10 @@ then (any headless Chromium works; on sandboxed Linux add `--no-sandbox`):
   hauls (the ×N badge over a truck) show up without a long probe.
   `&yard=1` builds a second truck yard near HQ, stations a truck there,
   and sets it as the active yard, for screenshotting the yard marker/
-  per-yard truck counts. `&techtree=1` opens the 🔬 Research overlay
+  per-yard truck counts. `&highway=1` completes pavedRoads and paves all
+  built roads (highway styling); `&suplevel=2` levels every supplier up
+  twice (▲ pips); `&drain=1` empties supplier stocks (red low-stock
+  bars). `&techtree=1` opens the 🔬 Research overlay
   (its own menu, separate from the Shop panel's Build/Buy list) on load,
   for screenshotting the tree layout.
 - **Mobile layout**: same screenshot with `--window-size=390,844`. Caveat

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -74,6 +74,24 @@ that ambient animation as its background — it now lives independently at
   the full tree in its own overlay, laid out left-to-right by
   prerequisite depth with connecting lines to its `requires` (not a flat
   list — see `updateResearchTree`/`researchTiers` in `ui.js`).
+- **Supplier stock**: suppliers hold a finite stockpile that regenerates
+  over time (`SUPPLIER_REGEN`) up to a cap; a truck arriving at a dry
+  supplier waits there (`'loading'` phase) until stock catches up. Each
+  supplier is individually upgradable in **Upgrade mode** (⬆️, top
+  right): tap twice to raise its cap and regen (per-supplier `level`,
+  price ladder `SUPPLIER_UPGRADE_BASE/GROWTH`). The Fertilizer Program
+  research boosts all suppliers' regen globally.
+- **Highways** (needs Asphalt Paving researched): Upgrade mode on a road
+  paves it (`edge.level 1`) — trucks cross it `HIGHWAY_SPEED_MULT`×
+  faster, and pathfinding weighs edges by travel time so routes prefer
+  paved legs.
+- **Per-yard truck prices**: the truck price ladder tracks trucks homed
+  at the *active yard* (`SC.trucksAtYard`), so a new yard resets the
+  ladder to base price — the ever-growing yard price is the balance
+  lever.
+- **Deeper chains pay more**: order payouts multiply the good's value by
+  `1 + ORDER_DEPTH_VALUE × (depth − 1)`, so cars/robots out-earn bread
+  beyond their base value gap.
 - **Manual placement** (needs Site Requisition researched): pick a good
   in the Shop panel's Build section, then tap the map to drop that
   supplier/factory anywhere on land — at a premium over the free
@@ -127,9 +145,10 @@ sync with it):
   Inspect-mode hold gesture above uses the same long-press primitive).
 - More research nodes (order-pay boosts, faster milestones); a
   "promotions" tech that temporarily boosts demand for a chosen good,
-  per the plan's next-steps discussion. The tree UI (own overlay,
-  branching by tier) is built — it just has few branches to show until
-  these land.
+  per the plan's next-steps discussion. (The tree UI and four new techs
+  — Asphalt Paving, Overdrive Engines, Fertilizer Program, Factory
+  Automation — landed in v1.10/1.11; promotions/repeatable research is
+  still open.)
 - Research cancel/refund (currently a started project can't be aborted).
 - Reassigning an existing truck to a different yard (today you choose a
   yard at purchase time only; there's no way to move a truck already

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Supply Chain Tycoon | Niklas Billgren</title>
-    <link rel="stylesheet" href="style.css?v=1.10.0">
+    <link rel="stylesheet" href="style.css?v=1.11.0">
 </head>
 <body>
     <canvas id="gameCanvas"></canvas>
@@ -21,6 +21,7 @@
     <div id="top-right">
         <div id="mode-toggle" class="mode-toggle">
             <button id="mode-build" class="mode-btn active" title="Build roads">🔨</button>
+            <button id="mode-upgrade" class="mode-btn" title="Upgrade: tap a supplier or road to level it up">⬆️</button>
             <button id="mode-inspect" class="mode-btn" title="Inspect: hover/hold a node for its connections">🔍</button>
         </div>
         <button id="btn-menu" class="icon-btn" title="Menu">☰</button>
@@ -127,6 +128,8 @@
                 <li><b>Credit line:</b> you can spend into the red down to −$1,500, but debt bleeds 10% interest per minute — pay it off fast.</li>
                 <li><b>Research:</b> in the Shop panel, invest upfront and wait it out to unlock upgrades like manual site placement and a bigger credit line.</li>
                 <li><b>Truck yards:</b> HQ is your first yard. Build more (Shop panel) to station trucks closer to distant routes — idle trucks head home to their yard, so they stay ready near their own region.</li>
+                <li><b>Supplier stock:</b> suppliers hold a finite stock that refills over time — trucks wait at a dry supplier. Upgrade mode (⬆️, top right): tap a supplier twice to raise its stock cap and refill rate.</li>
+                <li><b>Highways:</b> after the Asphalt Paving research, use Upgrade mode on a road to pave it — trucks drive 60% faster there.</li>
                 <li><b>Move around:</b> drag to pan, scroll or pinch to zoom. Tap a road twice to demolish it.</li>
                 <li><b>Inspect mode (🔍, top right):</b> hover or hold a node to see its connections — a factory's needed ingredients, a supplier's factories, or a city's open orders — with the relevant roads lit up.</li>
             </ul>
@@ -143,22 +146,22 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=1.10.0"></script>
-    <script src="js/state.js?v=1.10.0"></script>
-    <script src="js/save.js?v=1.10.0"></script>
-    <script src="js/sfx.js?v=1.10.0"></script>
-    <script src="js/map.js?v=1.10.0"></script>
-    <script src="js/camera.js?v=1.10.0"></script>
-    <script src="js/roads.js?v=1.10.0"></script>
-    <script src="js/factories.js?v=1.10.0"></script>
-    <script src="js/economy.js?v=1.10.0"></script>
-    <script src="js/vehicles.js?v=1.10.0"></script>
-    <script src="js/inspect.js?v=1.10.0"></script>
-    <script src="js/research.js?v=1.10.0"></script>
-    <script src="js/placement.js?v=1.10.0"></script>
-    <script src="js/render.js?v=1.10.0"></script>
-    <script src="js/input.js?v=1.10.0"></script>
-    <script src="js/ui.js?v=1.10.0"></script>
-    <script src="js/main.js?v=1.10.0"></script>
+    <script src="js/config.js?v=1.11.0"></script>
+    <script src="js/state.js?v=1.11.0"></script>
+    <script src="js/save.js?v=1.11.0"></script>
+    <script src="js/sfx.js?v=1.11.0"></script>
+    <script src="js/map.js?v=1.11.0"></script>
+    <script src="js/camera.js?v=1.11.0"></script>
+    <script src="js/roads.js?v=1.11.0"></script>
+    <script src="js/factories.js?v=1.11.0"></script>
+    <script src="js/economy.js?v=1.11.0"></script>
+    <script src="js/vehicles.js?v=1.11.0"></script>
+    <script src="js/inspect.js?v=1.11.0"></script>
+    <script src="js/research.js?v=1.11.0"></script>
+    <script src="js/placement.js?v=1.11.0"></script>
+    <script src="js/render.js?v=1.11.0"></script>
+    <script src="js/input.js?v=1.11.0"></script>
+    <script src="js/ui.js?v=1.11.0"></script>
+    <script src="js/main.js?v=1.11.0"></script>
 </body>
 </html>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -1,7 +1,7 @@
 // Supply Chain Tycoon — constants, materials, recipes, prices
 window.SC = window.SC || {};
 
-SC.VERSION = '1.10.0';
+SC.VERSION = '1.11.0';
 
 SC.CONFIG = {
     WORLD_W: 2200,
@@ -23,9 +23,32 @@ SC.CONFIG = {
     BRIDGE_MULT: 3,            // river crossings cost extra
     ROAD_REFUND: 0.5,          // fraction returned when demolishing
 
+    // Truck price ladders PER YARD: the nth truck stationed at a given
+    // yard costs base * growth^n, so building a new yard "resets" the
+    // ladder there. The counterweight is YARD_PRICE_GROWTH below — each
+    // extra yard costs 1.5× the last, so cheap trucks are bought with
+    // increasingly expensive yards.
     TRUCK_PRICE: 500,
     TRUCK_PRICE_GROWTH: 1.35,
     TRUCK_SPEED: 80,           // world units / second
+
+    // Road upgrades (research-gated by 'pavedRoads'): a highway edge
+    // moves trucks HIGHWAY_SPEED_MULT× faster; upgrade cost scales with
+    // length like building does (bridges cost extra again).
+    ROAD_UPGRADE_PER_UNIT: 0.9,
+    HIGHWAY_SPEED_MULT: 1.6,
+
+    // Suppliers hold a finite stock that regenerates over time; trucks
+    // wait at an empty supplier until enough stock accumulates. Each
+    // supplier can be upgraded individually (tap in Upgrade mode):
+    // +CAP_PER_LEVEL capacity and +REGEN_PER_LEVEL regen per level.
+    SUPPLIER_STOCK_CAP: 8,
+    SUPPLIER_CAP_PER_LEVEL: 4,
+    SUPPLIER_REGEN: 0.25,          // units per second at level 0
+    SUPPLIER_REGEN_PER_LEVEL: 0.5, // +50% of base regen per level
+    SUPPLIER_MAX_LEVEL: 4,
+    SUPPLIER_UPGRADE_BASE: 400,
+    SUPPLIER_UPGRADE_GROWTH: 1.6,
 
     FACTORY_SITE_PRICE: 700,
 
@@ -45,6 +68,7 @@ SC.CONFIG = {
     ORDER_MAX_ACTIVE: 6,
     ORDER_DIST_PAY: 0.35,      // $ per world-unit of factory->city distance
     ORDER_DEPTH_SLACK: 0.5,    // extra deadline fraction per chain tier past 1
+    ORDER_DEPTH_VALUE: 0.25,   // extra payout fraction per chain tier past 1
     SALVAGE_PAY: 15,           // cargo delivered after its order expired
 
     // A new locked supplier/factory site activates every N deliveries.
@@ -85,9 +109,29 @@ SC.RESEARCH = {
     creditLine3: {
         name: 'Credit Line III', emoji: '💳', cost: 1800, time: 100, requires: ['creditLine2'],
         desc: 'Raises your credit limit by another $2,000.', creditBonus: 2000
+    },
+    pavedRoads: {
+        name: 'Asphalt Paving', emoji: '🛣️', cost: 800, time: 60, requires: [],
+        desc: 'Upgrade individual roads to highways — trucks drive 60% faster on them.'
+    },
+    overdrive: {
+        name: 'Overdrive Engines', emoji: '⚡', cost: 1600, time: 90, requires: ['pavedRoads'],
+        desc: 'Raises the Truck Speed upgrade cap by 3 levels.',
+        upgradeMaxBonus: { truckSpeed: 3 }
+    },
+    fertilizer: {
+        name: 'Fertilizer Program', emoji: '🌱', cost: 1000, time: 70, requires: [],
+        desc: 'All suppliers regenerate stock 50% faster.',
+        supplierRegenBonus: 0.5
+    },
+    automation: {
+        name: 'Factory Automation', emoji: '🦾', cost: 2000, time: 110, requires: ['fertilizer'],
+        desc: 'Raises the Factory Speed upgrade cap by 3 levels.',
+        upgradeMaxBonus: { factorySpeed: 3 }
     }
 };
-SC.RESEARCH_ORDER = ['manualPlacement', 'creditLine2', 'creditLine3'];
+SC.RESEARCH_ORDER = ['manualPlacement', 'creditLine2', 'pavedRoads', 'fertilizer',
+                     'creditLine3', 'overdrive', 'automation'];
 
 // Goods tree. Raw goods come from suppliers; crafted goods are made in a
 // factory dedicated to that recipe. Only `orderable` goods appear in city

--- a/supply-chain/js/economy.js
+++ b/supply-chain/js/economy.js
@@ -46,7 +46,10 @@ SC.economy = (function() {
             }
         }
         if (nearest === Infinity) nearest = 400;
-        const payout = Math.round((qty * (SC.GOODS[product].value + C().ORDER_DIST_PAY * nearest)) / 5) * 5;
+        // Deeper chains pay a premium on top of the good's base value —
+        // multi-tier logistics (car, robot) should out-earn bread runs.
+        const depthMult = 1 + C().ORDER_DEPTH_VALUE * (SC.depthOf(product) - 1);
+        const payout = Math.round((qty * (SC.GOODS[product].value * depthMult + C().ORDER_DIST_PAY * nearest)) / 5) * 5;
 
         // Deeper chains (steel -> car) get extra deadline slack
         const slack = 1 + C().ORDER_DEPTH_SLACK * (SC.depthOf(product) - 1);
@@ -172,8 +175,31 @@ SC.economy = (function() {
         }
     }
 
+    // Suppliers regenerate stock toward their (level-scaled) cap; trucks
+    // arriving at a dry supplier wait in the 'loading' phase (vehicles.js).
+    function tickSuppliers(dt) {
+        for (const n of SC.state.nodes) {
+            if (n.kind !== 'supplier' || !n.active) continue;
+            const cap = SC.supplierCap(n);
+            if (n.stock < cap) n.stock = Math.min(cap, n.stock + SC.supplierRegen(n) * dt);
+        }
+    }
+
+    // Per-supplier upgrade: each level raises stock cap and regen rate.
+    function upgradeSupplier(node) {
+        if (!node || node.kind !== 'supplier' || !node.active) return { ok: false, reason: 'invalid' };
+        const price = SC.supplierUpgradePrice(node);
+        if (price === null) return { ok: false, reason: 'maxed' };
+        if (!SC.canAfford(price)) return { ok: false, reason: 'money', cost: price };
+        SC.state.money -= price;
+        node.level = (node.level || 0) + 1;
+        SC.emit('supplierUpgraded', { node, price });
+        return { ok: true, level: node.level };
+    }
+
     let planTimer = 0;
     function tick(dt) {
+        tickSuppliers(dt);
         // Debt interest: a negative balance bleeds continuously. Interest
         // can push the debt past the credit limit (purchases stay blocked
         // until deliveries pay it back down).
@@ -227,5 +253,6 @@ SC.economy = (function() {
     }
 
     return { spawnOrder, planOrder, deliverProduct, expireOrder,
-             onNetworkChanged, tick, buyUpgrade, craftableProducts, bestSourceFor };
+             onNetworkChanged, tick, tickSuppliers, buyUpgrade, upgradeSupplier,
+             craftableProducts, bestSourceFor };
 })();

--- a/supply-chain/js/input.js
+++ b/supply-chain/js/input.js
@@ -12,6 +12,7 @@ SC.input = (function() {
     let hover = null;           // world pos of the mouse, for the ghost road
     let pendingDemolish = null; // edge tapped once, awaiting confirm tap
     let pendingBuy = null;      // for-sale factory tapped once
+    let pendingUpgrade = null;  // Upgrade mode: node/edge tapped once, awaiting confirm
     let inspectNode = null;     // Inspect mode: node currently hovered/held
     let holdTimer = null;       // Inspect mode (touch): pending long-press
 
@@ -64,9 +65,58 @@ SC.input = (function() {
         }
     }
 
+    // Upgrade mode (⬆): tap a supplier to level up its stock/regen, or a
+    // road to pave it into a highway (needs 'pavedRoads' research). Same
+    // two-tap confirm pattern as demolish/site-buy.
+    function handleUpgradeTap(sx, sy) {
+        const node = nodeAtScreen(sx, sy);
+        const target = (node && node.kind === 'supplier') ? node : (node ? null : edgeAtScreen(sx, sy));
+        if (!target) {
+            if (node) SC.emit('toast', { text: 'Only suppliers and roads can be upgraded', kind: 'info' });
+            pendingUpgrade = null;
+            return;
+        }
+        const isNode = !!target.kind;
+
+        if (pendingUpgrade !== target) { // first tap: quote it
+            let text;
+            if (isNode) {
+                const price = SC.supplierUpgradePrice(target);
+                text = price === null
+                    ? `${SC.emojiOf(target.mat)} supplier is already max level`
+                    : `Tap again to upgrade this ${SC.nameOf(target.mat).toLowerCase()} supplier to Lv${(target.level || 0) + 2} — $${price} (more stock, faster regen)`;
+                pendingUpgrade = price === null ? null : target;
+            } else {
+                const q = SC.roads.upgradeQuote(target);
+                text = target.level > 0 ? 'Already a highway'
+                     : !SC.research.isDone('pavedRoads') ? 'Requires Asphalt Paving research 🛣️'
+                     : `Tap again to pave this road into a highway — $${q.cost} (trucks +60% here)`;
+                pendingUpgrade = (target.level === 0 && SC.research.isDone('pavedRoads')) ? target : null;
+            }
+            SC.sfx.play('click');
+            SC.emit('toast', { text, kind: 'info' });
+            return;
+        }
+
+        pendingUpgrade = null; // second tap: do it
+        const res = isNode ? SC.economy.upgradeSupplier(target) : SC.roads.upgrade(target);
+        if (res.ok) {
+            SC.sfx.play('build');
+            SC.emit('toast', {
+                text: isNode ? `${SC.emojiOf(target.mat)} supplier upgraded to Lv${target.level + 1}!`
+                             : 'Road paved into a highway! 🛣️',
+                kind: 'good'
+            });
+        } else if (res.reason === 'money') {
+            SC.sfx.play('error');
+            SC.emit('toast', { text: `Credit limit reached — costs $${res.cost}`, kind: 'error' });
+        }
+    }
+
     function handleTap(sx, sy) {
         const st = SC.state;
         if (st.mode === 'inspect') return; // Inspect mode: hover/hold only, no building
+        if (st.mode === 'upgrade') { handleUpgradeTap(sx, sy); return; }
         if (st.placeMode) { handlePlacementTap(sx, sy); return; }
 
         const node = nodeAtScreen(sx, sy);
@@ -161,6 +211,7 @@ SC.input = (function() {
     function reset() {
         pendingDemolish = null;
         pendingBuy = null;
+        pendingUpgrade = null;
         inspectNode = null;
         clearHoldTimer();
     }
@@ -243,6 +294,7 @@ SC.input = (function() {
         getInspectNode: () => inspectNode,
         getHover: () => hover,
         getPendingDemolish: () => pendingDemolish,
+        getPendingUpgrade: () => pendingUpgrade,
         _handleTap: handleTap,
         // Headless verification hook: force a hover point without a real
         // pointermove, so placement/road ghost previews can be screenshotted.

--- a/supply-chain/js/main.js
+++ b/supply-chain/js/main.js
@@ -102,6 +102,28 @@ SC.runProbe = function(seconds) {
             if (SC.RESEARCH[id]) SC.state.research.completed[id] = true;
         }
     }
+    // Complete pavedRoads and pave every built road, so highway styling
+    // can be screenshotted
+    if (p.has('highway')) {
+        SC.state.money = Math.max(SC.state.money, 50000);
+        SC.state.research.completed.pavedRoads = true;
+        for (const e of SC.state.edges.slice()) SC.roads.upgrade(e);
+    }
+    // Level up every supplier N times (&suplevel=2) for the ▲ pips, and
+    // &drain=1 empties supplier stocks so the red low-stock bar shows
+    if (p.has('suplevel')) {
+        const lv = parseInt(p.get('suplevel'), 10) || 1;
+        SC.state.money = Math.max(SC.state.money, 100000);
+        for (const n of SC.state.nodes) {
+            if (n.kind !== 'supplier' || !n.active) continue;
+            for (let i = 0; i < lv; i++) SC.economy.upgradeSupplier(n);
+        }
+    }
+    if (p.has('drain')) {
+        for (const n of SC.state.nodes) {
+            if (n.kind === 'supplier') n.stock = Math.min(n.stock, 1);
+        }
+    }
     // Arm placement mode so the ghost preview can be screenshotted, e.g.
     // ?placemode=supplier:wheat
     if (p.has('placemode')) {

--- a/supply-chain/js/map.js
+++ b/supply-chain/js/map.js
@@ -21,8 +21,13 @@ SC.map = (function() {
             isHQ: !!opts.isHQ,
             edges: [],                  // neighbour node refs (kept by roads.js)
             // factory-only production state
-            inv: {}, reserved: {}, queue: [], crafting: null
+            inv: {}, reserved: {}, queue: [], crafting: null,
+            // supplier-only: upgrade level and regenerating stock
+            level: opts.level || 0
         };
+        if (kind === 'supplier') {
+            n.stock = opts.stock !== undefined ? opts.stock : SC.supplierCap(n);
+        }
         SC.state.nodes.push(n);
         return n;
     }

--- a/supply-chain/js/render.js
+++ b/supply-chain/js/render.js
@@ -90,12 +90,19 @@ SC.render = (function() {
 
     function drawRoads() {
         const pending = SC.input.getPendingDemolish && SC.input.getPendingDemolish();
+        const pendingUp = SC.input.getPendingUpgrade && SC.input.getPendingUpgrade();
         for (const e of SC.state.edges) {
             ctx.beginPath();
             ctx.moveTo(e.a.x, e.a.y);
             ctx.lineTo(e.b.x, e.b.y);
             if (e === pending) {
                 ctx.strokeStyle = 'rgba(248, 113, 113, 0.9)';
+                ctx.lineWidth = 6;
+            } else if (e === pendingUp) { // Upgrade mode: road armed for paving
+                ctx.strokeStyle = 'rgba(250, 204, 21, 0.9)';
+                ctx.lineWidth = 6;
+            } else if (e.level > 0) {     // highway: wider, brighter, gold core
+                ctx.strokeStyle = 'rgba(226, 232, 240, 0.65)';
                 ctx.lineWidth = 6;
             } else {
                 ctx.strokeStyle = e.bridge ? 'rgba(125, 170, 210, 0.55)' : 'rgba(148, 163, 184, 0.45)';
@@ -104,6 +111,16 @@ SC.render = (function() {
             ctx.setLineDash(e.bridge ? [14, 8] : []);
             ctx.stroke();
             ctx.setLineDash([]);
+            if (e.level > 0 && e !== pending && e !== pendingUp) {
+                ctx.beginPath();
+                ctx.moveTo(e.a.x, e.a.y);
+                ctx.lineTo(e.b.x, e.b.y);
+                ctx.strokeStyle = 'rgba(250, 204, 21, 0.5)';
+                ctx.lineWidth = 1.5;
+                ctx.setLineDash([10, 10]);
+                ctx.stroke();
+                ctx.setLineDash([]);
+            }
         }
     }
 
@@ -241,6 +258,18 @@ SC.render = (function() {
                 ctx.strokeStyle = SC.colorOf(n.mat);
                 ctx.stroke();
                 emojiPlate(SC.emojiOf(n.mat), n.x, n.y, R - 2, 19);
+                // Stock bar: how full the regenerating stockpile is —
+                // red when nearly dry (trucks will queue up waiting).
+                const cap = SC.supplierCap(n);
+                const frac = Math.max(0, Math.min(1, (n.stock || 0) / cap));
+                const bw = 30;
+                ctx.fillStyle = 'rgba(255, 255, 255, 0.12)';
+                ctx.fillRect(n.x - bw / 2, n.y + R + 9, bw, 4);
+                ctx.fillStyle = frac < 0.25 ? '#f87171' : SC.colorOf(n.mat);
+                ctx.fillRect(n.x - bw / 2, n.y + R + 9, bw * frac, 4);
+                if (n.level > 0) {
+                    label('▲'.repeat(n.level), n.x, n.y - R - 12, '#facc15', 10);
+                }
             } else if (n.kind === 'factory') {
                 ctx.beginPath();
                 ctx.rect(n.x - R - 2, n.y - R - 2, (R + 2) * 2, (R + 2) * 2);

--- a/supply-chain/js/research.js
+++ b/supply-chain/js/research.js
@@ -58,5 +58,28 @@ SC.research = (function() {
         return b;
     }
 
-    return { isDone, isAvailable, activeId, canStart, start, progress, tick, creditBonus };
+    // Extra upgrade levels unlocked for `key` (e.g. Overdrive Engines
+    // adds { truckSpeed: 3 }) — read by SC.upgradeMax.
+    function upgradeMaxBonus(key) {
+        let b = 0;
+        for (const id in SC.state.research.completed) {
+            const t = SC.RESEARCH[id];
+            if (t && t.upgradeMaxBonus && t.upgradeMaxBonus[key]) b += t.upgradeMaxBonus[key];
+        }
+        return b;
+    }
+
+    // Global supplier regen multiplier bonus (Fertilizer Program) —
+    // read by SC.supplierRegen.
+    function supplierRegenBonus() {
+        let b = 0;
+        for (const id in SC.state.research.completed) {
+            const t = SC.RESEARCH[id];
+            if (t && t.supplierRegenBonus) b += t.supplierRegenBonus;
+        }
+        return b;
+    }
+
+    return { isDone, isAvailable, activeId, canStart, start, progress, tick,
+             creditBonus, upgradeMaxBonus, supplierRegenBonus };
 })();

--- a/supply-chain/js/roads.js
+++ b/supply-chain/js/roads.js
@@ -25,7 +25,7 @@ SC.roads = (function() {
         if (!q) return { ok: false, reason: 'invalid' };
         if (!SC.canAfford(q.cost)) return { ok: false, reason: 'money', cost: q.cost };
         SC.state.money -= q.cost;
-        const edge = { a, b, len: q.len, bridge: q.bridge, cost: q.cost };
+        const edge = { a, b, len: q.len, bridge: q.bridge, cost: q.cost, level: 0 };
         SC.state.edges.push(edge);
         a.edges.push(b);
         b.edges.push(a);
@@ -53,7 +53,35 @@ SC.roads = (function() {
         return true;
     }
 
-    // Dijkstra over the road graph. Returns { path: [nodes], dist } or null.
+    // Highways (edge.level 1, unlocked by 'pavedRoads' research) move
+    // trucks HIGHWAY_SPEED_MULT× faster on that edge.
+    function speedMult(edge) {
+        return edge && edge.level ? SC.CONFIG.HIGHWAY_SPEED_MULT : 1;
+    }
+
+    // Quote for upgrading a road to a highway; null when not possible.
+    function upgradeQuote(edge) {
+        if (!edge || edge.level > 0) return null;
+        if (!SC.research.isDone('pavedRoads')) return null;
+        const cost = Math.round(edge.len * SC.CONFIG.ROAD_UPGRADE_PER_UNIT *
+            (edge.bridge ? SC.CONFIG.BRIDGE_MULT : 1));
+        return { cost };
+    }
+
+    function upgrade(edge) {
+        const q = upgradeQuote(edge);
+        if (!q) return { ok: false, reason: 'invalid' };
+        if (!SC.canAfford(q.cost)) return { ok: false, reason: 'money', cost: q.cost };
+        SC.state.money -= q.cost;
+        edge.level = 1;
+        SC.economy && SC.economy.onNetworkChanged();
+        SC.emit('roadUpgraded', { edge, cost: q.cost });
+        return { ok: true, edge };
+    }
+
+    // Dijkstra over the road graph, weighted by travel TIME (highway
+    // edges count len/speedMult), so routing prefers upgraded roads.
+    // Returns { path: [nodes], dist } or null.
     function findPath(from, to) {
         if (from === to) return { path: [from], dist: 0 };
         const dist = new Map([[from, 0]]);
@@ -70,7 +98,7 @@ SC.roads = (function() {
             done.add(cur);
             for (const nb of cur.edges) {
                 const e = findEdge(cur, nb);
-                const d = dist.get(cur) + e.len;
+                const d = dist.get(cur) + e.len / speedMult(e);
                 if (!dist.has(nb) || d < dist.get(nb)) {
                     dist.set(nb, d);
                     prev.set(nb, cur);
@@ -89,5 +117,6 @@ SC.roads = (function() {
         return r ? r.dist : Infinity;
     }
 
-    return { findEdge, quote, build, demolish, findPath, pathDist };
+    return { findEdge, quote, build, demolish, findPath, pathDist,
+             speedMult, upgradeQuote, upgrade };
 })();

--- a/supply-chain/js/save.js
+++ b/supply-chain/js/save.js
@@ -9,7 +9,7 @@ window.SC = window.SC || {};
 
 SC.save = (function() {
     const KEY = 'scTycoonSave.v1';
-    const FORMAT = 3; // v3: truck yards (trucks[] now {nodeId, homeYardId} objects)
+    const FORMAT = 4; // v4: supplier stock/levels + road upgrade levels
 
     function serialize() {
         const st = SC.state;
@@ -55,9 +55,10 @@ SC.save = (function() {
             nodes: st.nodes.map(n => ({
                 id: n.id, kind: n.kind, x: n.x, y: n.y, mat: n.mat, recipe: n.recipe,
                 active: n.active, forSale: n.forSale, isHQ: n.isHQ,
+                level: n.level || 0, stock: n.stock,
                 inv: inv.get(n.id) || {}
             })),
-            edges: st.edges.map(e => ({ a: e.a.id, b: e.b.id, cost: e.cost })),
+            edges: st.edges.map(e => ({ a: e.a.id, b: e.b.id, cost: e.cost, level: e.level || 0 })),
             trucks: st.trucks.map(t => ({
                 nodeId: (t.node || st.nodes[0]).id,
                 homeYardId: (t.homeYard || t.node || st.nodes[0]).id
@@ -96,7 +97,8 @@ SC.save = (function() {
         for (const nd of data.nodes) {
             const n = SC.map.makeNode(nd.kind, nd.x, nd.y, {
                 id: nd.id, mat: nd.mat, recipe: nd.recipe, active: nd.active,
-                forSale: nd.forSale, isHQ: nd.isHQ
+                forSale: nd.forSale, isHQ: nd.isHQ,
+                level: nd.level || 0, stock: nd.stock
             });
             n.inv = Object.assign({}, nd.inv);
             byId.set(n.id, n);
@@ -106,7 +108,7 @@ SC.save = (function() {
             if (!a || !b) continue;
             const len = Math.hypot(a.x - b.x, a.y - b.y);
             const bridge = SC.map.segmentCrossesRiver(a.x, a.y, b.x, b.y);
-            st.edges.push({ a, b, len, bridge, cost: ed.cost });
+            st.edges.push({ a, b, len, bridge, cost: ed.cost, level: ed.level || 0 });
             a.edges.push(b);
             b.edges.push(a);
         }

--- a/supply-chain/js/state.js
+++ b/supply-chain/js/state.js
@@ -38,7 +38,7 @@ SC.newState = function() {
 
         selectedNode: null, // node picked as road start (input.js)
         highlight: null,    // { paths, color, city, until } — order route overlay
-        mode: 'build',      // 'build' (default, current tap-to-build) | 'inspect'
+        mode: 'build',      // 'build' (default, tap-to-build) | 'upgrade' | 'inspect'
         placeMode: null,    // { kind: 'supplier'|'factory'|'yard', good } — manual placement (input.js)
         gameStarted: false
     };
@@ -70,15 +70,51 @@ SC.truckCapacity = function() {
     return 1 + u.boost * SC.state.upgrades.truckCapacity;
 };
 
+// Upgrade level cap: config max plus any research upgradeMaxBonus
+// (e.g. Overdrive Engines raises truckSpeed's cap by 3).
+SC.upgradeMax = function(key) {
+    return SC.CONFIG.UPGRADES[key].max + SC.research.upgradeMaxBonus(key);
+};
+
 SC.upgradePrice = function(key) {
     const u = SC.CONFIG.UPGRADES[key];
     const lvl = SC.state.upgrades[key];
-    return lvl >= u.max ? null : Math.round(u.base * Math.pow(u.growth, lvl));
+    return lvl >= SC.upgradeMax(key) ? null : Math.round(u.base * Math.pow(u.growth, lvl));
 };
 
-SC.truckPrice = function() {
+// Trucks whose home is this yard — the per-yard price ladder's rung.
+SC.trucksAtYard = function(yard) {
+    return SC.state.trucks.filter(t => t.homeYard === yard).length;
+};
+
+// Truck price ladders per yard: a new yard resets the ladder (yards
+// themselves get pricier via yardPrice, which is the balance lever).
+// Pass the yard the truck would station at; defaults to the same
+// resolution buyTruck uses (active yard, falling back to HQ).
+SC.truckPrice = function(yard) {
+    if (!yard) {
+        yard = SC.isYard(SC.state.activeYard) ? SC.state.activeYard
+             : (SC.state.nodes.find(n => n.isHQ) || SC.state.nodes[0]);
+    }
     return Math.round(SC.CONFIG.TRUCK_PRICE *
-        Math.pow(SC.CONFIG.TRUCK_PRICE_GROWTH, SC.state.trucksBought));
+        Math.pow(SC.CONFIG.TRUCK_PRICE_GROWTH, SC.trucksAtYard(yard)));
+};
+
+// ── Suppliers: finite, regenerating, upgradable stock ─────
+SC.supplierCap = function(n) {
+    return SC.CONFIG.SUPPLIER_STOCK_CAP + SC.CONFIG.SUPPLIER_CAP_PER_LEVEL * (n.level || 0);
+};
+
+SC.supplierRegen = function(n) {
+    return SC.CONFIG.SUPPLIER_REGEN *
+        (1 + SC.CONFIG.SUPPLIER_REGEN_PER_LEVEL * (n.level || 0)) *
+        (1 + SC.research.supplierRegenBonus());
+};
+
+SC.supplierUpgradePrice = function(n) {
+    if ((n.level || 0) >= SC.CONFIG.SUPPLIER_MAX_LEVEL) return null;
+    return Math.round(SC.CONFIG.SUPPLIER_UPGRADE_BASE *
+        Math.pow(SC.CONFIG.SUPPLIER_UPGRADE_GROWTH, n.level || 0));
 };
 
 SC.yardPrice = function() {

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -39,7 +39,7 @@ SC.ui = (function() {
             const btn = $('btn-' + key);
             const price = SC.upgradePrice(key);
             const lvl = st.upgrades[key];
-            btn.querySelector('.lvl').textContent = '●'.repeat(lvl) + '○'.repeat(SC.CONFIG.UPGRADES[key].max - lvl);
+            btn.querySelector('.lvl').textContent = '●'.repeat(lvl) + '○'.repeat(SC.upgradeMax(key) - lvl);
             if (price === null) {
                 btn.querySelector('.price').textContent = 'MAX';
                 btn.disabled = true;
@@ -248,7 +248,9 @@ SC.ui = (function() {
                     <span>${SC.emojiOf(c.factory.recipe)} ${SC.GOODS[c.factory.recipe].building}</span>
                     <span>${c.connected ? Math.round(c.dist) + 'u' : 'no route!'}</span>
                 </div>`).join('') : '<div class="itip-row itip-bad">No factory needs this yet</div>';
-            return `<div class="itip-title">${SC.emojiOf(info.mat)} ${SC.nameOf(info.mat)} supplier</div>
+            const n = info.node;
+            return `<div class="itip-title">${SC.emojiOf(info.mat)} ${SC.nameOf(info.mat)} supplier${n.level ? ` <span class="itip-forsale">Lv${n.level + 1}</span>` : ''}</div>
+                    <div class="itip-row"><span>Stock</span><span>${Math.floor(n.stock)}/${SC.supplierCap(n)}</span></div>
                     <div class="itip-sub">Used by</div>${rows}`;
         }
         const rows = info.orders.length ? info.orders.map(o => {
@@ -281,8 +283,10 @@ SC.ui = (function() {
         SC.state.placeMode = null; // don't leave manual placement armed while inspecting
         SC.input.reset();
         $('mode-build').classList.toggle('active', mode === 'build');
+        $('mode-upgrade').classList.toggle('active', mode === 'upgrade');
         $('mode-inspect').classList.toggle('active', mode === 'inspect');
         SC.sfx.play('click');
+        if (mode === 'upgrade') toast('Upgrade mode: tap a supplier or a road', 'info');
     }
 
     let ordersTimer = 0, lastOrderCount = -1;
@@ -387,6 +391,7 @@ SC.ui = (function() {
         });
 
         $('mode-build').addEventListener('click', () => setMode('build'));
+        $('mode-upgrade').addEventListener('click', () => setMode('upgrade'));
         $('mode-inspect').addEventListener('click', () => setMode('inspect'));
 
         $('btn-menu').addEventListener('click', () => { SC.sfx.play('click'); openMenu(); });

--- a/supply-chain/js/vehicles.js
+++ b/supply-chain/js/vehicles.js
@@ -35,7 +35,9 @@ SC.vehicles = (function() {
             if (jobs[i].order === order) jobs.splice(i, 1);
         }
         for (const t of SC.state.trucks) {
-            if (t.phase !== 'toPickup') continue; // loaded trucks finish their run; salvage handles the drop
+            // loaded trucks finish their run; salvage handles the drop.
+            // 'loading' trucks haven't consumed stock yet, so cancel freely.
+            if (t.phase !== 'toPickup' && t.phase !== 'loading') continue;
             const before = t.jobs.length;
             t.jobs = t.jobs.filter(j => j.order !== order);
             if (t.jobs.length === before) continue;
@@ -66,17 +68,7 @@ SC.vehicles = (function() {
         if (truck.phase === 'returning') { truck.phase = null; return; }
         if (!truck.jobs.length) return;
         if (truck.phase === 'toPickup') {
-            const first = truck.jobs[0];
-            const route = SC.roads.findPath(first.pickup, first.drop);
-            if (!route) { // network changed underneath us: give the jobs back
-                SC.state.jobs.push(...truck.jobs);
-                truck.jobs = [];
-                truck.phase = null;
-                return;
-            }
-            truck.cargo = truck.jobs.map(j => j.item);
-            truck.phase = 'toDrop';
-            setPath(truck, route.path);
+            loadAtPickup(truck);
         } else if (truck.phase === 'toDrop') {
             for (const job of truck.jobs) {
                 if (job.type === 'raw') {
@@ -89,6 +81,32 @@ SC.vehicles = (function() {
             truck.jobs = [];
             truck.phase = null;
         }
+    }
+
+    // Truck arrived at its pickup (or is waiting there). Suppliers hold
+    // finite regenerating stock: if there isn't enough for the whole
+    // bundle yet, the truck waits in the 'loading' phase and retries
+    // each tick until the stock catches up. Factory pickups (crafted
+    // intermediates/products) are made-to-order and never stock-gated.
+    function loadAtPickup(truck) {
+        const first = truck.jobs[0];
+        const route = SC.roads.findPath(first.pickup, first.drop);
+        if (!route) { // network changed underneath us: give the jobs back
+            SC.state.jobs.push(...truck.jobs);
+            truck.jobs = [];
+            truck.phase = null;
+            return;
+        }
+        if (first.pickup.kind === 'supplier') {
+            if ((first.pickup.stock || 0) < truck.jobs.length) {
+                truck.phase = 'loading';
+                return;
+            }
+            first.pickup.stock -= truck.jobs.length;
+        }
+        truck.cargo = truck.jobs.map(j => j.item);
+        truck.phase = 'toDrop';
+        setPath(truck, route.path);
     }
 
     // Assign pending jobs to idle trucks. Repeatedly matches the globally
@@ -147,11 +165,14 @@ SC.vehicles = (function() {
     function tick(dt) {
         const speed = SC.truckSpeed();
         for (const t of SC.state.trucks) {
+            if (t.phase === 'loading') { loadAtPickup(t); continue; } // waiting on supplier stock
             if (!t.path) continue;
             let remaining = speed * dt;
             while (remaining > 0 && t.path && t.pathIdx < t.path.length - 1) {
                 const a = t.path[t.pathIdx], b = t.path[t.pathIdx + 1];
-                const segLen = Math.hypot(b.x - a.x, b.y - a.y) || 1;
+                // Highways carry trucks faster on that segment
+                const mult = SC.roads.speedMult(SC.roads.findEdge(a, b));
+                const segLen = (Math.hypot(b.x - a.x, b.y - a.y) || 1) / mult;
                 const distLeft = segLen * (1 - t.progress);
                 if (remaining < distLeft) {
                     t.progress += remaining / segLen;
@@ -175,12 +196,12 @@ SC.vehicles = (function() {
     }
 
     function buyTruck() {
-        const price = SC.truckPrice();
+        const hq = SC.state.nodes.find(n => n.isHQ) || SC.state.nodes[0];
+        const yard = SC.isYard(SC.state.activeYard) ? SC.state.activeYard : hq;
+        const price = SC.truckPrice(yard); // per-yard ladder
         if (!SC.canAfford(price)) return { ok: false, reason: 'money', cost: price };
         SC.state.money -= price;
         SC.state.trucksBought++;
-        const hq = SC.state.nodes.find(n => n.isHQ) || SC.state.nodes[0];
-        const yard = SC.isYard(SC.state.activeYard) ? SC.state.activeYard : hq;
         const truck = addTruck(yard, yard);
         SC.emit('truckBought', { truck, price });
         return { ok: true, truck };

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -15,19 +15,19 @@
     <div id="results"></div>
 
     <!-- Pure logic only: no render/input/ui/main, no canvas needed -->
-    <script src="js/config.js?v=1.10.0"></script>
-    <script src="js/state.js?v=1.10.0"></script>
-    <script src="js/save.js?v=1.10.0"></script>
-    <script src="js/sfx.js?v=1.10.0"></script>
-    <script src="js/map.js?v=1.10.0"></script>
-    <script src="js/camera.js?v=1.10.0"></script>
-    <script src="js/roads.js?v=1.10.0"></script>
-    <script src="js/factories.js?v=1.10.0"></script>
-    <script src="js/economy.js?v=1.10.0"></script>
-    <script src="js/vehicles.js?v=1.10.0"></script>
-    <script src="js/inspect.js?v=1.10.0"></script>
-    <script src="js/research.js?v=1.10.0"></script>
-    <script src="js/placement.js?v=1.10.0"></script>
+    <script src="js/config.js?v=1.11.0"></script>
+    <script src="js/state.js?v=1.11.0"></script>
+    <script src="js/save.js?v=1.11.0"></script>
+    <script src="js/sfx.js?v=1.11.0"></script>
+    <script src="js/map.js?v=1.11.0"></script>
+    <script src="js/camera.js?v=1.11.0"></script>
+    <script src="js/roads.js?v=1.11.0"></script>
+    <script src="js/factories.js?v=1.11.0"></script>
+    <script src="js/economy.js?v=1.11.0"></script>
+    <script src="js/vehicles.js?v=1.11.0"></script>
+    <script src="js/inspect.js?v=1.11.0"></script>
+    <script src="js/research.js?v=1.11.0"></script>
+    <script src="js/placement.js?v=1.11.0"></script>
 
     <script>
     let passed = 0, failed = 0;
@@ -182,9 +182,18 @@
         SC.state.upgrades.truckSpeed = SC.CONFIG.UPGRADES.truckSpeed.max;
         assert('maxed upgrade rejected', SC.upgradePrice('truckSpeed') === null &&
             !SC.economy.buyUpgrade('truckSpeed').ok);
+        // Truck prices ladder per yard: growth tracks trucks homed at the
+        // active yard, and a fresh yard resets the ladder to base price.
+        const hq = SC.state.nodes.find(n => n.isHQ);
+        SC.state.activeYard = hq;
         const t0 = SC.truckPrice();
-        SC.state.trucksBought = 2;
-        assert('truck price grows with fleet', SC.truckPrice() > t0);
+        assert('first truck at a yard costs base price', t0 === SC.CONFIG.TRUCK_PRICE);
+        SC.vehicles.addTruck(hq, hq);
+        SC.vehicles.addTruck(hq, hq);
+        assert('truck price grows with trucks at the active yard', SC.truckPrice() > t0);
+        const yard = SC.map.makeNode('yard', 900, 900, { active: true });
+        SC.state.activeYard = yard;
+        assert('a new yard resets the truck price ladder', SC.truckPrice() === SC.CONFIG.TRUCK_PRICE);
     })();
 
     // ── Truck capacity: base, upgrade effect, bundling, partial cancel ──
@@ -875,6 +884,174 @@
 
         assert('infoFor is null for inactive nodes',
             SC.inspect.infoFor(SC.map.makeNode('supplier', 900, 900, { mat: 'ore' })) === null);
+    })();
+
+    // ── Supplier stock: cap, regen, consumption, trucks wait when dry ──
+    (function() {
+        const { S1, S2, F, C } = fixture();
+        SC.state.money = 100000;
+        assert('supplier starts with a full stockpile', S1.stock === SC.supplierCap(S1));
+        assert('base cap matches config', SC.supplierCap(S1) === SC.CONFIG.SUPPLIER_STOCK_CAP);
+
+        S1.stock = 2;
+        SC.economy.tickSuppliers(4);
+        assert('stock regenerates over time', approx(S1.stock, 2 + SC.CONFIG.SUPPLIER_REGEN * 4, 0.01));
+        SC.economy.tickSuppliers(10000);
+        assert('regen stops at the cap', S1.stock === SC.supplierCap(S1));
+
+        SC.roads.build(S1, F);
+        const truck = SC.vehicles.addTruck(S1);
+        const before = S1.stock;
+        SC.vehicles.addJob({ type: 'raw', item: 'wheat', pickup: S1, drop: F, order: null, task: null });
+        SC.vehicles.dispatch();
+        assert('pickup consumes one unit of supplier stock',
+            S1.stock === before - 1 && truck.phase === 'toDrop');
+    })();
+
+    // ── Supplier stock: dry supplier makes the truck wait ('loading') ──
+    (function() {
+        const { S1, F } = fixture();
+        SC.state.money = 100000;
+        SC.roads.build(S1, F);
+        S1.stock = 0;
+        const truck = SC.vehicles.addTruck(S1);
+        SC.vehicles.addJob({ type: 'raw', item: 'wheat', pickup: S1, drop: F, order: null, task: null });
+        SC.vehicles.dispatch();
+        assert('truck at a dry supplier waits in the loading phase', truck.phase === 'loading');
+        assert('loading truck is not counted as idle for dispatch', truck.jobs.length === 1);
+
+        // Regen refills the stock; the waiting truck then loads and departs
+        for (let i = 0; i < 100 && truck.phase === 'loading'; i++) {
+            SC.economy.tickSuppliers(0.1);
+            SC.vehicles.tick(0.1);
+        }
+        assert('truck departs once regen catches up', truck.phase === 'toDrop' || truck.phase === null);
+        assert('the loaded unit was taken from stock', S1.stock < 1);
+    })();
+
+    // ── Supplier upgrades: price ladder, cap/regen boost, max level ──
+    (function() {
+        const { S1 } = fixture();
+        SC.state.money = 100000;
+        const p0 = SC.supplierUpgradePrice(S1);
+        assert('level-0 upgrade costs the base price', p0 === SC.CONFIG.SUPPLIER_UPGRADE_BASE);
+        const cap0 = SC.supplierCap(S1), regen0 = SC.supplierRegen(S1);
+        const res = SC.economy.upgradeSupplier(S1);
+        assert('upgrade charges and levels the supplier',
+            res.ok && S1.level === 1 && SC.state.money === 100000 - p0);
+        assert('upgrade raises cap and regen',
+            SC.supplierCap(S1) > cap0 && SC.supplierRegen(S1) > regen0);
+        assert('next level costs more', SC.supplierUpgradePrice(S1) > p0);
+        S1.level = SC.CONFIG.SUPPLIER_MAX_LEVEL;
+        assert('maxed supplier cannot upgrade further',
+            SC.supplierUpgradePrice(S1) === null && !SC.economy.upgradeSupplier(S1).ok);
+        assert('cities cannot be supplier-upgraded',
+            !SC.economy.upgradeSupplier(SC.state.nodes.find(n => n.kind === 'city')).ok);
+
+        // Fertilizer research boosts every supplier's regen globally
+        const r0 = SC.supplierRegen(S1);
+        SC.state.research.completed.fertilizer = true;
+        assert('fertilizer research boosts supplier regen',
+            approx(SC.supplierRegen(S1), r0 * (1 + SC.RESEARCH.fertilizer.supplierRegenBonus), 0.001));
+    })();
+
+    // ── Road upgrades: research gate, cost, routing and truck speed ──
+    (function() {
+        const { S1, S2, F, C } = fixture();
+        SC.state.money = 100000;
+        const e1 = SC.roads.build(S1, F).edge;
+        assert('road upgrade locked before pavedRoads research',
+            SC.roads.upgradeQuote(e1) === null && !SC.roads.upgrade(e1).ok);
+
+        SC.state.research.completed.pavedRoads = true;
+        const q = SC.roads.upgradeQuote(e1);
+        assert('upgrade quote scales with length',
+            q && q.cost === Math.round(e1.len * SC.CONFIG.ROAD_UPGRADE_PER_UNIT));
+        const m0 = SC.state.money;
+        assert('upgrade charges and marks the edge a highway',
+            SC.roads.upgrade(e1).ok && e1.level === 1 && SC.state.money === m0 - q.cost);
+        assert('an edge cannot be upgraded twice', SC.roads.upgradeQuote(e1) === null);
+
+        // Dijkstra weighs highways by travel time, so a paved detour of
+        // equal length beats the unpaved one.
+        assert('pathfinding dist shrinks on a highway',
+            approx(SC.roads.pathDist(S1, F), e1.len / SC.CONFIG.HIGHWAY_SPEED_MULT, 0.01));
+
+        // A truck physically crosses a highway edge faster than an
+        // identical-length normal one: count ticks to finish each leg.
+        const e2 = SC.roads.build(S2, F).edge; // same 316.23u length as S1->F, unpaved
+        function ticksToTraverse(from, to) {
+            const truck = SC.vehicles.addTruck(from);
+            truck.phase = 'returning'; // plain travel, no pickup/drop logic
+            truck.path = SC.roads.findPath(from, to).path;
+            truck.pathIdx = 0; truck.progress = 0;
+            let n = 0;
+            while (truck.path && n < 1000) { SC.vehicles.tick(0.05); n++; }
+            SC.state.trucks.pop();
+            return n;
+        }
+        const hwyTicks = ticksToTraverse(S1, F); // paved leg
+        const stdTicks = ticksToTraverse(S2, F); // unpaved leg
+        assert('truck crosses a highway edge faster than a normal one',
+            hwyTicks < stdTicks && approx(stdTicks / hwyTicks, SC.CONFIG.HIGHWAY_SPEED_MULT, 0.2));
+    })();
+
+    // ── Research-gated upgrade caps (Overdrive / Automation) ──
+    (function() {
+        fixture();
+        SC.state.money = 100000;
+        SC.state.upgrades.truckSpeed = SC.CONFIG.UPGRADES.truckSpeed.max;
+        assert('truckSpeed capped at config max without research',
+            SC.upgradePrice('truckSpeed') === null);
+        SC.state.research.completed.overdrive = true;
+        assert('overdrive research raises the truckSpeed cap',
+            SC.upgradeMax('truckSpeed') === SC.CONFIG.UPGRADES.truckSpeed.max + 3 &&
+            SC.upgradePrice('truckSpeed') !== null);
+        assert('buying past the old cap works once researched',
+            SC.economy.buyUpgrade('truckSpeed').ok &&
+            SC.state.upgrades.truckSpeed === SC.CONFIG.UPGRADES.truckSpeed.max + 1);
+        assert('factorySpeed cap untouched by overdrive',
+            SC.upgradeMax('factorySpeed') === SC.CONFIG.UPGRADES.factorySpeed.max);
+    })();
+
+    // ── Deeper chains pay a value premium ───────────
+    (function() {
+        // A world where ONLY robots (depth 3) are craftable: the spawned
+        // order's payout must include the 1.5× depth premium on top of
+        // base value (robot city sits right next to the factory, so the
+        // distance term stays small).
+        SC.newState(); SC.map._resetSeq();
+        SC.state.river = { spine: [{ x: 2100, y: 0 }, { x: 2100, y: SC.CONFIG.WORLD_H }], halfWidths: [10, 10] };
+        const city = SC.map.makeNode('city', 100, 100, { active: true, isHQ: true });
+        SC.map.makeNode('factory', 150, 100, { active: true, recipe: 'robot' });
+        SC.map.makeNode('factory', 300, 100, { active: true, recipe: 'circuit' });
+        SC.map.makeNode('factory', 450, 100, { active: true, recipe: 'wire' });
+        SC.map.makeNode('factory', 600, 100, { active: true, recipe: 'steel' });
+        for (const mat of ['copper', 'rubber', 'chips', 'ore', 'coal']) {
+            SC.map.makeNode('supplier', 700 + Math.random() * 100, 300, { active: true, mat });
+        }
+        const o = SC.economy.spawnOrder();
+        const mult = 1 + SC.CONFIG.ORDER_DEPTH_VALUE * (SC.depthOf('robot') - 1);
+        assert('only robots are orderable in this world', o && o.product === 'robot');
+        assert('depth premium applied to the payout',
+            o.payout >= SC.GOODS.robot.value * mult); // 900 * 1.5 = 1350 minimum
+    })();
+
+    // ── Save round-trip: supplier stock/levels + highway edges ──
+    (function() {
+        const { S1, F } = fixture();
+        SC.state.money = 100000;
+        const edge = SC.roads.build(S1, F).edge;
+        SC.state.research.completed.pavedRoads = true;
+        SC.roads.upgrade(edge);
+        SC.economy.upgradeSupplier(S1);
+        S1.stock = 3.5;
+
+        SC.save.restore(SC.save.serialize());
+        const rS1 = SC.state.nodes.find(n => n.kind === 'supplier' && n.mat === 'wheat');
+        assert('supplier level survives a round-trip', rS1.level === 1);
+        assert('supplier stock survives a round-trip', approx(rS1.stock, 3.5, 0.001));
+        assert('highway level survives a round-trip', SC.state.edges[0].level === 1);
     })();
 
     document.getElementById('summary').textContent = `${passed} passed / ${failed} failed`;


### PR DESCRIPTION
Deepens the supply-chain game's progression per the design batch:

- **Supplier stock**: suppliers hold finite, regenerating stock; trucks wait at a dry supplier (`'loading'` phase). Each supplier is individually upgradable (cap + regen) via the new **Upgrade mode** (⬆️, third top-right mode button).
- **Highways**: after the Asphalt Paving research, Upgrade mode paves a road — trucks cross it 1.6× faster, and pathfinding weighs edges by travel time so routes prefer paved legs.
- **Per-yard truck prices**: the truck price ladder tracks trucks homed at the active yard, so a new yard resets the price to base; ever-growing yard prices are the balance lever.
- **Research tree deepened to 7 techs**: Asphalt Paving → Overdrive Engines (+3 truck-speed cap) and Fertilizer Program (global +50% supplier regen) → Factory Automation (+3 factory-speed cap), so the tree overlay actually branches.
- **Deeper chains pay more**: +25% order value per chain tier past the first (cars ×1.25, robots ×1.5).
- Save format v4; 33 new logic-test assertions (207 total, all passing); reconciled with master's touch tap-slop fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS)_