### PR TITLE
v1.13.0: promotions, loan-default fail state, difficulty modes

### DIFF
--- a/supply-chain/CLAUDE.md
+++ b/supply-chain/CLAUDE.md
@@ -74,7 +74,12 @@ then (any headless Chromium works; on sandboxed Linux add `--no-sandbox`):
   per-yard truck counts. `&highway=1` completes pavedRoads and paves all
   built roads (highway styling); `&suplevel=2` levels every supplier up
   twice (▲ pips); `&drain=1` empties supplier stocks (red low-stock
-  bars). `&techtree=1` opens the 🔬 Research overlay
+  bars). `&doom=42` forces a balance beyond the credit limit with 42s
+  on the default countdown (⚠ HUD state); `&gameover=1` triggers the
+  foreclosure overlay; `&promo=1` completes Marketing Blitz and starts
+  a promotion (shop button shows the running timer). `?new=1` (no
+  probe) shows the new-game screen incl. the difficulty picker.
+  `&techtree=1` opens the 🔬 Research overlay
   (its own menu, separate from the Shop panel's Build/Buy list) on load,
   for screenshotting the tree layout.
 - **Mobile layout**: same screenshot with `--window-size=390,844`. Caveat

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -66,11 +66,28 @@ that ambient animation as its background — it now lives independently at
 - **Growth**: every 3 filled orders a locked supplier/factory site
   activates (buy factory sites with a tap-twice); this track never
   touches cities — see Orders above for how customer DCs unlock.
+- **Difficulty** (picked on the new-game screen, fixed per run, saved):
+  `SC.DIFFICULTIES` presets set starting money, debt interest rate,
+  order-deadline multiplier, and the default grace period. Normal is
+  the balance baseline (15%/min interest, 20% tighter deadlines);
+  Easy keeps the original pace; Hard tightens both further; Sandbox
+  starts rich with no interest and no fail state (`noFail`).
+- **Default fail state**: purchases are blocked past −creditLimit, so
+  only compounding interest can drag the balance below it — that's an
+  unrecoverable-by-buying spiral, so it starts a grace-period countdown
+  (HUD shows `⚠ DEFAULT IN Ns`). Recover above the limit to clear it;
+  hit zero and the bank forecloses: game-over overlay, save wiped.
+  The countdown is persisted so reloading doesn't reset it.
+- **Promotions** (needs Marketing Blitz researched): a repeatable paid
+  action in the Shop — `PROMO_COST` buys `PROMO_DURATION` seconds of
+  ~3× faster order arrivals plus a higher concurrent-order cap. One at
+  a time; the timer survives saves (`promoUntil`).
 - **Research**: one project at a time, paid upfront, takes real time,
-  then unlocks its effect — `SC.RESEARCH` in `config.js`. Eleven techs
+  then unlocks its effect — `SC.RESEARCH` in `config.js`. Twelve techs
   across four branches: Site Requisition (manual placement); Credit
   Line II/III → Premium Contracts (+15% payouts) → Regional Marketing
-  (customer DCs arrive 40% sooner); Asphalt Paving (highways) →
+  (customer DCs arrive 40% sooner) and Marketing Blitz (unlocks
+  promotions, above); Asphalt Paving (highways) →
   Overdrive Engines (+3 truck-speed cap) → Bulk Logistics (+2 capacity
   cap); Fertilizer Program (+50% supplier regen) → Factory Automation
   (+3 factory-speed cap) and Preservatives (+25% order deadlines).
@@ -155,12 +172,12 @@ sync with it):
 - Difficulty ramp: order deadlines shrink at higher levels; game-over state.
 - Touch: long-press as an alternative to double-tap for demolish/buy (the
   Inspect-mode hold gesture above uses the same long-press primitive).
-- A "promotions" tech that temporarily boosts demand for a chosen good,
-  per the plan's next-steps discussion — the one backlog research idea
-  still open, since it needs repeatable/timed research (the current
-  tree assumes each id completes once). Order-pay boosts, faster
-  customer growth, and cap-raising techs all landed in v1.10–1.12.
+- Promotions landed in v1.13 as a research-unlocked *repeatable shop
+  action* (the tree stays one-shot-per-id); a per-good targeted promo
+  is the remaining refinement if wanted.
 - Research cancel/refund (currently a started project can't be aborted).
+- Difficulty ramp *within* a run (deadlines shrinking over time) —
+  difficulty presets landed in v1.13, but each run is flat.
 - Faster-milestone research (unlock a site every 2 deliveries instead
   of 3) — considered for v1.12 but deferred: milestone pace is the main
   faucet controlling map growth, and cheapening it risks flooding the

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Supply Chain Tycoon | Niklas Billgren</title>
-    <link rel="stylesheet" href="style.css?v=1.12.0">
+    <link rel="stylesheet" href="style.css?v=1.13.0">
 </head>
 <body>
     <canvas id="gameCanvas"></canvas>
@@ -77,6 +77,11 @@
                 <span class="price" id="research-shortcut-status">Open tree</span>
             </button>
 
+            <button class="shop-btn hidden" id="btn-promo">
+                <span class="sname">📣 Run promotion</span>
+                <span class="price">$600</span>
+            </button>
+
             <div class="shop-section-title hidden" id="build-title">📍 Build (premium placement)</div>
             <div id="build-list"></div>
         </div>
@@ -94,6 +99,18 @@
                 <svg id="research-tree-edges"></svg>
                 <div id="research-tree-nodes"></div>
             </div>
+        </div>
+    </div>
+
+    <div id="gameover-overlay" class="hidden">
+        <div class="menu-card">
+            <div class="menu-title">
+                <h1>🏦 Loan defaulted!</h1>
+            </div>
+            <p class="gameover-text">The debt spiralled past your credit limit and the
+               grace period ran out — the bank has foreclosed on the company.</p>
+            <div class="menu-stats" id="gameover-stats"></div>
+            <button class="menu-btn primary" id="gameover-restart">↻ Start a new company</button>
         </div>
     </div>
 
@@ -129,7 +146,7 @@
                 <li><b>Build roads:</b> tap a node, then tap another. Crossing the river costs bridge money.</li>
                 <li><b>Fill orders:</b> connect each ingredient's supplier to the factory, and the factory to the ordering HQ/DC. Dispatch is automatic.</li>
                 <li><b>Earn &amp; grow:</b> payouts fund more roads, trucks, factories and upgrades. New sites appear as you deliver.</li>
-                <li><b>Credit line:</b> you can spend into the red down to −$1,500, but debt bleeds 10% interest per minute — pay it off fast.</li>
+                <li><b>Credit line:</b> you can spend into the red down to −$1,500, but debt bleeds interest every minute (rate set by difficulty — 15%/min on Normal). If interest drags you <i>below</i> the limit, a default countdown starts — recover in time or the bank forecloses and the run ends. Sandbox never forecloses.</li>
                 <li><b>Research:</b> in the Shop panel, invest upfront and wait it out to unlock upgrades like manual site placement and a bigger credit line.</li>
                 <li><b>Truck yards:</b> HQ is your first yard. Build more (Shop panel) to station trucks closer to distant routes — idle trucks head home to their yard, so they stay ready near their own region.</li>
                 <li><b>Supplier stock:</b> suppliers hold a finite stock that refills over time — trucks wait at a dry supplier. Upgrade mode (⬆️, top right): tap a supplier twice to raise its stock cap and refill rate.</li>
@@ -146,26 +163,30 @@
                 <span>🧵+💾→🔌</span>
                 <span>🔌+🔩→🤖</span>
             </div>
+            <div id="difficulty-section">
+                <div class="shop-section-title" style="margin-top:0">Difficulty</div>
+                <div id="difficulty-picker"></div>
+            </div>
             <button id="help-start">Start hauling</button>
         </div>
     </div>
 
-    <script src="js/config.js?v=1.12.0"></script>
-    <script src="js/state.js?v=1.12.0"></script>
-    <script src="js/save.js?v=1.12.0"></script>
-    <script src="js/sfx.js?v=1.12.0"></script>
-    <script src="js/map.js?v=1.12.0"></script>
-    <script src="js/camera.js?v=1.12.0"></script>
-    <script src="js/roads.js?v=1.12.0"></script>
-    <script src="js/factories.js?v=1.12.0"></script>
-    <script src="js/economy.js?v=1.12.0"></script>
-    <script src="js/vehicles.js?v=1.12.0"></script>
-    <script src="js/inspect.js?v=1.12.0"></script>
-    <script src="js/research.js?v=1.12.0"></script>
-    <script src="js/placement.js?v=1.12.0"></script>
-    <script src="js/render.js?v=1.12.0"></script>
-    <script src="js/input.js?v=1.12.0"></script>
-    <script src="js/ui.js?v=1.12.0"></script>
-    <script src="js/main.js?v=1.12.0"></script>
+    <script src="js/config.js?v=1.13.0"></script>
+    <script src="js/state.js?v=1.13.0"></script>
+    <script src="js/save.js?v=1.13.0"></script>
+    <script src="js/sfx.js?v=1.13.0"></script>
+    <script src="js/map.js?v=1.13.0"></script>
+    <script src="js/camera.js?v=1.13.0"></script>
+    <script src="js/roads.js?v=1.13.0"></script>
+    <script src="js/factories.js?v=1.13.0"></script>
+    <script src="js/economy.js?v=1.13.0"></script>
+    <script src="js/vehicles.js?v=1.13.0"></script>
+    <script src="js/inspect.js?v=1.13.0"></script>
+    <script src="js/research.js?v=1.13.0"></script>
+    <script src="js/placement.js?v=1.13.0"></script>
+    <script src="js/render.js?v=1.13.0"></script>
+    <script src="js/input.js?v=1.13.0"></script>
+    <script src="js/ui.js?v=1.13.0"></script>
+    <script src="js/main.js?v=1.13.0"></script>
 </body>
 </html>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -1,7 +1,7 @@
 // Supply Chain Tycoon — constants, materials, recipes, prices
 window.SC = window.SC || {};
 
-SC.VERSION = '1.12.0';
+SC.VERSION = '1.13.0';
 
 SC.CONFIG = {
     WORLD_W: 2200,
@@ -9,13 +9,24 @@ SC.CONFIG = {
     NODE_MIN_DIST: 170,
     NODE_MARGIN: 80,
 
-    START_MONEY: 1200,
     START_TRUCKS: 2,
 
     // Credit line: purchases may push the balance negative down to
-    // -CREDIT_LIMIT, but debt accrues interest continuously.
+    // -CREDIT_LIMIT, but debt accrues interest continuously. Interest can
+    // compound the balance BELOW the limit (purchases are blocked there,
+    // so it's a death spiral): that starts the default countdown — climb
+    // back above -limit within the grace period or the run ends. Interest
+    // rate, grace period, deadlines and starting money all come from the
+    // difficulty preset (SC.DIFFICULTIES below).
     CREDIT_LIMIT: 1500,
-    DEBT_INTEREST_PER_MIN: 0.10, // 10% of the outstanding debt per minute
+
+    // Promotions (unlocked by the 'promotions' research): a paid, timed
+    // demand burst — orders arrive much faster and the concurrent-order
+    // cap rises while it runs. Repeatable, one at a time.
+    PROMO_COST: 600,
+    PROMO_DURATION: 45,          // seconds per promotion
+    PROMO_ORDER_MULT: 0.35,      // order-spawn interval multiplier while active
+    PROMO_ORDER_CAP_BONUS: 2,    // extra concurrent orders while active
 
     AUTOSAVE_INTERVAL: 5,        // seconds between autosaves
 
@@ -94,6 +105,35 @@ SC.CONFIG = {
     YARD_PRICE_GROWTH: 1.5
 };
 
+// Difficulty presets, chosen on the new-game screen and fixed for the
+// run (persisted in the save). Normal is the balance baseline: 15%/min
+// interest and 20% shorter order deadlines than the original tuning.
+// Easy keeps the pre-1.13 pace; Sandbox never forecloses (noFail) and
+// starts rich, for players who just want to build networks.
+SC.DIFFICULTIES = {
+    easy: {
+        label: 'Easy', emoji: '🌱', startMoney: 1500,
+        interestPerMin: 0.10, deadlineMult: 1.0, defaultGrace: 90,
+        desc: 'Relaxed deadlines, gentle interest.'
+    },
+    normal: {
+        label: 'Normal', emoji: '🚚', startMoney: 1200,
+        interestPerMin: 0.15, deadlineMult: 0.8, defaultGrace: 60,
+        desc: 'Tight deadlines, 15%/min debt interest.'
+    },
+    hard: {
+        label: 'Hard', emoji: '🔥', startMoney: 1000,
+        interestPerMin: 0.20, deadlineMult: 0.65, defaultGrace: 45,
+        desc: 'Brutal deadlines, punishing interest.'
+    },
+    sandbox: {
+        label: 'Sandbox', emoji: '🏖️', startMoney: 50000,
+        interestPerMin: 0, deadlineMult: 1.5, defaultGrace: 60, noFail: true,
+        desc: 'Deep pockets, no interest, no bankruptcy.'
+    }
+};
+SC.DIFFICULTY_ORDER = ['easy', 'normal', 'hard', 'sandbox'];
+
 // Research tree: one active project at a time, paid upfront, takes `time`
 // seconds, then unlocks its effect. `requires` lists prerequisite ids.
 // RESEARCH_ORDER fixes menu display order (object key order isn't a
@@ -149,11 +189,15 @@ SC.RESEARCH = {
         name: 'Bulk Logistics', emoji: '🏗️', cost: 2400, time: 120, requires: ['overdrive'],
         desc: 'Raises the Truck Capacity upgrade cap by 2 levels.',
         upgradeMaxBonus: { truckCapacity: 2 }
+    },
+    promotions: {
+        name: 'Marketing Blitz', emoji: '📣', cost: 1800, time: 100, requires: ['premiumContracts'],
+        desc: 'Unlocks paid promotions: a 45s burst of extra orders, repeatable from the Shop.'
     }
 };
 SC.RESEARCH_ORDER = ['manualPlacement', 'creditLine2', 'pavedRoads', 'fertilizer',
                      'creditLine3', 'premiumContracts', 'overdrive', 'automation', 'coldStorage',
-                     'rapidExpansion', 'bulkLogistics'];
+                     'rapidExpansion', 'promotions', 'bulkLogistics'];
 
 // Goods tree. Raw goods come from suppliers; crafted goods are made in a
 // factory dedicated to that recipe. Only `orderable` goods appear in city

--- a/supply-chain/js/economy.js
+++ b/supply-chain/js/economy.js
@@ -54,10 +54,11 @@ SC.economy = (function() {
             (1 + SC.research.payoutBonus())) / 5) * 5;
 
         // Deeper chains (steel -> car) get extra deadline slack;
-        // Preservatives research stretches every deadline further.
+        // Preservatives research stretches every deadline further, and
+        // the difficulty preset scales the whole thing (Normal = 0.8×).
         const slack = 1 + C().ORDER_DEPTH_SLACK * (SC.depthOf(product) - 1);
         const deadline = rand(C().ORDER_DEADLINE[0], C().ORDER_DEADLINE[1]) * slack *
-            (1 + SC.research.deadlineBonus());
+            (1 + SC.research.deadlineBonus()) * SC.diff().deadlineMult;
         const order = {
             id: ++SC.state.orderSeq,
             city, product, qty,
@@ -181,9 +182,29 @@ SC.economy = (function() {
 
     // Demand scales with the customer network: each active DC beyond HQ
     // raises the concurrent-order cap, so a grown map generates enough
-    // work to pay for its grown costs.
+    // work to pay for its grown costs. A running promotion adds more.
     function maxActiveOrders() {
-        return C().ORDER_MAX_ACTIVE + C().ORDER_PER_CITY * Math.max(0, activeCities().length - 1);
+        return C().ORDER_MAX_ACTIVE + C().ORDER_PER_CITY * Math.max(0, activeCities().length - 1) +
+               (isPromoActive() ? C().PROMO_ORDER_CAP_BONUS : 0);
+    }
+
+    // ── Promotions: paid, timed demand bursts (Marketing Blitz) ──
+    function isPromoActive() {
+        return SC.state.time < SC.state.promoUntil;
+    }
+
+    function promoTimeLeft() {
+        return Math.max(0, SC.state.promoUntil - SC.state.time);
+    }
+
+    function startPromotion() {
+        if (!SC.research.isDone('promotions')) return { ok: false, reason: 'locked' };
+        if (isPromoActive()) return { ok: false, reason: 'active' };
+        if (!SC.canAfford(C().PROMO_COST)) return { ok: false, reason: 'money', cost: C().PROMO_COST };
+        SC.state.money -= C().PROMO_COST;
+        SC.state.promoUntil = SC.state.time + C().PROMO_DURATION;
+        SC.emit('promoStarted', { until: SC.state.promoUntil });
+        return { ok: true };
     }
 
     // Suppliers regenerate stock toward their (level-scaled) cap; trucks
@@ -211,13 +232,33 @@ SC.economy = (function() {
     let planTimer = 0;
     function tick(dt) {
         tickSuppliers(dt);
-        // Debt interest: a negative balance bleeds continuously. Interest
-        // can push the debt past the credit limit (purchases stay blocked
-        // until deliveries pay it back down).
-        if (SC.state.money < 0) {
-            const interest = -SC.state.money * (C().DEBT_INTEREST_PER_MIN / 60) * dt;
+        // Debt interest: a negative balance bleeds continuously, at the
+        // difficulty's rate. Interest can push the debt past the credit
+        // limit (purchases stay blocked until deliveries pay it down).
+        if (SC.state.money < 0 && SC.diff().interestPerMin > 0) {
+            const interest = -SC.state.money * (SC.diff().interestPerMin / 60) * dt;
             SC.state.money -= interest;
             SC.state.interestPaid += interest;
+        }
+
+        // Default countdown: below the credit limit nothing can be bought,
+        // so only deliveries already in flight can save you — recover above
+        // -creditLimit within the grace period or the bank forecloses.
+        // Sandbox (noFail) skips foreclosure entirely.
+        if (SC.state.money < -SC.creditLimit() && !SC.diff().noFail) {
+            if (SC.state.defaultIn === null) {
+                SC.state.defaultIn = SC.diff().defaultGrace;
+                SC.emit('debtWarning', { grace: SC.diff().defaultGrace });
+            } else {
+                SC.state.defaultIn -= dt;
+                if (SC.state.defaultIn <= 0 && !SC.state.gameOver) {
+                    SC.state.gameOver = true;
+                    SC.emit('gameOver', { debt: -SC.state.money });
+                }
+            }
+        } else if (SC.state.defaultIn !== null) {
+            SC.state.defaultIn = null;
+            SC.emit('debtRecovered');
         }
 
         // New customer DCs (cities) unlock on their own clock, independent
@@ -233,8 +274,9 @@ SC.economy = (function() {
                 : Infinity; // pool exhausted — stop checking
         }
 
-        // New orders arrive a bit faster as you level up
-        SC.state.nextOrderIn -= dt;
+        // New orders arrive a bit faster as you level up; a running
+        // promotion makes the clock toward the next order tick ~3x faster.
+        SC.state.nextOrderIn -= dt * (isPromoActive() ? 1 / C().PROMO_ORDER_MULT : 1);
         if (SC.state.nextOrderIn <= 0 && SC.state.orders.length < maxActiveOrders()) {
             const o = spawnOrder();
             if (o) planOrder(o);
@@ -266,5 +308,6 @@ SC.economy = (function() {
 
     return { spawnOrder, planOrder, deliverProduct, expireOrder,
              onNetworkChanged, tick, tickSuppliers, buyUpgrade, upgradeSupplier,
-             craftableProducts, bestSourceFor, maxActiveOrders };
+             craftableProducts, bestSourceFor, maxActiveOrders,
+             isPromoActive, promoTimeLeft, startPromotion };
 })();

--- a/supply-chain/js/main.js
+++ b/supply-chain/js/main.js
@@ -9,7 +9,9 @@ SC.init = function() {
     if (!wantFresh && SC.save.exists()) restored = SC.save.load();
 
     if (!restored) {
-        SC.newState();
+        // Difficulty is chosen on the new-game screen (written to
+        // localStorage by the picker so it survives the reload).
+        SC.newState(localStorage.getItem('scTycoonDifficulty') || 'normal');
         SC.map._resetSeq();
         SC.map.generateWorld();
         const start = SC.state.nodes.find(n => n.isHQ);
@@ -38,7 +40,7 @@ SC.init = function() {
         let dt = Math.min(0.05, (now - last) / 1000);
         last = now;
 
-        if (SC.state.gameStarted && !SC.state.paused) {
+        if (SC.state.gameStarted && !SC.state.paused && !SC.state.gameOver) {
             SC.state.time += dt;
             SC.economy.tick(dt);
             SC.factories.tick(dt);
@@ -60,7 +62,7 @@ SC.init = function() {
     // (visibilitychange), bfcache eviction / close (pagehide), and desktop
     // close (beforeunload). localStorage writes are synchronous, so these
     // are safe places to flush.
-    const flush = () => { if (SC.state.gameStarted && !wantFresh) SC.save.store(); };
+    const flush = () => { if (SC.state.gameStarted && !wantFresh && !SC.state.gameOver) SC.save.store(); };
     document.addEventListener('visibilitychange', () => { if (document.hidden) flush(); });
     window.addEventListener('pagehide', flush);
     window.addEventListener('beforeunload', flush);
@@ -95,6 +97,25 @@ SC.runProbe = function(seconds) {
     }
     // Force a debt balance so the red HUD/credit UI can be screenshotted
     if (p.has('debt')) SC.state.money = -Math.abs(parseFloat(p.get('debt')) || 800);
+    // Default-countdown / game-over screenshots: &doom=N puts the balance
+    // beyond the credit limit with N seconds on the clock; &gameover=1
+    // triggers the foreclosure overlay directly.
+    if (p.has('doom')) {
+        SC.state.money = -(SC.creditLimit() + 800);
+        SC.state.defaultIn = parseFloat(p.get('doom')) || SC.diff().defaultGrace;
+    }
+    if (p.has('gameover')) {
+        SC.state.money = -(SC.creditLimit() + 800);
+        SC.state.gameOver = true;
+        SC.emit('gameOver', { debt: -SC.state.money });
+    }
+    // Complete the promotions tech and light one up (&promo=1)
+    if (p.has('promo')) {
+        SC.state.money = Math.max(SC.state.money, 50000);
+        SC.state.research.completed.premiumContracts = true;
+        SC.state.research.completed.promotions = true;
+        SC.economy.startPromotion();
+    }
     // Instantly complete research so the placement UI can be screenshotted
     if (p.has('research')) {
         SC.state.money = Math.max(SC.state.money, 50000);

--- a/supply-chain/js/save.js
+++ b/supply-chain/js/save.js
@@ -38,6 +38,7 @@ SC.save = (function() {
 
         return {
             v: FORMAT,
+            difficulty: st.difficulty,
             money: st.money, earnedTotal: st.earnedTotal,
             interestPaid: st.interestPaid,
             delivered: st.delivered, missed: st.missed,
@@ -46,6 +47,7 @@ SC.save = (function() {
             activeYardId: st.activeYard ? st.activeYard.id : null,
             time: st.time, nextOrderIn: st.nextOrderIn, orderSeq: st.orderSeq,
             nextCustomerIn: st.nextCustomerIn,
+            promoUntil: st.promoUntil, defaultIn: st.defaultIn,
             upgrades: Object.assign({}, st.upgrades),
             research: {
                 completed: Object.assign({}, st.research.completed),
@@ -72,7 +74,7 @@ SC.save = (function() {
     }
 
     function restore(data) {
-        SC.newState();
+        SC.newState(data.difficulty || 'normal');
         SC.map._resetSeq();
         const st = SC.state;
         st.money = data.money;
@@ -86,6 +88,8 @@ SC.save = (function() {
         st.nextOrderIn = data.nextOrderIn;
         st.orderSeq = data.orderSeq;
         st.nextCustomerIn = data.nextCustomerIn !== undefined ? data.nextCustomerIn : st.nextCustomerIn;
+        st.promoUntil = data.promoUntil || 0;
+        st.defaultIn = data.defaultIn !== undefined ? data.defaultIn : null;
         st.upgrades = Object.assign(st.upgrades, data.upgrades);
         if (data.research) {
             st.research.completed = Object.assign({}, data.research.completed);

--- a/supply-chain/js/state.js
+++ b/supply-chain/js/state.js
@@ -7,10 +7,14 @@ SC.listeners = {};
 SC.on = function(ev, fn) { (SC.listeners[ev] = SC.listeners[ev] || []).push(fn); };
 SC.emit = function(ev, data) { (SC.listeners[ev] || []).forEach(fn => fn(data)); };
 
-SC.newState = function() {
+// `difficulty` is fixed for the run: it sets starting money here and
+// interest/deadline/grace modifiers via SC.diff() everywhere else.
+SC.newState = function(difficulty) {
+    if (!SC.DIFFICULTIES[difficulty]) difficulty = 'normal';
     SC.state = {
+        difficulty,
         time: 0,
-        money: SC.CONFIG.START_MONEY,
+        money: SC.DIFFICULTIES[difficulty].startMoney,
         earnedTotal: 0,
         interestPaid: 0,
         delivered: 0,
@@ -35,6 +39,9 @@ SC.newState = function() {
 
         upgrades: { truckSpeed: 0, factorySpeed: 0, truckCapacity: 0 },
         research: { completed: {}, active: null }, // active: { id, t } elapsed seconds
+        promoUntil: 0,      // sim time the running promotion ends (0 = none)
+        defaultIn: null,    // default countdown while below -creditLimit (null = safe)
+        gameOver: false,    // defaulted — sim frozen, overlay shown
 
         selectedNode: null, // node picked as road start (input.js)
         highlight: null,    // { paths, color, city, until } — order route overlay
@@ -43,6 +50,11 @@ SC.newState = function() {
         gameStarted: false
     };
     return SC.state;
+};
+
+// The active difficulty preset (interest, deadlines, grace, fail state).
+SC.diff = function() {
+    return SC.DIFFICULTIES[SC.state.difficulty] || SC.DIFFICULTIES.normal;
 };
 
 // Purchases may dip into the credit line: affordable as long as the

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -19,8 +19,9 @@ SC.ui = (function() {
         const st = SC.state;
         const inDebt = st.money < 0;
         $('hud-money').textContent = (inDebt ? '−' : '') + fmt(Math.abs(st.money));
-        $('hud-money-label').textContent = inDebt
-            ? `Debt (${Math.round(SC.CONFIG.DEBT_INTEREST_PER_MIN * 100)}%/min)` : 'Money';
+        $('hud-money-label').textContent = st.defaultIn !== null
+            ? `⚠ DEFAULT IN ${Math.max(0, Math.ceil(st.defaultIn))}s`
+            : inDebt ? `Debt (${Math.round(SC.diff().interestPerMin * 100)}%/min)` : 'Money';
         $('hud-money-item').classList.toggle('debt', inDebt);
         const idle = st.trucks.filter(t => !t.jobs.length && !t.path).length;
         $('hud-trucks').textContent = `${idle}/${st.trucks.length}`;
@@ -50,7 +51,22 @@ SC.ui = (function() {
         }
         updateResearchShortcut();
         updateResearchTree();
+        updatePromo();
         updateBuild();
+    }
+
+    // ── Promotions (Marketing Blitz): repeatable paid demand burst ──
+    function updatePromo() {
+        const btn = $('btn-promo');
+        btn.classList.toggle('hidden', !SC.research.isDone('promotions'));
+        if (btn.classList.contains('hidden')) return;
+        if (SC.economy.isPromoActive()) {
+            btn.disabled = true;
+            btn.querySelector('.price').textContent = `${Math.ceil(SC.economy.promoTimeLeft())}s left`;
+        } else {
+            btn.disabled = !SC.canAfford(SC.CONFIG.PROMO_COST);
+            btn.querySelector('.price').textContent = fmt(SC.CONFIG.PROMO_COST);
+        }
     }
 
     // ── Truck yards: HQ is always one; more can be built (not research-
@@ -341,6 +357,7 @@ SC.ui = (function() {
             ? `${SC.RESEARCH[st.research.active.id].name} (${Math.round(SC.research.progress(st.research.active.id) * 100)}%)`
             : 'None';
         $('menu-stats').innerHTML = `
+            <div><span>Difficulty</span><b>${SC.diff().emoji} ${SC.diff().label}</b></div>
             <div><span>Balance</span><b class="${st.money < 0 ? 'neg' : 'pos'}">${st.money < 0 ? '−' : ''}${fmt(Math.abs(st.money))}</b></div>
             <div><span>Credit limit</span><b>${fmt(SC.creditLimit())}</b></div>
             <div><span>Total earned</span><b>${fmt(st.earnedTotal)}</b></div>
@@ -423,16 +440,18 @@ SC.ui = (function() {
         $('menu-help').addEventListener('click', () => {
             $('menu-overlay').classList.add('hidden'); // stay paused while reading
             resetNewGameArm();
+            $('difficulty-section').classList.add('hidden'); // mid-run: mode is locked in
             $('help-overlay').classList.remove('hidden');
         });
         $('menu-newgame').addEventListener('click', () => {
             if (newGameArmed) {
                 // Reloading fires pagehide/beforeunload, whose autosave flush
                 // (main.js) would otherwise re-persist this still-in-memory
-                // state right after clear() and undo the reset.
+                // state right after clear() and undo the reset. ?new=1
+                // routes through the new-game screen (difficulty picker).
                 SC.state.gameStarted = false;
                 SC.save.clear();
-                location.reload();
+                location.href = location.pathname + '?new=1';
                 return;
             }
             newGameArmed = true;
@@ -477,6 +496,12 @@ SC.ui = (function() {
             });
         }
 
+        $('btn-promo').addEventListener('click', () => {
+            const res = SC.economy.startPromotion();
+            if (res.ok) { SC.sfx.play('cash'); toast(`📣 Promotion running — ${SC.CONFIG.PROMO_DURATION}s of extra orders!`, 'good'); }
+            else if (res.reason === 'money') { SC.sfx.play('error'); toast(`Credit limit reached — promotion costs ${fmt(res.cost)}`, 'error'); }
+            updateShop();
+        });
         $('btn-research-tree').addEventListener('click', () => { SC.sfx.play('click'); openResearchTree(); });
         $('research-tree-close').addEventListener('click', () => { SC.sfx.play('click'); closeResearchTree(); });
         $('research-overlay').addEventListener('click', e => {
@@ -510,6 +535,11 @@ SC.ui = (function() {
         $('shop-header').addEventListener('click', () =>
             $('shop-panel').classList.toggle('collapsed'));
 
+        $('gameover-restart').addEventListener('click', () => {
+            SC.save.clear();
+            location.href = location.pathname + '?new=1'; // fresh run, difficulty picker shown
+        });
+
         $('help-start').addEventListener('click', () => {
             $('help-overlay').classList.add('hidden');
             localStorage.setItem('scTycoonHelpSeen', 'true');
@@ -534,21 +564,75 @@ SC.ui = (function() {
             SC.sfx.play('unlock');
             toast(`🔬 Research complete: ${SC.RESEARCH[id].name}!`, 'good');
         });
+        SC.on('debtWarning', d => {
+            SC.sfx.play('error');
+            toast(`🏦 Debt past your credit limit — recover within ${Math.round(d.grace)}s or the bank forecloses!`, 'error');
+        });
+        SC.on('debtRecovered', () => toast('Debt back within the credit limit — default averted', 'good'));
+        SC.on('gameOver', d => {
+            SC.sfx.play('expire');
+            SC.save.clear(); // a defaulted company doesn't get resurrected on reload
+            const st = SC.state;
+            $('gameover-stats').innerHTML = `
+                <div><span>Final debt</span><b class="neg">−${fmt(Math.abs(d.debt))}</b></div>
+                <div><span>Total earned</span><b>${fmt(st.earnedTotal)}</b></div>
+                <div><span>Interest paid</span><b>${fmt(st.interestPaid)}</b></div>
+                <div><span>Orders filled / missed</span><b>${st.delivered} / ${st.missed}</b></div>
+                <div><span>Time survived</span><b>${fmtDuration(st.time)}</b></div>`;
+            $('gameover-overlay').classList.remove('hidden');
+        });
+    }
+
+    // ── Difficulty picker (new-game screen only) ─────
+    function updateDifficultyPicker() {
+        const d = SC.state.difficulty;
+        $('difficulty-picker').innerHTML = SC.DIFFICULTY_ORDER.map(k => {
+            const p = SC.DIFFICULTIES[k];
+            return `<button class="diff-btn ${k === d ? 'active' : ''}" data-diff="${k}">
+                <span class="diff-name">${p.emoji} ${p.label}</span>
+                <span class="diff-desc">${p.desc}</span>
+            </button>`;
+        }).join('');
+    }
+
+    function bindDifficultyPicker() {
+        $('difficulty-picker').addEventListener('click', e => {
+            const btn = e.target.closest('[data-diff]');
+            if (!btn || SC.state.gameStarted) return;
+            const k = btn.dataset.diff;
+            localStorage.setItem('scTycoonDifficulty', k); // future new games default here
+            // The world is still untouched pre-start, so the preset can
+            // apply in place: swap the mode and its starting money.
+            SC.state.difficulty = k;
+            SC.state.money = SC.DIFFICULTIES[k].startMoney;
+            SC.sfx.play('click');
+            updateDifficultyPicker();
+            updateHUD();
+        });
     }
 
     function init() {
         bind();
+        bindDifficultyPicker();
         $('menu-version').textContent = 'v' + SC.VERSION;
         updateOrders();
         updateShop();
         updateHUD();
-        if (SC.state.gameStarted || // restored from autosave in main.js
-            localStorage.getItem('scTycoonHelpSeen') === 'true' ||
-            new URLSearchParams(location.search).has('nohelp') ||
-            new URLSearchParams(location.search).has('probe')) {
+        const params = new URLSearchParams(location.search);
+        // ?new=1 (menu "New game" / post-foreclosure restart) always routes
+        // through the new-game screen so the difficulty can be picked.
+        const forceNewScreen = params.has('new') && !params.has('nohelp') && !params.has('probe');
+        if (!forceNewScreen &&
+            (SC.state.gameStarted || // restored from autosave in main.js
+             localStorage.getItem('scTycoonHelpSeen') === 'true' ||
+             params.has('nohelp') || params.has('probe'))) {
             $('help-overlay').classList.add('hidden');
             SC.state.gameStarted = true;
         }
+        // The picker only makes sense before a world has been played on —
+        // opening Help mid-game (via the menu) hides it.
+        $('difficulty-section').classList.toggle('hidden', SC.state.gameStarted);
+        updateDifficultyPicker();
         if (window.innerWidth <= 768) {
             $('orders-panel').classList.add('collapsed');
             $('shop-panel').classList.add('collapsed');

--- a/supply-chain/style.css
+++ b/supply-chain/style.css
@@ -315,6 +315,58 @@ html, body {
 }
 .research-bar div { height: 100%; background: var(--accent-color); border-radius: 2px; }
 
+/* ── Difficulty picker (new-game screen) ────────── */
+#difficulty-section.hidden { display: none; }
+#difficulty-picker {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.45rem;
+    margin-bottom: 1rem;
+}
+.diff-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.15rem;
+    padding: 0.55rem 0.7rem;
+    border-radius: 10px;
+    border: 1px solid var(--card-border);
+    background: rgba(15, 23, 42, 0.5);
+    color: var(--text-primary);
+    cursor: pointer;
+    text-align: left;
+}
+.diff-btn:hover { border-color: var(--accent-color); }
+.diff-btn.active {
+    border-color: var(--accent-color);
+    background: rgba(56, 189, 248, 0.15);
+}
+.diff-name { font-weight: 700; font-size: 0.85rem; }
+.diff-desc { color: var(--text-secondary); font-size: 0.7rem; line-height: 1.3; }
+
+/* ── Game-over (foreclosure) overlay ────────────── */
+#gameover-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 320;
+    background: rgba(15, 23, 42, 0.85);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+}
+#gameover-overlay.hidden { display: none; }
+#gameover-overlay .menu-card { border-color: rgba(248, 113, 113, 0.45); }
+.gameover-text {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    line-height: 1.5;
+    margin-bottom: 0.9rem;
+}
+.shop-btn.hidden { display: none; }
+
 /* ── Research tree overlay ──────────────────────── */
 #research-overlay {
     position: fixed;

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -15,19 +15,19 @@
     <div id="results"></div>
 
     <!-- Pure logic only: no render/input/ui/main, no canvas needed -->
-    <script src="js/config.js?v=1.12.0"></script>
-    <script src="js/state.js?v=1.12.0"></script>
-    <script src="js/save.js?v=1.12.0"></script>
-    <script src="js/sfx.js?v=1.12.0"></script>
-    <script src="js/map.js?v=1.12.0"></script>
-    <script src="js/camera.js?v=1.12.0"></script>
-    <script src="js/roads.js?v=1.12.0"></script>
-    <script src="js/factories.js?v=1.12.0"></script>
-    <script src="js/economy.js?v=1.12.0"></script>
-    <script src="js/vehicles.js?v=1.12.0"></script>
-    <script src="js/inspect.js?v=1.12.0"></script>
-    <script src="js/research.js?v=1.12.0"></script>
-    <script src="js/placement.js?v=1.12.0"></script>
+    <script src="js/config.js?v=1.13.0"></script>
+    <script src="js/state.js?v=1.13.0"></script>
+    <script src="js/save.js?v=1.13.0"></script>
+    <script src="js/sfx.js?v=1.13.0"></script>
+    <script src="js/map.js?v=1.13.0"></script>
+    <script src="js/camera.js?v=1.13.0"></script>
+    <script src="js/roads.js?v=1.13.0"></script>
+    <script src="js/factories.js?v=1.13.0"></script>
+    <script src="js/economy.js?v=1.13.0"></script>
+    <script src="js/vehicles.js?v=1.13.0"></script>
+    <script src="js/inspect.js?v=1.13.0"></script>
+    <script src="js/research.js?v=1.13.0"></script>
+    <script src="js/placement.js?v=1.13.0"></script>
 
     <script>
     let passed = 0, failed = 0;
@@ -673,12 +673,15 @@
         assert('canAfford mirrors the limit',
             SC.canAfford(10) && !SC.canAfford(11));
 
-        // Interest bleeds while negative, and only while negative
+        // Interest bleeds while negative, and only while negative, at the
+        // difficulty's rate (Normal = 15%/min)
         SC.state.money = -1000;
         SC.state.interestPaid = 0;
         SC.economy.tick(60); // one minute in one tick
-        assert('debt accrues ~10% interest per minute',
-            approx(SC.state.money, -1100, 1) && approx(SC.state.interestPaid, 100, 1));
+        const rate = SC.diff().interestPerMin;
+        assert('debt accrues the difficulty interest rate per minute',
+            approx(SC.state.money, -1000 * (1 + rate), 1) && approx(SC.state.interestPaid, 1000 * rate, 1));
+        assert('normal difficulty charges 15%/min', rate === 0.15);
         SC.state.money = 500;
         const ip = SC.state.interestPaid;
         SC.economy.tick(60);
@@ -1068,13 +1071,15 @@
         const boosted = Math.round(((SC.GOODS.bread.value + SC.CONFIG.ORDER_DIST_PAY * 300) * 1.15) / 5) * 5;
         assert('premium contracts boost payouts by 15%', o2.payout === boosted && o2.payout > o1.payout);
 
-        assert('baseline deadline stays in its config range',
-            o1.deadline >= SC.CONFIG.ORDER_DEADLINE[0] && o1.deadline <= SC.CONFIG.ORDER_DEADLINE[1]);
+        const dm = SC.diff().deadlineMult; // Normal = 0.8 (20% tighter than base)
+        assert('baseline deadline is the config range scaled by difficulty',
+            o1.deadline >= SC.CONFIG.ORDER_DEADLINE[0] * dm && o1.deadline <= SC.CONFIG.ORDER_DEADLINE[1] * dm);
+        assert('normal difficulty tightens deadlines by 20%', dm === 0.8);
         SC.state.research.completed.coldStorage = true;
         const o3 = SC.economy.spawnOrder();
         assert('preservatives stretch deadlines by 25%',
-            o3.deadline >= SC.CONFIG.ORDER_DEADLINE[0] * 1.25 &&
-            o3.deadline <= SC.CONFIG.ORDER_DEADLINE[1] * 1.25);
+            o3.deadline >= SC.CONFIG.ORDER_DEADLINE[0] * dm * 1.25 &&
+            o3.deadline <= SC.CONFIG.ORDER_DEADLINE[1] * dm * 1.25);
     })();
 
     // ── Regional Marketing / Bulk Logistics research effects ──
@@ -1131,6 +1136,103 @@
             res2.ok === true ? res2.truck !== busy : true);
         const res3 = SC.vehicles.reassignTruck(SC.map.makeNode('city', 1900, 1200, { active: true }));
         assert('reassigning to a non-yard is rejected', !res3.ok && res3.reason === 'invalid');
+    })();
+
+    // ── Promotions: research gate, cost, faster orders, expiry ──
+    (function() {
+        const { S1, S2, F, C } = fixture();
+        SC.state.money = 100000;
+        assert('promotion locked without the research',
+            !SC.economy.startPromotion().ok && SC.economy.startPromotion().reason === 'locked');
+
+        SC.state.research.completed.promotions = true;
+        const m0 = SC.state.money;
+        const res = SC.economy.startPromotion();
+        assert('promotion charges its cost and activates',
+            res.ok && SC.state.money === m0 - SC.CONFIG.PROMO_COST && SC.economy.isPromoActive());
+        assert('a second promotion cannot overlap',
+            !SC.economy.startPromotion().ok && SC.economy.startPromotion().reason === 'active');
+        assert('promo raises the concurrent-order cap',
+            SC.economy.maxActiveOrders() === SC.CONFIG.ORDER_MAX_ACTIVE + SC.CONFIG.PROMO_ORDER_CAP_BONUS);
+
+        // The clock toward the next order runs ~1/PROMO_ORDER_MULT faster
+        SC.state.orders.length = 0;
+        SC.state.nextOrderIn = 10;
+        SC.economy.tick(1);
+        assert('order clock ticks faster during a promotion',
+            approx(SC.state.nextOrderIn, 10 - 1 / SC.CONFIG.PROMO_ORDER_MULT, 0.01));
+
+        SC.state.time += SC.CONFIG.PROMO_DURATION + 1;
+        assert('promotion expires after its duration',
+            !SC.economy.isPromoActive() && SC.economy.promoTimeLeft() === 0);
+        assert('a new promotion can start after expiry', SC.economy.startPromotion().ok);
+    })();
+
+    // ── Default fail state: countdown, recovery, foreclosure ──
+    (function() {
+        fixture();
+        let over = null, warned = false, recovered = false;
+        SC.on('gameOver', d => { over = d; });
+        SC.on('debtWarning', () => { warned = true; });
+        SC.on('debtRecovered', () => { recovered = true; });
+
+        SC.state.money = -(SC.creditLimit() + 200); // beyond the limit
+        SC.economy.tick(0.1);
+        assert('crossing the limit starts the default countdown',
+            warned && SC.state.defaultIn !== null && SC.state.defaultIn <= SC.diff().defaultGrace);
+
+        // Paying the debt back down clears the countdown
+        SC.state.money = -100;
+        SC.economy.tick(0.1);
+        assert('recovering above the limit clears the countdown',
+            recovered && SC.state.defaultIn === null && !SC.state.gameOver);
+
+        // Sink again and let the clock run out
+        SC.state.money = -(SC.creditLimit() + 200);
+        for (let i = 0; i < 2000 && !SC.state.gameOver; i++) SC.economy.tick(0.1);
+        assert('running out the grace period forecloses the run',
+            SC.state.gameOver && over && over.debt > SC.creditLimit());
+    })();
+
+    // ── Difficulty presets: interest, deadlines, sandbox no-fail ──
+    (function() {
+        SC.newState('easy');
+        assert('easy keeps the classic 10%/min rate and full deadlines',
+            SC.diff().interestPerMin === 0.10 && SC.diff().deadlineMult === 1.0 &&
+            SC.state.money === SC.DIFFICULTIES.easy.startMoney);
+
+        SC.newState('hard');
+        assert('hard raises interest and tightens deadlines further',
+            SC.diff().interestPerMin > 0.15 && SC.diff().deadlineMult < 0.8);
+
+        SC.newState('bogus');
+        assert('unknown difficulty falls back to normal', SC.state.difficulty === 'normal');
+
+        // Sandbox: no interest, never forecloses
+        fixture();
+        SC.state.difficulty = 'sandbox';
+        SC.state.money = -(SC.creditLimit() + 500);
+        SC.state.interestPaid = 0;
+        for (let i = 0; i < 1500; i++) SC.economy.tick(0.1); // 150s, past any grace
+        assert('sandbox charges no interest', SC.state.interestPaid === 0);
+        assert('sandbox never defaults',
+            !SC.state.gameOver && SC.state.defaultIn === null);
+    })();
+
+    // ── Save round-trip: difficulty, promo timer, default countdown ──
+    (function() {
+        SC.newState('hard');
+        SC.map._resetSeq();
+        SC.state.river = { spine: [{ x: 1100, y: 0 }, { x: 1100, y: SC.CONFIG.WORLD_H }], halfWidths: [40, 40] };
+        SC.map.makeNode('city', 700, 200, { active: true, isHQ: true });
+        SC.state.promoUntil = 123;
+        SC.state.defaultIn = 17.5;
+
+        SC.save.restore(SC.save.serialize());
+        assert('difficulty survives a round-trip', SC.state.difficulty === 'hard');
+        assert('promo timer survives a round-trip', SC.state.promoUntil === 123);
+        assert('default countdown survives a round-trip (no reload cheese)',
+            approx(SC.state.defaultIn, 17.5));
     })();
 
     document.getElementById('summary').textContent = `${passed} passed / ${failed} failed`;


### PR DESCRIPTION
Adds the promotions tech and rebalances debt with a real fail state and difficulty modes:

- **Marketing Blitz** research (behind Premium Contracts) unlocks a repeatable paid shop action: $600 buys 45s of ~3× faster order arrivals plus a higher concurrent-order cap. The tech stays one-shot; the repeatable part is the action, so the tree's assumptions hold.
- **Loan-default fail state**: purchases are already blocked past −creditLimit, so only compounding interest can drag you below it — that death spiral now starts a grace-period countdown (HUD shows `⚠ DEFAULT IN Ns`, persisted across saves so reloading doesn't reset it). Recover in time or the bank forecloses: game-over overlay with final stats, save wiped, restart routes through the new-game screen.
- **Difficulty modes** (picked on the new-game screen, fixed per run, saved): Easy keeps the classic 10%/min + full deadlines; **Normal is the new baseline — 15%/min interest and 20% tighter deadlines**; Hard is 20%/min and 35% tighter; Sandbox starts with $50k, no interest, and never forecloses. Menu "New game" and post-foreclosure restarts route through the picker.
- Reconciled with master's corner-UI relayout (HUD top-left, mode toggle bottom-right).
- 20 new test assertions (242 total, all passing post-merge); verified via probe screenshots (default countdown HUD, foreclosure overlay, promo timer button, difficulty picker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS)_