### PR TITLE
v1.12.0: commerce/logistics research tier, truck reassignment, demand scaling

### DIFF
--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -67,13 +67,25 @@ that ambient animation as its background — it now lives independently at
   activates (buy factory sites with a tap-twice); this track never
   touches cities — see Orders above for how customer DCs unlock.
 - **Research**: one project at a time, paid upfront, takes real time,
-  then unlocks its effect — `SC.RESEARCH` in `config.js`. Ships with Site
-  Requisition (unlocks manual placement, below) and a two-tier Credit
-  Line II/III (each raises the credit limit, stacking). The Shop panel
-  keeps a one-line shortcut (progress/available count); tapping it opens
-  the full tree in its own overlay, laid out left-to-right by
-  prerequisite depth with connecting lines to its `requires` (not a flat
-  list — see `updateResearchTree`/`researchTiers` in `ui.js`).
+  then unlocks its effect — `SC.RESEARCH` in `config.js`. Eleven techs
+  across four branches: Site Requisition (manual placement); Credit
+  Line II/III → Premium Contracts (+15% payouts) → Regional Marketing
+  (customer DCs arrive 40% sooner); Asphalt Paving (highways) →
+  Overdrive Engines (+3 truck-speed cap) → Bulk Logistics (+2 capacity
+  cap); Fertilizer Program (+50% supplier regen) → Factory Automation
+  (+3 factory-speed cap) and Preservatives (+25% order deadlines).
+  Effect fields are generic — additive bonuses (`creditBonus`,
+  `payoutBonus`, `deadlineBonus`, `supplierRegenBonus`) sum via
+  `research.bonusSum`, `customerSpawnMult` multiplies, and
+  `upgradeMaxBonus` raises upgrade caps. The Shop panel keeps a
+  one-line shortcut (progress/available count); tapping it opens the
+  full tree in its own overlay, laid out left-to-right by prerequisite
+  depth with connecting lines to its `requires` (not a flat list — see
+  `updateResearchTree`/`researchTiers` in `ui.js`).
+- **Demand scaling**: the concurrent-order cap grows with the customer
+  network (`economy.maxActiveOrders` = base + `ORDER_PER_CITY` per
+  active DC beyond HQ), so a grown map generates enough work to pay
+  for its grown costs.
 - **Supplier stock**: suppliers hold a finite stockpile that regenerates
   over time (`SUPPLIER_REGEN`) up to a cap; a truck arriving at a dry
   supplier waits there (`'loading'` phase) until stock catches up. Each
@@ -143,13 +155,13 @@ sync with it):
 - Difficulty ramp: order deadlines shrink at higher levels; game-over state.
 - Touch: long-press as an alternative to double-tap for demolish/buy (the
   Inspect-mode hold gesture above uses the same long-press primitive).
-- More research nodes (order-pay boosts, faster milestones); a
-  "promotions" tech that temporarily boosts demand for a chosen good,
-  per the plan's next-steps discussion. (The tree UI and four new techs
-  — Asphalt Paving, Overdrive Engines, Fertilizer Program, Factory
-  Automation — landed in v1.10/1.11; promotions/repeatable research is
-  still open.)
+- A "promotions" tech that temporarily boosts demand for a chosen good,
+  per the plan's next-steps discussion — the one backlog research idea
+  still open, since it needs repeatable/timed research (the current
+  tree assumes each id completes once). Order-pay boosts, faster
+  customer growth, and cap-raising techs all landed in v1.10–1.12.
 - Research cancel/refund (currently a started project can't be aborted).
-- Reassigning an existing truck to a different yard (today you choose a
-  yard at purchase time only; there's no way to move a truck already
-  in the fleet).
+- Faster-milestone research (unlock a site every 2 deliveries instead
+  of 3) — considered for v1.12 but deferred: milestone pace is the main
+  faucet controlling map growth, and cheapening it risks flooding the
+  midgame with sites; revisit alongside a difficulty ramp.

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Supply Chain Tycoon | Niklas Billgren</title>
-    <link rel="stylesheet" href="style.css?v=1.11.0">
+    <link rel="stylesheet" href="style.css?v=1.12.0">
 </head>
 <body>
     <canvas id="gameCanvas"></canvas>
@@ -51,6 +51,10 @@
                 <label for="yard-select">Station new trucks at</label>
                 <select id="yard-select"></select>
             </div>
+            <button class="shop-btn" id="btn-moveTruck">
+                <span class="sname">⇄ Move an idle truck here</span>
+                <span class="price">free</span>
+            </button>
             <button class="shop-btn build-btn" id="btn-yard">
                 <span class="sname">🅿️ Build truck yard</span>
                 <span class="price">$1,200</span>
@@ -146,22 +150,22 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=1.11.0"></script>
-    <script src="js/state.js?v=1.11.0"></script>
-    <script src="js/save.js?v=1.11.0"></script>
-    <script src="js/sfx.js?v=1.11.0"></script>
-    <script src="js/map.js?v=1.11.0"></script>
-    <script src="js/camera.js?v=1.11.0"></script>
-    <script src="js/roads.js?v=1.11.0"></script>
-    <script src="js/factories.js?v=1.11.0"></script>
-    <script src="js/economy.js?v=1.11.0"></script>
-    <script src="js/vehicles.js?v=1.11.0"></script>
-    <script src="js/inspect.js?v=1.11.0"></script>
-    <script src="js/research.js?v=1.11.0"></script>
-    <script src="js/placement.js?v=1.11.0"></script>
-    <script src="js/render.js?v=1.11.0"></script>
-    <script src="js/input.js?v=1.11.0"></script>
-    <script src="js/ui.js?v=1.11.0"></script>
-    <script src="js/main.js?v=1.11.0"></script>
+    <script src="js/config.js?v=1.12.0"></script>
+    <script src="js/state.js?v=1.12.0"></script>
+    <script src="js/save.js?v=1.12.0"></script>
+    <script src="js/sfx.js?v=1.12.0"></script>
+    <script src="js/map.js?v=1.12.0"></script>
+    <script src="js/camera.js?v=1.12.0"></script>
+    <script src="js/roads.js?v=1.12.0"></script>
+    <script src="js/factories.js?v=1.12.0"></script>
+    <script src="js/economy.js?v=1.12.0"></script>
+    <script src="js/vehicles.js?v=1.12.0"></script>
+    <script src="js/inspect.js?v=1.12.0"></script>
+    <script src="js/research.js?v=1.12.0"></script>
+    <script src="js/placement.js?v=1.12.0"></script>
+    <script src="js/render.js?v=1.12.0"></script>
+    <script src="js/input.js?v=1.12.0"></script>
+    <script src="js/ui.js?v=1.12.0"></script>
+    <script src="js/main.js?v=1.12.0"></script>
 </body>
 </html>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -1,7 +1,7 @@
 // Supply Chain Tycoon — constants, materials, recipes, prices
 window.SC = window.SC || {};
 
-SC.VERSION = '1.11.0';
+SC.VERSION = '1.12.0';
 
 SC.CONFIG = {
     WORLD_W: 2200,
@@ -65,7 +65,8 @@ SC.CONFIG = {
 
     ORDER_INTERVAL: [14, 24],  // seconds between new orders (shrinks as you level)
     ORDER_DEADLINE: [100, 160],// seconds to fulfil
-    ORDER_MAX_ACTIVE: 6,
+    ORDER_MAX_ACTIVE: 6,       // base cap; +ORDER_PER_CITY per DC beyond HQ
+    ORDER_PER_CITY: 2,         // demand scales with the customer network
     ORDER_DIST_PAY: 0.35,      // $ per world-unit of factory->city distance
     ORDER_DEPTH_SLACK: 0.5,    // extra deadline fraction per chain tier past 1
     ORDER_DEPTH_VALUE: 0.25,   // extra payout fraction per chain tier past 1
@@ -128,10 +129,31 @@ SC.RESEARCH = {
         name: 'Factory Automation', emoji: '🦾', cost: 2000, time: 110, requires: ['fertilizer'],
         desc: 'Raises the Factory Speed upgrade cap by 3 levels.',
         upgradeMaxBonus: { factorySpeed: 3 }
+    },
+    premiumContracts: {
+        name: 'Premium Contracts', emoji: '💰', cost: 1400, time: 80, requires: ['creditLine2'],
+        desc: 'Negotiate better rates — all order payouts +15%.',
+        payoutBonus: 0.15
+    },
+    rapidExpansion: {
+        name: 'Regional Marketing', emoji: '🏙️', cost: 2200, time: 120, requires: ['premiumContracts'],
+        desc: 'Word gets around — new customer DCs appear 40% sooner.',
+        customerSpawnMult: 0.6
+    },
+    coldStorage: {
+        name: 'Preservatives', emoji: '🧊', cost: 1200, time: 80, requires: ['fertilizer'],
+        desc: 'Goods keep longer — order deadlines +25%.',
+        deadlineBonus: 0.25
+    },
+    bulkLogistics: {
+        name: 'Bulk Logistics', emoji: '🏗️', cost: 2400, time: 120, requires: ['overdrive'],
+        desc: 'Raises the Truck Capacity upgrade cap by 2 levels.',
+        upgradeMaxBonus: { truckCapacity: 2 }
     }
 };
 SC.RESEARCH_ORDER = ['manualPlacement', 'creditLine2', 'pavedRoads', 'fertilizer',
-                     'creditLine3', 'overdrive', 'automation'];
+                     'creditLine3', 'premiumContracts', 'overdrive', 'automation', 'coldStorage',
+                     'rapidExpansion', 'bulkLogistics'];
 
 // Goods tree. Raw goods come from suppliers; crafted goods are made in a
 // factory dedicated to that recipe. Only `orderable` goods appear in city

--- a/supply-chain/js/economy.js
+++ b/supply-chain/js/economy.js
@@ -48,12 +48,16 @@ SC.economy = (function() {
         if (nearest === Infinity) nearest = 400;
         // Deeper chains pay a premium on top of the good's base value —
         // multi-tier logistics (car, robot) should out-earn bread runs.
+        // Premium Contracts research boosts every payout on top.
         const depthMult = 1 + C().ORDER_DEPTH_VALUE * (SC.depthOf(product) - 1);
-        const payout = Math.round((qty * (SC.GOODS[product].value * depthMult + C().ORDER_DIST_PAY * nearest)) / 5) * 5;
+        const payout = Math.round((qty * (SC.GOODS[product].value * depthMult + C().ORDER_DIST_PAY * nearest) *
+            (1 + SC.research.payoutBonus())) / 5) * 5;
 
-        // Deeper chains (steel -> car) get extra deadline slack
+        // Deeper chains (steel -> car) get extra deadline slack;
+        // Preservatives research stretches every deadline further.
         const slack = 1 + C().ORDER_DEPTH_SLACK * (SC.depthOf(product) - 1);
-        const deadline = rand(C().ORDER_DEADLINE[0], C().ORDER_DEADLINE[1]) * slack;
+        const deadline = rand(C().ORDER_DEADLINE[0], C().ORDER_DEADLINE[1]) * slack *
+            (1 + SC.research.deadlineBonus());
         const order = {
             id: ++SC.state.orderSeq,
             city, product, qty,
@@ -175,6 +179,13 @@ SC.economy = (function() {
         }
     }
 
+    // Demand scales with the customer network: each active DC beyond HQ
+    // raises the concurrent-order cap, so a grown map generates enough
+    // work to pay for its grown costs.
+    function maxActiveOrders() {
+        return C().ORDER_MAX_ACTIVE + C().ORDER_PER_CITY * Math.max(0, activeCities().length - 1);
+    }
+
     // Suppliers regenerate stock toward their (level-scaled) cap; trucks
     // arriving at a dry supplier wait in the 'loading' phase (vehicles.js).
     function tickSuppliers(dt) {
@@ -217,13 +228,14 @@ SC.economy = (function() {
             const node = SC.map.unlockNext(n => n.kind === 'city');
             if (node) SC.emit('unlock', node);
             SC.state.nextCustomerIn = node
-                ? rand(C().CUSTOMER_SPAWN_INTERVAL[0], C().CUSTOMER_SPAWN_INTERVAL[1])
+                ? rand(C().CUSTOMER_SPAWN_INTERVAL[0], C().CUSTOMER_SPAWN_INTERVAL[1]) *
+                  SC.research.customerSpawnMult() // Regional Marketing shortens the wait
                 : Infinity; // pool exhausted — stop checking
         }
 
         // New orders arrive a bit faster as you level up
         SC.state.nextOrderIn -= dt;
-        if (SC.state.nextOrderIn <= 0 && SC.state.orders.length < C().ORDER_MAX_ACTIVE) {
+        if (SC.state.nextOrderIn <= 0 && SC.state.orders.length < maxActiveOrders()) {
             const o = spawnOrder();
             if (o) planOrder(o);
             const pace = Math.max(0.5, 1 - SC.state.delivered * 0.02);
@@ -254,5 +266,5 @@ SC.economy = (function() {
 
     return { spawnOrder, planOrder, deliverProduct, expireOrder,
              onNetworkChanged, tick, tickSuppliers, buyUpgrade, upgradeSupplier,
-             craftableProducts, bestSourceFor };
+             craftableProducts, bestSourceFor, maxActiveOrders };
 })();

--- a/supply-chain/js/research.js
+++ b/supply-chain/js/research.js
@@ -48,14 +48,32 @@ SC.research = (function() {
         }
     }
 
-    // Sum of creditBonus across completed research — read by SC.creditLimit.
-    function creditBonus() {
+    // Sum a numeric effect field across completed research. Additive
+    // effects (creditBonus, payoutBonus, ...) all use this shape.
+    function bonusSum(field) {
         let b = 0;
         for (const id in SC.state.research.completed) {
             const t = SC.RESEARCH[id];
-            if (t && t.creditBonus) b += t.creditBonus;
+            if (t && t[field]) b += t[field];
         }
         return b;
+    }
+
+    // Read by SC.creditLimit / economy.spawnOrder / SC.supplierRegen.
+    function creditBonus() { return bonusSum('creditBonus'); }
+    function payoutBonus() { return bonusSum('payoutBonus'); }
+    function deadlineBonus() { return bonusSum('deadlineBonus'); }
+    function supplierRegenBonus() { return bonusSum('supplierRegenBonus'); }
+
+    // Multiplicative: product of every completed tech's customerSpawnMult
+    // (Regional Marketing's 0.6 shortens the wait for new customer DCs).
+    function customerSpawnMult() {
+        let m = 1;
+        for (const id in SC.state.research.completed) {
+            const t = SC.RESEARCH[id];
+            if (t && t.customerSpawnMult) m *= t.customerSpawnMult;
+        }
+        return m;
     }
 
     // Extra upgrade levels unlocked for `key` (e.g. Overdrive Engines
@@ -69,17 +87,7 @@ SC.research = (function() {
         return b;
     }
 
-    // Global supplier regen multiplier bonus (Fertilizer Program) —
-    // read by SC.supplierRegen.
-    function supplierRegenBonus() {
-        let b = 0;
-        for (const id in SC.state.research.completed) {
-            const t = SC.RESEARCH[id];
-            if (t && t.supplierRegenBonus) b += t.supplierRegenBonus;
-        }
-        return b;
-    }
-
     return { isDone, isAvailable, activeId, canStart, start, progress, tick,
-             creditBonus, upgradeMaxBonus, supplierRegenBonus };
+             creditBonus, payoutBonus, deadlineBonus, supplierRegenBonus,
+             customerSpawnMult, upgradeMaxBonus };
 })();

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -76,6 +76,10 @@ SC.ui = (function() {
         btn.classList.toggle('active', !!active);
         btn.querySelector('.price').textContent = active ? 'Tap map…' : fmt(price);
         btn.disabled = !active && !SC.canAfford(price);
+
+        // Move-truck: needs an idle truck homed somewhere else
+        $('btn-moveTruck').disabled = !st.trucks.some(t =>
+            !t.jobs.length && t.homeYard !== st.activeYard && (!t.path || t.phase === 'returning'));
     }
 
     // ── Research & Build (Shop panel sections) ──────
@@ -445,6 +449,12 @@ SC.ui = (function() {
         $('yard-select').addEventListener('change', e => {
             const node = SC.state.nodes.find(n => n.id === +e.target.value);
             if (node) SC.state.activeYard = node;
+        });
+        $('btn-moveTruck').addEventListener('click', () => {
+            const res = SC.vehicles.reassignTruck(SC.state.activeYard);
+            if (res.ok) { SC.sfx.play('click'); toast(`Truck rebased to ${yardLabel(SC.state.activeYard)}`, 'good'); }
+            else { SC.sfx.play('error'); toast('No idle truck available at another yard', 'error'); }
+            updateShop();
         });
         $('btn-yard').addEventListener('click', () => {
             const st = SC.state;

--- a/supply-chain/js/vehicles.js
+++ b/supply-chain/js/vehicles.js
@@ -207,5 +207,20 @@ SC.vehicles = (function() {
         return { ok: true, truck };
     }
 
-    return { addTruck, addJob, cancelJobsForOrder, dispatch, tick, buyTruck };
+    // Re-home an idle truck to `yard` (free — moving isn't creating).
+    // Takes one from the yard with the biggest fleet so bases even out;
+    // the dispatcher's go-home logic then drives it to its new yard.
+    function reassignTruck(yard) {
+        if (!SC.isYard(yard)) return { ok: false, reason: 'invalid' };
+        const idle = SC.state.trucks.filter(t =>
+            !t.jobs.length && t.homeYard !== yard && (!t.path || t.phase === 'returning'));
+        if (!idle.length) return { ok: false, reason: 'none' };
+        idle.sort((a, b) => SC.trucksAtYard(b.homeYard) - SC.trucksAtYard(a.homeYard));
+        const truck = idle[0];
+        truck.homeYard = yard;
+        SC.emit('truckReassigned', { truck, yard });
+        return { ok: true, truck };
+    }
+
+    return { addTruck, addJob, cancelJobsForOrder, dispatch, tick, buyTruck, reassignTruck };
 })();

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -15,19 +15,19 @@
     <div id="results"></div>
 
     <!-- Pure logic only: no render/input/ui/main, no canvas needed -->
-    <script src="js/config.js?v=1.11.0"></script>
-    <script src="js/state.js?v=1.11.0"></script>
-    <script src="js/save.js?v=1.11.0"></script>
-    <script src="js/sfx.js?v=1.11.0"></script>
-    <script src="js/map.js?v=1.11.0"></script>
-    <script src="js/camera.js?v=1.11.0"></script>
-    <script src="js/roads.js?v=1.11.0"></script>
-    <script src="js/factories.js?v=1.11.0"></script>
-    <script src="js/economy.js?v=1.11.0"></script>
-    <script src="js/vehicles.js?v=1.11.0"></script>
-    <script src="js/inspect.js?v=1.11.0"></script>
-    <script src="js/research.js?v=1.11.0"></script>
-    <script src="js/placement.js?v=1.11.0"></script>
+    <script src="js/config.js?v=1.12.0"></script>
+    <script src="js/state.js?v=1.12.0"></script>
+    <script src="js/save.js?v=1.12.0"></script>
+    <script src="js/sfx.js?v=1.12.0"></script>
+    <script src="js/map.js?v=1.12.0"></script>
+    <script src="js/camera.js?v=1.12.0"></script>
+    <script src="js/roads.js?v=1.12.0"></script>
+    <script src="js/factories.js?v=1.12.0"></script>
+    <script src="js/economy.js?v=1.12.0"></script>
+    <script src="js/vehicles.js?v=1.12.0"></script>
+    <script src="js/inspect.js?v=1.12.0"></script>
+    <script src="js/research.js?v=1.12.0"></script>
+    <script src="js/placement.js?v=1.12.0"></script>
 
     <script>
     let passed = 0, failed = 0;
@@ -1052,6 +1052,85 @@
         assert('supplier level survives a round-trip', rS1.level === 1);
         assert('supplier stock survives a round-trip', approx(rS1.stock, 3.5, 0.001));
         assert('highway level survives a round-trip', SC.state.edges[0].level === 1);
+    })();
+
+    // ── Premium Contracts / Preservatives: payout & deadline bonuses ──
+    (function() {
+        const { S1, S2, F, C } = fixture();
+        SC.state.money = 100000;
+        // F(400,200) -> C(700,200) = 300u: payout is fully deterministic
+        const o1 = SC.economy.spawnOrder();
+        const base = Math.round((SC.GOODS.bread.value + SC.CONFIG.ORDER_DIST_PAY * 300) / 5) * 5;
+        assert('baseline bread payout matches the formula', o1.payout === base);
+
+        SC.state.research.completed.premiumContracts = true;
+        const o2 = SC.economy.spawnOrder();
+        const boosted = Math.round(((SC.GOODS.bread.value + SC.CONFIG.ORDER_DIST_PAY * 300) * 1.15) / 5) * 5;
+        assert('premium contracts boost payouts by 15%', o2.payout === boosted && o2.payout > o1.payout);
+
+        assert('baseline deadline stays in its config range',
+            o1.deadline >= SC.CONFIG.ORDER_DEADLINE[0] && o1.deadline <= SC.CONFIG.ORDER_DEADLINE[1]);
+        SC.state.research.completed.coldStorage = true;
+        const o3 = SC.economy.spawnOrder();
+        assert('preservatives stretch deadlines by 25%',
+            o3.deadline >= SC.CONFIG.ORDER_DEADLINE[0] * 1.25 &&
+            o3.deadline <= SC.CONFIG.ORDER_DEADLINE[1] * 1.25);
+    })();
+
+    // ── Regional Marketing / Bulk Logistics research effects ──
+    (function() {
+        fixture();
+        assert('customer spawn multiplier is 1 with no research', SC.research.customerSpawnMult() === 1);
+        SC.state.research.completed.rapidExpansion = true;
+        assert('regional marketing shortens customer spawn intervals',
+            approx(SC.research.customerSpawnMult(), SC.RESEARCH.rapidExpansion.customerSpawnMult));
+
+        SC.state.upgrades.truckCapacity = SC.CONFIG.UPGRADES.truckCapacity.max;
+        assert('truckCapacity capped without bulk logistics', SC.upgradePrice('truckCapacity') === null);
+        SC.state.research.completed.bulkLogistics = true;
+        assert('bulk logistics raises the capacity cap by 2',
+            SC.upgradeMax('truckCapacity') === SC.CONFIG.UPGRADES.truckCapacity.max + 2 &&
+            SC.upgradePrice('truckCapacity') !== null);
+    })();
+
+    // ── Order cap scales with the customer network ──
+    (function() {
+        fixture(); // one active city (HQ)
+        assert('order cap is the base with only HQ active',
+            SC.economy.maxActiveOrders() === SC.CONFIG.ORDER_MAX_ACTIVE);
+        SC.map.makeNode('city', 900, 900, { active: true });
+        SC.map.makeNode('city', 1500, 300, { active: true });
+        assert('each extra active DC raises the order cap',
+            SC.economy.maxActiveOrders() === SC.CONFIG.ORDER_MAX_ACTIVE + 2 * SC.CONFIG.ORDER_PER_CITY);
+        assert('inactive cities do not count', (function() {
+            SC.map.makeNode('city', 1800, 900, { active: false });
+            return SC.economy.maxActiveOrders() === SC.CONFIG.ORDER_MAX_ACTIVE + 2 * SC.CONFIG.ORDER_PER_CITY;
+        })());
+    })();
+
+    // ── Truck reassignment: idle trucks re-home between yards ──
+    (function() {
+        const { S1, F, C } = fixture(); // C is HQ
+        SC.state.money = 100000;
+        const yard = SC.map.makeNode('yard', 900, 900, { active: true });
+        const t1 = SC.vehicles.addTruck(C, C);
+        const t2 = SC.vehicles.addTruck(C, C);
+
+        const res = SC.vehicles.reassignTruck(yard);
+        assert('an idle truck re-homes to the target yard',
+            res.ok && res.truck.homeYard === yard);
+        assert('other trucks keep their home', [t1, t2].filter(t => t.homeYard === C).length === 1);
+
+        // Busy trucks are not eligible
+        SC.roads.build(S1, F);
+        const busy = [t1, t2].find(t => t.homeYard === C);
+        busy.jobs = [{ type: 'raw', item: 'wheat', pickup: S1, drop: F, order: null, task: null }];
+        busy.phase = 'toPickup';
+        const res2 = SC.vehicles.reassignTruck(C); // pull one back to HQ
+        assert('a truck with jobs is not eligible to move',
+            res2.ok === true ? res2.truck !== busy : true);
+        const res3 = SC.vehicles.reassignTruck(SC.map.makeNode('city', 1900, 1200, { active: true }));
+        assert('reassigning to a non-yard is rejected', !res3.ok && res3.reason === 'invalid');
     })();
 
     document.getElementById('summary').textContent = `${passed} passed / ${failed} failed`;


### PR DESCRIPTION
Continues deepening progression without committing further to idle-game mechanics:

- **Four new techs** (tree now 11 across 3 tiers): Premium Contracts (+15% order payouts) → Regional Marketing (customer DCs arrive 40% sooner); Bulk Logistics (+2 truck-capacity cap, behind Overdrive Engines); Preservatives (+25% order deadlines, behind Fertilizer Program).
- **Generic research effects**: additive bonus fields share one `bonusSum` helper; `customerSpawnMult` multiplies; `upgradeMaxBonus` raises caps — future techs are one config entry.
- **Truck reassignment** (backlog item): free "⇄ Move an idle truck here" button under the yard picker re-homes an idle truck to the active yard, pulling from the biggest fleet so bases even out.
- **Balance — demand scaling**: the concurrent-order cap now grows +2 per active customer DC beyond HQ (`economy.maxActiveOrders`), so a grown map generates enough orders to fund its grown costs.
- 15 new test assertions (222 total, all passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS)_