### PR TITLE
v1.17.0: road congestion, feature-flagged per difficulty

### DIFF
--- a/supply-chain/CLAUDE.md
+++ b/supply-chain/CLAUDE.md
@@ -89,7 +89,10 @@ then (any headless Chromium works; on sandboxed Linux add `--no-sandbox`):
   synchronous probe. `&seed=xyz` reproduces a specific map (river shape,
   node layout) instead of a random one — same mechanism as the shareable
   `?seed=` on a real new game; pair with `probe` to get a deterministic
-  screenshot of a known layout.
+  screenshot of a known layout. `&jam=1` force-enables congestion and
+  parks 4 trucks mid-span on the factory→HQ edge (bypassing real
+  dispatch timing) so the red congestion glow can be screenshotted
+  deterministically.
 - **Mobile layout**: same screenshot with `--window-size=390,844`. Caveat
   found while building the research-tree overlay: this Chromium build
   enforces a **hard ~500px minimum layout viewport** in headless mode —

--- a/supply-chain/PLAN.md
+++ b/supply-chain/PLAN.md
@@ -35,6 +35,13 @@ pan/pinch camera).
 
 ## Shipped
 
+- v1.17.0: **road congestion**, feature-flagged. Per item 8 below —
+  details there.
+- v1.15.0-v1.16.0 (parallel branches, master): top-left corner UI
+  consolidated into one pill (☰ + money/debt + idle trucks), Filled/
+  Missed HUD tiles dropped (already in the ☰ menu's stats), back button
+  moved into the menu, fast-forward toggle repositioned to avoid
+  overlapping the Orders panel on phones.
 - v1.14.0: **fast-forward + seeded worlds**. A 1×/2×/4× toggle under the
   HUD runs `speed` fixed-size sub-steps of `economy`/`factories`/
   `vehicles`/`research`.tick per animation frame (same dt each sub-step,
@@ -188,12 +195,16 @@ actually shipped.)*
    whether missed orders should carry any penalty beyond the lost
    payout. Revisit together with the deferred faster-milestone
    research (README backlog).
-8. **Road congestion** — per-edge speed drops when >N trucks are on it;
-   rendered as the road glowing warmer. Rewards building parallel routes
-   and ring roads instead of one mega-highway. (The *positive* half of
-   per-edge speed shipped in v1.11 as highways — `edge.level`,
-   `SC.roads.speedMult`, and time-weighted Dijkstra are exactly the
-   plumbing congestion would reuse with a dynamic multiplier < 1.)
+8. ~~Road congestion~~ — shipped v1.17.0, reusing exactly the highway
+   plumbing this item predicted: `edge.level`'s `speedMult` gained a
+   `congestionMult` factor (`SC.vehicles.truckCountOnEdge` beyond
+   `CONGESTION_THRESHOLD` slows an edge multiplicatively, floored at
+   `CONGESTION_FLOOR`), read live by both truck movement and Dijkstra's
+   weighting, so dispatch actually prefers a quieter parallel road. A
+   busy road glows warmer (`render.drawRoads`). Shipped as a **feature
+   flag** (`SC.state.congestionEnabled`) per the owner's request: on by
+   default for Normal/Hard, off for Easy/Sandbox, toggle anytime from
+   the ☰ menu regardless of difficulty.
 9. **River ferries** — a cheaper-but-slower alternative to bridges: build
    a dock pair, ferry shuttles on a fixed cadence (reuses the old sim's
    boat visual). Bridges = fast + expensive, ferries = cheap + queueing.

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -121,6 +121,17 @@ that ambient animation as its background — it now lives independently at
   paves it (`edge.level 1`) — trucks cross it `HIGHWAY_SPEED_MULT`×
   faster, and pathfinding weighs edges by travel time so routes prefer
   paved legs.
+- **Congestion** (feature-flagged via `SC.state.congestionEnabled`,
+  toggle anytime from the ☰ menu; defaults per difficulty — on for
+  Normal/Hard, off for Easy/Sandbox): once more than
+  `CONGESTION_THRESHOLD` trucks share an edge at once, each additional
+  truck slows it multiplicatively (`CONGESTION_STEP`, floored at
+  `CONGESTION_FLOOR` — never a full stop). `SC.roads.speedMult` folds
+  this in on top of the highway boost, live off
+  `SC.vehicles.truckCountOnEdge`, so it affects both truck movement
+  *and* Dijkstra's routing weight — dispatch naturally prefers a
+  quieter parallel road over a jammed one. The road glows warmer the
+  busier it gets (`render.drawRoads`).
 - **Per-yard truck prices**: the truck price ladder tracks trucks homed
   at the *active yard* (`SC.trucksAtYard`), so a new yard resets the
   ladder to base price — the ever-growing yard price is the balance
@@ -166,10 +177,10 @@ they signal the UI through the tiny `SC.on`/`SC.emit` pub/sub in state.js.
 | `js/save.js` | Autosave/restore to localStorage (serialize/restore round-trip) |
 | `js/rng.js` | Seeded PRNG (xmur3 hash + mulberry32 stream) used only by map.js's world gen, so `?seed=` reproduces a map |
 | `js/map.js` | World gen: river, node sites, starter cluster (seeded via `js/rng.js`, `generateWorld(seed)`); `unlockNext(filterFn)` for milestone (supplier/factory) and customer-DC (city) unlock tracks |
-| `js/roads.js` | Road build/demolish/quote, highway upgrades, Dijkstra pathfinding weighted by travel time |
+| `js/roads.js` | Road build/demolish/quote, highway upgrades, congestion (`speedMult`/`congestionMult`), Dijkstra pathfinding weighted by travel time |
 | `js/factories.js` | Craft tasks (incl. intermediates), raw intake, production ticks, site purchase |
 | `js/economy.js` | Orders (spawn/plan/deliver/expire) with recursive multi-tier sourcing, money, interest + default countdown, upgrades, supplier stock regen/upgrades, promotions, customer-DC spawn timer |
-| `js/vehicles.js` | Trucks (each with a home yard), haul jobs, dispatcher (globally nearest idle truck per job, bundles same-route jobs up to capacity, sends idle trucks home), supplier-stock loading waits, reassignment, movement |
+| `js/vehicles.js` | Trucks (each with a home yard), haul jobs, dispatcher (globally nearest idle truck per job, bundles same-route jobs up to capacity, sends idle trucks home), supplier-stock loading waits, reassignment, movement, `truckCountOnEdge` (feeds congestion) |
 | `js/inspect.js` | Inspect-mode data: node → its connections/routes, for the hover/hold tooltip and highlight |
 | `js/research.js` | Tech tree engine: one active project, cost/time, generic effect accessors (`bonusSum`, `customerSpawnMult`, `upgradeMaxBonus`) |
 | `js/placement.js` | Manual site placement: cost, validity (land/river/min-distance); supplier/factory locked behind research, truck yards are not |

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Supply Chain Tycoon | Niklas Billgren</title>
-    <link rel="stylesheet" href="style.css?v=1.16.0">
+    <link rel="stylesheet" href="style.css?v=1.17.0">
 </head>
 <body>
     <canvas id="gameCanvas"></canvas>
@@ -127,6 +127,7 @@
             <button class="menu-btn primary" id="menu-resume">▶ Resume</button>
             <button class="menu-btn" id="menu-save">💾 Save now</button>
             <button class="menu-btn" id="menu-sound">🔊 Sound</button>
+            <button class="menu-btn" id="menu-congestion">🚦 Congestion</button>
             <button class="menu-btn" id="menu-fullscreen">⛶ Full screen</button>
             <button class="menu-btn" id="menu-help">❓ How to play</button>
             <button class="menu-btn danger" id="menu-newgame">🗑 New game</button>
@@ -154,6 +155,7 @@
                 <li><b>Truck yards:</b> HQ is your first yard. Build more (Shop panel) to station trucks closer to distant routes — idle trucks head home to their yard, so they stay ready near their own region.</li>
                 <li><b>Supplier stock:</b> suppliers hold a finite stock that refills over time — trucks wait at a dry supplier. Upgrade mode (⬆️, bottom right): tap a supplier twice to raise its stock cap and refill rate.</li>
                 <li><b>Highways:</b> after the Asphalt Paving research, use Upgrade mode on a road to pave it — trucks drive 60% faster there.</li>
+                <li><b>Congestion:</b> on by default (Normal/Hard difficulty), a busy road glows warmer and slows down past a few trucks — build parallel routes instead of one mega-highway. Toggle it anytime from the ☰ menu.</li>
                 <li><b>Fast-forward:</b> the 1×/2×/4× toggle under the HUD speeds up the whole sim — orders, crafting, trucks, interest, everything.</li>
                 <li><b>Move around:</b> drag to pan, scroll or pinch to zoom. Tap a road twice to demolish it.</li>
                 <li><b>Inspect mode (🔍, bottom right):</b> hover (or tap on mobile) a node to see its connections — a factory's needed ingredients, a supplier's factories, or a city's open orders — with the relevant roads lit up. Tap again to dismiss.</li>
@@ -175,23 +177,23 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=1.16.0"></script>
-    <script src="js/state.js?v=1.16.0"></script>
-    <script src="js/save.js?v=1.16.0"></script>
-    <script src="js/sfx.js?v=1.16.0"></script>
-    <script src="js/rng.js?v=1.16.0"></script>
-    <script src="js/map.js?v=1.16.0"></script>
-    <script src="js/camera.js?v=1.16.0"></script>
-    <script src="js/roads.js?v=1.16.0"></script>
-    <script src="js/factories.js?v=1.16.0"></script>
-    <script src="js/economy.js?v=1.16.0"></script>
-    <script src="js/vehicles.js?v=1.16.0"></script>
-    <script src="js/inspect.js?v=1.16.0"></script>
-    <script src="js/research.js?v=1.16.0"></script>
-    <script src="js/placement.js?v=1.16.0"></script>
-    <script src="js/render.js?v=1.16.0"></script>
-    <script src="js/input.js?v=1.16.0"></script>
-    <script src="js/ui.js?v=1.16.0"></script>
-    <script src="js/main.js?v=1.16.0"></script>
+    <script src="js/config.js?v=1.17.0"></script>
+    <script src="js/state.js?v=1.17.0"></script>
+    <script src="js/save.js?v=1.17.0"></script>
+    <script src="js/sfx.js?v=1.17.0"></script>
+    <script src="js/rng.js?v=1.17.0"></script>
+    <script src="js/map.js?v=1.17.0"></script>
+    <script src="js/camera.js?v=1.17.0"></script>
+    <script src="js/roads.js?v=1.17.0"></script>
+    <script src="js/factories.js?v=1.17.0"></script>
+    <script src="js/economy.js?v=1.17.0"></script>
+    <script src="js/vehicles.js?v=1.17.0"></script>
+    <script src="js/inspect.js?v=1.17.0"></script>
+    <script src="js/research.js?v=1.17.0"></script>
+    <script src="js/placement.js?v=1.17.0"></script>
+    <script src="js/render.js?v=1.17.0"></script>
+    <script src="js/input.js?v=1.17.0"></script>
+    <script src="js/ui.js?v=1.17.0"></script>
+    <script src="js/main.js?v=1.17.0"></script>
 </body>
 </html>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -1,7 +1,7 @@
 // Supply Chain Tycoon — constants, materials, recipes, prices
 window.SC = window.SC || {};
 
-SC.VERSION = '1.16.0';
+SC.VERSION = '1.17.0';
 
 SC.CONFIG = {
     WORLD_W: 2200,
@@ -48,6 +48,17 @@ SC.CONFIG = {
     // length like building does (bridges cost extra again).
     ROAD_UPGRADE_PER_UNIT: 0.9,
     HIGHWAY_SPEED_MULT: 1.6,
+
+    // Congestion (toggle: SC.state.congestionEnabled, defaulted per
+    // difficulty below, flippable anytime from the pause menu): once
+    // more than CONGESTION_THRESHOLD trucks share an edge at the same
+    // moment, each additional truck slows that edge by CONGESTION_STEP
+    // (multiplicative), down to a CONGESTION_FLOOR minimum — never a
+    // full stop. Applies to both truck movement and Dijkstra's routing
+    // weight, so dispatch naturally prefers a parallel, less-jammed road.
+    CONGESTION_THRESHOLD: 2,
+    CONGESTION_STEP: 0.18,
+    CONGESTION_FLOOR: 0.35,
 
     // Suppliers hold a finite stock that regenerates over time; trucks
     // wait at an empty supplier until enough stock accumulates. Each
@@ -109,27 +120,29 @@ SC.CONFIG = {
 // run (persisted in the save). Normal is the balance baseline: 15%/min
 // interest and 20% shorter order deadlines than the original tuning.
 // Easy keeps the pre-1.13 pace; Sandbox never forecloses (noFail) and
-// starts rich, for players who just want to build networks.
+// starts rich, for players who just want to build networks. `congestion`
+// is only the DEFAULT for SC.state.congestionEnabled — a live toggle in
+// the pause menu overrides it for the rest of the run either way.
 SC.DIFFICULTIES = {
     easy: {
         label: 'Easy', emoji: '🌱', startMoney: 1500,
-        interestPerMin: 0.10, deadlineMult: 1.0, defaultGrace: 90,
-        desc: 'Relaxed deadlines, gentle interest.'
+        interestPerMin: 0.10, deadlineMult: 1.0, defaultGrace: 90, congestion: false,
+        desc: 'Relaxed deadlines, gentle interest, no congestion.'
     },
     normal: {
         label: 'Normal', emoji: '🚚', startMoney: 1200,
-        interestPerMin: 0.15, deadlineMult: 0.8, defaultGrace: 60,
-        desc: 'Tight deadlines, 15%/min debt interest.'
+        interestPerMin: 0.15, deadlineMult: 0.8, defaultGrace: 60, congestion: true,
+        desc: 'Tight deadlines, 15%/min debt interest, road congestion.'
     },
     hard: {
         label: 'Hard', emoji: '🔥', startMoney: 1000,
-        interestPerMin: 0.20, deadlineMult: 0.65, defaultGrace: 45,
-        desc: 'Brutal deadlines, punishing interest.'
+        interestPerMin: 0.20, deadlineMult: 0.65, defaultGrace: 45, congestion: true,
+        desc: 'Brutal deadlines, punishing interest, road congestion.'
     },
     sandbox: {
         label: 'Sandbox', emoji: '🏖️', startMoney: 50000,
-        interestPerMin: 0, deadlineMult: 1.5, defaultGrace: 60, noFail: true,
-        desc: 'Deep pockets, no interest, no bankruptcy.'
+        interestPerMin: 0, deadlineMult: 1.5, defaultGrace: 60, noFail: true, congestion: false,
+        desc: 'Deep pockets, no interest, no bankruptcy, no congestion.'
     }
 };
 SC.DIFFICULTY_ORDER = ['easy', 'normal', 'hard', 'sandbox'];

--- a/supply-chain/js/main.js
+++ b/supply-chain/js/main.js
@@ -95,9 +95,10 @@ SC.runProbe = function(seconds) {
     const nearest = (kind, mat) => SC.state.nodes
         .filter(n => n.active && n.kind === kind && (!mat || n.mat === mat))
         .sort((a, b) => Math.hypot(a.x - f.x, a.y - f.y) - Math.hypot(b.x - f.x, b.y - f.y))[0];
+    const city = nearest('city');
     SC.roads.build(f, nearest('supplier', 'wheat'));
     SC.roads.build(f, nearest('supplier', 'water'));
-    SC.roads.build(f, nearest('city'));
+    SC.roads.build(f, city);
     const o = SC.economy.spawnOrder();
     if (o) SC.economy.planOrder(o);
     for (let t = 0; t < seconds; t += 0.05) {
@@ -154,6 +155,26 @@ SC.runProbe = function(seconds) {
     if (p.has('drain')) {
         for (const n of SC.state.nodes) {
             if (n.kind === 'supplier') n.stock = Math.min(n.stock, 1);
+        }
+    }
+    // Force-jam the factory->HQ edge with several trucks parked mid-span,
+    // so the congestion glow overlay can be screenshotted without waiting
+    // on real dispatch timing (&jam=1; also flips congestion on regardless
+    // of difficulty default).
+    if (p.has('jam')) {
+        SC.state.congestionEnabled = true;
+        SC.state.money = Math.max(SC.state.money, 50000);
+        const edge = SC.roads.findEdge(f, city);
+        if (edge) {
+            for (let i = 0; i < 4; i++) {
+                const truck = SC.vehicles.addTruck(f, f);
+                truck.path = [edge.a, edge.b];
+                truck.pathIdx = 0;
+                truck.progress = 0.25 + i * 0.15;
+                truck.phase = 'toDrop';
+                truck.x = edge.a.x + (edge.b.x - edge.a.x) * truck.progress;
+                truck.y = edge.a.y + (edge.b.y - edge.a.y) * truck.progress;
+            }
         }
     }
     // Arm placement mode so the ghost preview can be screenshotted, e.g.

--- a/supply-chain/js/render.js
+++ b/supply-chain/js/render.js
@@ -121,6 +121,20 @@ SC.render = (function() {
                 ctx.stroke();
                 ctx.setLineDash([]);
             }
+            // Congestion: an overloaded edge glows warmer, hottest at the
+            // busiest roads — the visual cue for "build a parallel route".
+            if (SC.state.congestionEnabled && e !== pending && e !== pendingUp) {
+                const excess = SC.vehicles.truckCountOnEdge(e) - SC.CONFIG.CONGESTION_THRESHOLD;
+                if (excess > 0) {
+                    const heat = Math.min(1, excess / 3);
+                    ctx.beginPath();
+                    ctx.moveTo(e.a.x, e.a.y);
+                    ctx.lineTo(e.b.x, e.b.y);
+                    ctx.strokeStyle = `rgba(248, 113, 113, ${0.25 + heat * 0.5})`;
+                    ctx.lineWidth = 5 + heat * 3;
+                    ctx.stroke();
+                }
+            }
         }
     }
 

--- a/supply-chain/js/roads.js
+++ b/supply-chain/js/roads.js
@@ -53,10 +53,27 @@ SC.roads = (function() {
         return true;
     }
 
+    // Congestion (feature-flagged, see SC.state.congestionEnabled):
+    // trucks beyond CONGESTION_THRESHOLD sharing an edge right now slow
+    // it down multiplicatively, floored at CONGESTION_FLOOR. Read live
+    // off vehicles.js each call, so it reacts in real time as trucks
+    // arrive/leave the edge — including inside Dijkstra's own weighting
+    // below, which is what makes routing actually prefer a quieter
+    // parallel road over a jammed one.
+    function congestionMult(edge) {
+        if (!SC.state.congestionEnabled || !SC.vehicles) return 1;
+        const excess = SC.vehicles.truckCountOnEdge(edge) - SC.CONFIG.CONGESTION_THRESHOLD;
+        return excess > 0
+            ? Math.max(SC.CONFIG.CONGESTION_FLOOR, 1 - SC.CONFIG.CONGESTION_STEP * excess)
+            : 1;
+    }
+
     // Highways (edge.level 1, unlocked by 'pavedRoads' research) move
-    // trucks HIGHWAY_SPEED_MULT× faster on that edge.
+    // trucks HIGHWAY_SPEED_MULT× faster on that edge; congestion (when
+    // enabled) then slows an overloaded edge back down on top of that.
     function speedMult(edge) {
-        return edge && edge.level ? SC.CONFIG.HIGHWAY_SPEED_MULT : 1;
+        if (!edge) return 1;
+        return (edge.level ? SC.CONFIG.HIGHWAY_SPEED_MULT : 1) * congestionMult(edge);
     }
 
     // Quote for upgrading a road to a highway; null when not possible.
@@ -118,5 +135,5 @@ SC.roads = (function() {
     }
 
     return { findEdge, quote, build, demolish, findPath, pathDist,
-             speedMult, upgradeQuote, upgrade };
+             speedMult, congestionMult, upgradeQuote, upgrade };
 })();

--- a/supply-chain/js/save.js
+++ b/supply-chain/js/save.js
@@ -40,6 +40,7 @@ SC.save = (function() {
             v: FORMAT,
             difficulty: st.difficulty,
             seed: st.seed,
+            congestionEnabled: st.congestionEnabled,
             money: st.money, earnedTotal: st.earnedTotal,
             interestPaid: st.interestPaid,
             delivered: st.delivered, missed: st.missed,
@@ -92,6 +93,8 @@ SC.save = (function() {
         st.promoUntil = data.promoUntil || 0;
         st.defaultIn = data.defaultIn !== undefined ? data.defaultIn : null;
         st.seed = data.seed || null;
+        st.congestionEnabled = data.congestionEnabled !== undefined
+            ? data.congestionEnabled : SC.DIFFICULTIES[st.difficulty].congestion;
         st.upgrades = Object.assign(st.upgrades, data.upgrades);
         if (data.research) {
             st.research.completed = Object.assign({}, data.research.completed);

--- a/supply-chain/js/state.js
+++ b/supply-chain/js/state.js
@@ -44,6 +44,7 @@ SC.newState = function(difficulty) {
         defaultIn: null,    // default countdown while below -creditLimit (null = safe)
         gameOver: false,    // defaulted — sim frozen, overlay shown
         speed: 1,           // fast-forward multiplier: 1/2/4, see main.js's loop
+        congestionEnabled: SC.DIFFICULTIES[difficulty].congestion, // live toggle, see roads.speedMult
 
         selectedNode: null, // node picked as road start (input.js)
         highlight: null,    // { paths, color, city, until } — order route overlay

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -379,6 +379,7 @@ SC.ui = (function() {
             ? `Autosaves every ${SC.CONFIG.AUTOSAVE_INTERVAL}s · last saved ${fmtDuration((Date.now() - at) / 1000)} ago`
             : `Autosaves every ${SC.CONFIG.AUTOSAVE_INTERVAL}s · not saved yet this session`;
         $('menu-sound').textContent = SC.sfx.isMuted() ? '🔇 Sound: off' : '🔊 Sound: on';
+        $('menu-congestion').textContent = st.congestionEnabled ? '🚦 Congestion: on' : '🚦 Congestion: off';
         $('menu-fullscreen').textContent = document.fullscreenElement ? '⛶ Exit full screen' : '⛶ Full screen';
     }
 
@@ -448,6 +449,11 @@ SC.ui = (function() {
         });
         $('menu-sound').addEventListener('click', () => {
             SC.sfx.toggleMute();
+            updateMenuInfo();
+        });
+        $('menu-congestion').addEventListener('click', () => {
+            SC.state.congestionEnabled = !SC.state.congestionEnabled;
+            SC.sfx.play('click');
             updateMenuInfo();
         });
         $('menu-fullscreen').addEventListener('click', () => {

--- a/supply-chain/js/vehicles.js
+++ b/supply-chain/js/vehicles.js
@@ -162,6 +162,19 @@ SC.vehicles = (function() {
         }
     }
 
+    // How many trucks are currently travelling this edge's segment right
+    // now, in either direction — read by SC.roads.speedMult for
+    // congestion (when SC.state.congestionEnabled).
+    function truckCountOnEdge(edge) {
+        let n = 0;
+        for (const t of SC.state.trucks) {
+            if (!t.path || t.pathIdx >= t.path.length - 1) continue;
+            const a = t.path[t.pathIdx], b = t.path[t.pathIdx + 1];
+            if ((a === edge.a && b === edge.b) || (a === edge.b && b === edge.a)) n++;
+        }
+        return n;
+    }
+
     function tick(dt) {
         const speed = SC.truckSpeed();
         for (const t of SC.state.trucks) {
@@ -222,5 +235,6 @@ SC.vehicles = (function() {
         return { ok: true, truck };
     }
 
-    return { addTruck, addJob, cancelJobsForOrder, dispatch, tick, buyTruck, reassignTruck };
+    return { addTruck, addJob, cancelJobsForOrder, dispatch, tick, buyTruck, reassignTruck,
+             truckCountOnEdge };
 })();

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -15,20 +15,20 @@
     <div id="results"></div>
 
     <!-- Pure logic only: no render/input/ui/main, no canvas needed -->
-    <script src="js/config.js?v=1.16.0"></script>
-    <script src="js/state.js?v=1.16.0"></script>
-    <script src="js/save.js?v=1.16.0"></script>
-    <script src="js/sfx.js?v=1.16.0"></script>
-    <script src="js/rng.js?v=1.16.0"></script>
-    <script src="js/map.js?v=1.16.0"></script>
-    <script src="js/camera.js?v=1.16.0"></script>
-    <script src="js/roads.js?v=1.16.0"></script>
-    <script src="js/factories.js?v=1.16.0"></script>
-    <script src="js/economy.js?v=1.16.0"></script>
-    <script src="js/vehicles.js?v=1.16.0"></script>
-    <script src="js/inspect.js?v=1.16.0"></script>
-    <script src="js/research.js?v=1.16.0"></script>
-    <script src="js/placement.js?v=1.16.0"></script>
+    <script src="js/config.js?v=1.17.0"></script>
+    <script src="js/state.js?v=1.17.0"></script>
+    <script src="js/save.js?v=1.17.0"></script>
+    <script src="js/sfx.js?v=1.17.0"></script>
+    <script src="js/rng.js?v=1.17.0"></script>
+    <script src="js/map.js?v=1.17.0"></script>
+    <script src="js/camera.js?v=1.17.0"></script>
+    <script src="js/roads.js?v=1.17.0"></script>
+    <script src="js/factories.js?v=1.17.0"></script>
+    <script src="js/economy.js?v=1.17.0"></script>
+    <script src="js/vehicles.js?v=1.17.0"></script>
+    <script src="js/inspect.js?v=1.17.0"></script>
+    <script src="js/research.js?v=1.17.0"></script>
+    <script src="js/placement.js?v=1.17.0"></script>
 
     <script>
     let passed = 0, failed = 0;
@@ -1301,6 +1301,126 @@
         assert('promo timer survives a round-trip', SC.state.promoUntil === 123);
         assert('default countdown survives a round-trip (no reload cheese)',
             approx(SC.state.defaultIn, 17.5));
+    })();
+
+    // ── Congestion: feature-flag defaults per difficulty ──
+    (function() {
+        SC.newState('easy');
+        assert('easy defaults congestion off', SC.state.congestionEnabled === false);
+        SC.newState('normal');
+        assert('normal defaults congestion on', SC.state.congestionEnabled === true);
+        SC.newState('hard');
+        assert('hard defaults congestion on', SC.state.congestionEnabled === true);
+        SC.newState('sandbox');
+        assert('sandbox defaults congestion off', SC.state.congestionEnabled === false);
+    })();
+
+    // ── Congestion: truckCountOnEdge counts trucks on that edge either way ──
+    (function() {
+        const { S1, S2, F, C } = fixture();
+        SC.state.money = 100000;
+        const e1 = SC.roads.build(S1, F).edge;
+        SC.roads.build(S2, F);
+        assert('no trucks on a fresh edge', SC.vehicles.truckCountOnEdge(e1) === 0);
+
+        const t1 = SC.vehicles.addTruck(S1);
+        t1.path = [S1, F]; t1.pathIdx = 0; // travelling a -> b
+        const t2 = SC.vehicles.addTruck(F);
+        t2.path = [F, S1]; t2.pathIdx = 0; // travelling b -> a (same edge, other direction)
+        const t3 = SC.vehicles.addTruck(S2);
+        t3.path = [S2, F]; t3.pathIdx = 0; // a different edge entirely
+        const idle = SC.vehicles.addTruck(S1); // no path: not travelling anywhere
+        assert('counts trucks on the edge regardless of direction, ignores others',
+            SC.vehicles.truckCountOnEdge(e1) === 2);
+        assert('a truck past the last segment index does not count', (function() {
+            t1.pathIdx = 1; // arrived
+            const n = SC.vehicles.truckCountOnEdge(e1);
+            t1.pathIdx = 0;
+            return n === 1; // only t2 left
+        })());
+    })();
+
+    // ── Congestion: speedMult combines with highways, respects the flag ──
+    (function() {
+        const { S1, F } = fixture();
+        SC.state.money = 100000;
+        SC.state.congestionEnabled = true;
+        const edge = SC.roads.build(S1, F).edge;
+
+        function jamWith(n) {
+            SC.state.trucks.length = 0;
+            for (let i = 0; i < n; i++) {
+                const t = SC.vehicles.addTruck(S1);
+                t.path = [S1, F]; t.pathIdx = 0;
+            }
+        }
+
+        jamWith(SC.CONFIG.CONGESTION_THRESHOLD);
+        assert('at/under the threshold, no slowdown', SC.roads.speedMult(edge) === 1);
+
+        jamWith(SC.CONFIG.CONGESTION_THRESHOLD + 2);
+        const expected = 1 - SC.CONFIG.CONGESTION_STEP * 2;
+        assert('past the threshold, speed drops per excess truck',
+            approx(SC.roads.speedMult(edge), expected, 0.001));
+
+        jamWith(SC.CONFIG.CONGESTION_THRESHOLD + 50);
+        assert('congestion never drops speed below the floor',
+            approx(SC.roads.speedMult(edge), SC.CONFIG.CONGESTION_FLOOR, 0.001));
+
+        SC.state.research.completed.pavedRoads = true;
+        SC.roads.upgrade(edge);
+        assert('congestion stacks multiplicatively with the highway boost',
+            approx(SC.roads.speedMult(edge), SC.CONFIG.HIGHWAY_SPEED_MULT * SC.CONFIG.CONGESTION_FLOOR, 0.001));
+
+        SC.state.congestionEnabled = false;
+        assert('disabling the flag removes congestion but keeps the highway boost',
+            approx(SC.roads.speedMult(edge), SC.CONFIG.HIGHWAY_SPEED_MULT, 0.001));
+    })();
+
+    // ── Congestion: Dijkstra routes around a jammed edge (flag-gated) ──
+    (function() {
+        // Two parallel routes of equal length from A to B: a direct edge,
+        // and a two-hop detour through M — same total distance, so
+        // findPath is indifferent until one gets jammed.
+        SC.newState('normal'); // congestion on by default
+        SC.map._resetSeq();
+        SC.state.river = { spine: [{ x: 5000, y: 0 }, { x: 5000, y: SC.CONFIG.WORLD_H }], halfWidths: [10, 10] };
+        const A = SC.map.makeNode('city', 0, 0, { active: true, isHQ: true });
+        const B = SC.map.makeNode('city', 400, 0, { active: true });
+        const M = SC.map.makeNode('supplier', 200, -1, { active: true, mat: 'wheat' }); // ~= 400 total, matches direct
+        SC.state.money = 100000;
+        const direct = SC.roads.build(A, B).edge;
+        SC.roads.build(A, M);
+        SC.roads.build(M, B);
+
+        assert('an uncongested direct edge is chosen over an equal-length detour',
+            SC.roads.findPath(A, B).path.length === 2);
+
+        for (let i = 0; i < SC.CONFIG.CONGESTION_THRESHOLD + 6; i++) {
+            const t = SC.vehicles.addTruck(A);
+            t.path = [A, B]; t.pathIdx = 0;
+        }
+        assert('a jammed direct edge is routed around once congestion matters',
+            SC.roads.findPath(A, B).path.length === 3);
+
+        SC.state.congestionEnabled = false;
+        assert('with the flag off, the jam is ignored and the direct edge wins again',
+            SC.roads.findPath(A, B).path.length === 2);
+    })();
+
+    // ── Save round-trip: congestion flag (both explicit states) ──
+    (function() {
+        const { S1, F, C } = fixture(); // fixture uses SC.newState() -> 'normal' default (on)
+        SC.state.money = 100000;
+        SC.state.congestionEnabled = false; // override the difficulty default
+        SC.save.restore(SC.save.serialize());
+        assert('an explicitly disabled congestion flag survives a round-trip',
+            SC.state.congestionEnabled === false);
+
+        SC.state.congestionEnabled = true;
+        SC.save.restore(SC.save.serialize());
+        assert('an explicitly enabled congestion flag survives a round-trip',
+            SC.state.congestionEnabled === true);
     })();
 
     document.getElementById('summary').textContent = `${passed} passed / ${failed} failed`;


### PR DESCRIPTION
Adds road congestion, as requested — built as a toggleable feature flag rather than baked permanently in:

- **Congestion**: once more than `CONGESTION_THRESHOLD` trucks share an edge at the same moment, each additional truck slows it multiplicatively (`CONGESTION_STEP`), floored at `CONGESTION_FLOOR` — never a full stop. `SC.roads.speedMult` folds this in on top of the highway boost, read live off a new `SC.vehicles.truckCountOnEdge`, so it affects both truck movement *and* Dijkstra's routing weight — dispatch naturally prefers a quieter parallel road over a jammed one. A busy road glows warmer (red overlay, intensity scales with how jammed it is).
- **Feature flag**: `SC.state.congestionEnabled` defaults per difficulty (on for Normal/Hard, off for Easy/Sandbox — matching each preset's philosophy) but is toggleable *anytime* from the ☰ menu ("🚦 Congestion: on/off"), independent of difficulty, and persists in the save.
- 17 new test assertions (309 total, all passing): truck-counting correctness, speed-multiplier math (threshold/step/floor, stacking with highways, flag on/off), and — the fun one — Dijkstra actually routing around a jammed edge in favor of an equal-length detour, then routing back once the flag is off.
- Reconciled with master's concurrent speed-toggle repositioning (moved to bottom-right, above the mode selector).

Verified via probe screenshots: `&jam=1` deterministically parks trucks on an edge to show the congestion glow, and the menu toggle renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS)_