### PR TITLE
v1.18.0: river ferries, a cheaper-but-slower alternative to bridges

### DIFF
--- a/supply-chain/CLAUDE.md
+++ b/supply-chain/CLAUDE.md
@@ -92,7 +92,9 @@ then (any headless Chromium works; on sandboxed Linux add `--no-sandbox`):
   screenshot of a known layout. `&jam=1` force-enables congestion and
   parks 4 trucks mid-span on the factory→HQ edge (bypassing real
   dispatch timing) so the red congestion glow can be screenshotted
-  deterministically.
+  deterministically. `&ferry=1` builds a ferry crossing from HQ to a
+  node mirrored across the river (guaranteed to cross it regardless of
+  map seed) for screenshotting the teal dashed line/shuttling boat.
 - **Mobile layout**: same screenshot with `--window-size=390,844`. Caveat
   found while building the research-tree overlay: this Chromium build
   enforces a **hard ~500px minimum layout viewport** in headless mode —

--- a/supply-chain/PLAN.md
+++ b/supply-chain/PLAN.md
@@ -35,6 +35,7 @@ pan/pinch camera).
 
 ## Shipped
 
+- v1.18.0: **river ferries**. Per item 9 below — details there.
 - v1.17.0: **road congestion**, feature-flagged. Per item 8 below —
   details there.
 - v1.15.0-v1.16.0 (parallel branches, master): top-left corner UI
@@ -205,9 +206,17 @@ actually shipped.)*
    flag** (`SC.state.congestionEnabled`) per the owner's request: on by
    default for Normal/Hard, off for Easy/Sandbox, toggle anytime from
    the ☰ menu regardless of difficulty.
-9. **River ferries** — a cheaper-but-slower alternative to bridges: build
-   a dock pair, ferry shuttles on a fixed cadence (reuses the old sim's
-   boat visual). Bridges = fast + expensive, ferries = cheap + queueing.
+9. ~~River ferries~~ — shipped v1.18.0, scoped down from the original
+   "dock pair + fixed-cadence shuttle" proposal to an edge-level
+   alternative chosen at build time (Shop panel toggle): a road across
+   the river builds as `edge.ferry` instead of a bridge — `FERRY_COST_MULT`
+   cheaper than `BRIDGE_MULT`, but `FERRY_SPEED_MULT` slower, can't be
+   paved into a highway. No new node kind or scheduling clock — the
+   "queueing" half of the ask is congestion (if enabled) applying to a
+   ferry edge same as any other, which reads as trucks queueing for the
+   boat without a separate queue simulation. A boat emoji shuttles back
+   and forth along the crossing for the promised visual, short of a full
+   dock/sprite treatment (that's Decision C's dedicated visual pass).
 10. **Contracts** — occasional long-running deals: "3× green every 60s for
     5 minutes at a locked-in rate". Creates steady demand you can build
     dedicated infrastructure for.

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -132,6 +132,17 @@ that ambient animation as its background — it now lives independently at
   *and* Dijkstra's routing weight — dispatch naturally prefers a
   quieter parallel road over a jammed one. The road glows warmer the
   busier it gets (`render.drawRoads`).
+- **Ferries**: a cheaper-but-slower alternative to a bridge, chosen at
+  *build* time via the Shop panel's "Ferry crossings" toggle — any road
+  drawn across the river while it's on builds `edge.ferry = true`
+  instead of a bridge, at `FERRY_COST_MULT` (cheaper than
+  `BRIDGE_MULT`) but `FERRY_SPEED_MULT` (slower than a normal road,
+  folded into `speedMult` the same way the highway boost is). A ferry
+  can't be paved into a highway (`upgradeQuote` rejects it — it's a
+  boat, not a road surface); congestion (if enabled) still applies on
+  top, so trucks queueing for the boat reuses the exact same mechanic
+  as a jammed road queue. Renders as a distinct teal dashed line with a
+  small ⛴ shuttling back and forth along the crossing.
 - **Per-yard truck prices**: the truck price ladder tracks trucks homed
   at the *active yard* (`SC.trucksAtYard`), so a new yard resets the
   ladder to base price — the ever-growing yard price is the balance
@@ -177,7 +188,7 @@ they signal the UI through the tiny `SC.on`/`SC.emit` pub/sub in state.js.
 | `js/save.js` | Autosave/restore to localStorage (serialize/restore round-trip) |
 | `js/rng.js` | Seeded PRNG (xmur3 hash + mulberry32 stream) used only by map.js's world gen, so `?seed=` reproduces a map |
 | `js/map.js` | World gen: river, node sites, starter cluster (seeded via `js/rng.js`, `generateWorld(seed)`); `unlockNext(filterFn)` for milestone (supplier/factory) and customer-DC (city) unlock tracks |
-| `js/roads.js` | Road build/demolish/quote, highway upgrades, congestion (`speedMult`/`congestionMult`), Dijkstra pathfinding weighted by travel time |
+| `js/roads.js` | Road build/demolish/quote (incl. ferry-vs-bridge), highway upgrades, congestion (`speedMult`/`congestionMult`), Dijkstra pathfinding weighted by travel time |
 | `js/factories.js` | Craft tasks (incl. intermediates), raw intake, production ticks, site purchase |
 | `js/economy.js` | Orders (spawn/plan/deliver/expire) with recursive multi-tier sourcing, money, interest + default countdown, upgrades, supplier stock regen/upgrades, promotions, customer-DC spawn timer |
 | `js/vehicles.js` | Trucks (each with a home yard), haul jobs, dispatcher (globally nearest idle truck per job, bundles same-route jobs up to capacity, sends idle trucks home), supplier-stock loading waits, reassignment, movement, `truckCountOnEdge` (feeds congestion) |

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Supply Chain Tycoon | Niklas Billgren</title>
-    <link rel="stylesheet" href="style.css?v=1.17.0">
+    <link rel="stylesheet" href="style.css?v=1.18.0">
 </head>
 <body>
     <canvas id="gameCanvas"></canvas>
@@ -60,6 +60,10 @@
             <button class="shop-btn build-btn" id="btn-yard">
                 <span class="sname">🅿️ Build truck yard</span>
                 <span class="price">$1,200</span>
+            </button>
+            <button class="shop-btn build-btn" id="btn-ferry-mode" title="When on, roads drawn across the river build a cheaper, slower ferry instead of a bridge">
+                <span class="sname">⛴️ Ferry crossings</span>
+                <span class="price">Off</span>
             </button>
             <button class="shop-btn" id="btn-truckSpeed">
                 <span class="sname">⚡ Truck speed <span class="lvl"></span></span>
@@ -147,7 +151,7 @@
                🧵 and electronics 💾) plus the same steel your cars use. Your
                trucks do the hauling — but only where roads exist.</p>
             <ul>
-                <li><b>Build roads:</b> tap a node, then tap another. Crossing the river costs bridge money.</li>
+                <li><b>Build roads:</b> tap a node, then tap another. Crossing the river costs bridge money — or flip the Shop panel's "Ferry crossings" toggle first for a cheaper, slower boat crossing instead.</li>
                 <li><b>Fill orders:</b> connect each ingredient's supplier to the factory, and the factory to the ordering HQ/DC. Dispatch is automatic.</li>
                 <li><b>Earn &amp; grow:</b> payouts fund more roads, trucks, factories and upgrades. New sites appear as you deliver.</li>
                 <li><b>Credit line:</b> you can spend into the red down to −$1,500, but debt bleeds interest every minute (rate set by difficulty — 15%/min on Normal). If interest drags you <i>below</i> the limit, a default countdown starts — recover in time or the bank forecloses and the run ends. Sandbox never forecloses.</li>
@@ -177,23 +181,23 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=1.17.0"></script>
-    <script src="js/state.js?v=1.17.0"></script>
-    <script src="js/save.js?v=1.17.0"></script>
-    <script src="js/sfx.js?v=1.17.0"></script>
-    <script src="js/rng.js?v=1.17.0"></script>
-    <script src="js/map.js?v=1.17.0"></script>
-    <script src="js/camera.js?v=1.17.0"></script>
-    <script src="js/roads.js?v=1.17.0"></script>
-    <script src="js/factories.js?v=1.17.0"></script>
-    <script src="js/economy.js?v=1.17.0"></script>
-    <script src="js/vehicles.js?v=1.17.0"></script>
-    <script src="js/inspect.js?v=1.17.0"></script>
-    <script src="js/research.js?v=1.17.0"></script>
-    <script src="js/placement.js?v=1.17.0"></script>
-    <script src="js/render.js?v=1.17.0"></script>
-    <script src="js/input.js?v=1.17.0"></script>
-    <script src="js/ui.js?v=1.17.0"></script>
-    <script src="js/main.js?v=1.17.0"></script>
+    <script src="js/config.js?v=1.18.0"></script>
+    <script src="js/state.js?v=1.18.0"></script>
+    <script src="js/save.js?v=1.18.0"></script>
+    <script src="js/sfx.js?v=1.18.0"></script>
+    <script src="js/rng.js?v=1.18.0"></script>
+    <script src="js/map.js?v=1.18.0"></script>
+    <script src="js/camera.js?v=1.18.0"></script>
+    <script src="js/roads.js?v=1.18.0"></script>
+    <script src="js/factories.js?v=1.18.0"></script>
+    <script src="js/economy.js?v=1.18.0"></script>
+    <script src="js/vehicles.js?v=1.18.0"></script>
+    <script src="js/inspect.js?v=1.18.0"></script>
+    <script src="js/research.js?v=1.18.0"></script>
+    <script src="js/placement.js?v=1.18.0"></script>
+    <script src="js/render.js?v=1.18.0"></script>
+    <script src="js/input.js?v=1.18.0"></script>
+    <script src="js/ui.js?v=1.18.0"></script>
+    <script src="js/main.js?v=1.18.0"></script>
 </body>
 </html>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -1,7 +1,7 @@
 // Supply Chain Tycoon — constants, materials, recipes, prices
 window.SC = window.SC || {};
 
-SC.VERSION = '1.17.0';
+SC.VERSION = '1.18.0';
 
 SC.CONFIG = {
     WORLD_W: 2200,
@@ -33,6 +33,16 @@ SC.CONFIG = {
     ROAD_COST_PER_UNIT: 0.6,
     BRIDGE_MULT: 3,            // river crossings cost extra
     ROAD_REFUND: 0.5,          // fraction returned when demolishing
+
+    // Ferries: a cheaper-but-slower alternative to a bridge, chosen at
+    // build time (toggle in the Shop panel) for any road crossing the
+    // river. Half the speed of a normal road, but a much smaller premium
+    // than BRIDGE_MULT's 3x. Congestion (if enabled) still applies on
+    // top — trucks queueing for the boat is the same mechanic as trucks
+    // queueing on a jammed road, just re-used. Can't be paved into a
+    // highway (see roads.upgradeQuote).
+    FERRY_COST_MULT: 1.4,
+    FERRY_SPEED_MULT: 0.5,
 
     // Truck price ladders PER YARD: the nth truck stationed at a given
     // yard costs base * growth^n, so building a new yard "resets" the

--- a/supply-chain/js/input.js
+++ b/supply-chain/js/input.js
@@ -130,7 +130,7 @@ SC.input = (function() {
         if (node) {
             pendingDemolish = null;
             if (st.selectedNode && st.selectedNode !== node) {
-                const res = SC.roads.build(st.selectedNode, node);
+                const res = SC.roads.build(st.selectedNode, node, { ferry: st.buildFerry });
                 if (res.ok) {
                     SC.sfx.play('build');
                     st.selectedNode = node; // chain roads mini-metro style

--- a/supply-chain/js/main.js
+++ b/supply-chain/js/main.js
@@ -157,6 +157,16 @@ SC.runProbe = function(seconds) {
             if (n.kind === 'supplier') n.stock = Math.min(n.stock, 1);
         }
     }
+    // Build a ferry crossing from HQ to a node mirrored across the river
+    // (guaranteed to cross it, regardless of map seed/orientation), so
+    // the teal dashed line + shuttling boat can be screenshotted.
+    if (p.has('ferry')) {
+        SC.state.money = Math.max(SC.state.money, 50000);
+        const hq = SC.state.nodes.find(n => n.isHQ);
+        const rv = SC.map.riverAt(hq.y);
+        const other = SC.map.makeNode('yard', rv.x + (rv.x - hq.x), hq.y, { active: true });
+        SC.roads.build(hq, other, { ferry: true });
+    }
     // Force-jam the factory->HQ edge with several trucks parked mid-span,
     // so the congestion glow overlay can be screenshotted without waiting
     // on real dispatch timing (&jam=1; also flips congestion on regardless

--- a/supply-chain/js/render.js
+++ b/supply-chain/js/render.js
@@ -105,10 +105,12 @@ SC.render = (function() {
                 ctx.strokeStyle = 'rgba(226, 232, 240, 0.65)';
                 ctx.lineWidth = 6;
             } else {
-                ctx.strokeStyle = e.bridge ? 'rgba(125, 170, 210, 0.55)' : 'rgba(148, 163, 184, 0.45)';
+                ctx.strokeStyle = e.ferry ? 'rgba(45, 212, 191, 0.6)'
+                                : e.bridge ? 'rgba(125, 170, 210, 0.55)'
+                                : 'rgba(148, 163, 184, 0.45)';
                 ctx.lineWidth = 4;
             }
-            ctx.setLineDash(e.bridge ? [14, 8] : []);
+            ctx.setLineDash(e.ferry ? [4, 10] : e.bridge ? [14, 8] : []);
             ctx.stroke();
             ctx.setLineDash([]);
             if (e.level > 0 && e !== pending && e !== pendingUp) {
@@ -120,6 +122,14 @@ SC.render = (function() {
                 ctx.setLineDash([10, 10]);
                 ctx.stroke();
                 ctx.setLineDash([]);
+            }
+            // Ferry: a little boat shuttles back and forth along the
+            // crossing — the "cheap but slow, queues to board" flavor.
+            if (e.ferry && e !== pending && e !== pendingUp) {
+                const t = (Math.sin(seaTime * 0.6) + 1) / 2;
+                const bx = e.a.x + (e.b.x - e.a.x) * t;
+                const by = e.a.y + (e.b.y - e.a.y) * t;
+                emoji('⛴', bx, by, 18);
             }
             // Congestion: an overloaded edge glows warmer, hottest at the
             // busiest roads — the visual cue for "build a parallel route".
@@ -147,10 +157,13 @@ SC.render = (function() {
             if (n.active && n !== sel && Math.hypot(n.x - hover.x, n.y - hover.y) < 40) target = n;
         }
         const end = target ? { x: target.x, y: target.y } : hover;
-        const q = target ? SC.roads.quote(sel, target) : (() => {
+        const ferryOpt = { ferry: SC.state.buildFerry };
+        const q = target ? SC.roads.quote(sel, target, ferryOpt) : (() => {
             const len = Math.hypot(sel.x - end.x, sel.y - end.y);
             const bridge = SC.map.segmentCrossesRiver(sel.x, sel.y, end.x, end.y);
-            return { len, bridge, cost: Math.round(len * SC.CONFIG.ROAD_COST_PER_UNIT * (bridge ? SC.CONFIG.BRIDGE_MULT : 1)) };
+            const ferry = SC.state.buildFerry && bridge;
+            const mult = ferry ? SC.CONFIG.FERRY_COST_MULT : (bridge ? SC.CONFIG.BRIDGE_MULT : 1);
+            return { len, bridge, ferry, cost: Math.round(len * SC.CONFIG.ROAD_COST_PER_UNIT * mult) };
         })();
         if (!q) return;
 
@@ -165,7 +178,8 @@ SC.render = (function() {
         ctx.setLineDash([]);
 
         const mx = (sel.x + end.x) / 2, my = (sel.y + end.y) / 2;
-        label(`$${q.cost}${q.bridge ? ' (bridge)' : ''}`, mx, my - 14,
+        const crossingLabel = q.ferry ? ' (ferry)' : q.bridge ? ' (bridge)' : '';
+        label(`$${q.cost}${crossingLabel}`, mx, my - 14,
               affordable ? '#34d399' : '#f87171');
     }
 

--- a/supply-chain/js/roads.js
+++ b/supply-chain/js/roads.js
@@ -8,24 +8,28 @@ SC.roads = (function() {
             (e.a === a && e.b === b) || (e.a === b && e.b === a)) || null;
     }
 
-    // Quote for a prospective road; null when not buildable.
-    function quote(a, b) {
+    // Quote for a prospective road; null when not buildable. `opts.ferry`
+    // requests a ferry instead of a bridge for a river crossing — cheaper
+    // than BRIDGE_MULT, at the cost of FERRY_SPEED_MULT (see speedMult).
+    // Meaningless (and ignored) for a segment that doesn't cross the river.
+    function quote(a, b, opts) {
         if (!a || !b || a === b) return null;
         if (!a.active || !b.active) return null;
         if (findEdge(a, b)) return null;
         const len = Math.hypot(a.x - b.x, a.y - b.y);
         const bridge = SC.map.segmentCrossesRiver(a.x, a.y, b.x, b.y);
-        const cost = Math.round(len * SC.CONFIG.ROAD_COST_PER_UNIT *
-            (bridge ? SC.CONFIG.BRIDGE_MULT : 1));
-        return { len, bridge, cost };
+        const ferry = !!(opts && opts.ferry) && bridge;
+        const mult = ferry ? SC.CONFIG.FERRY_COST_MULT : (bridge ? SC.CONFIG.BRIDGE_MULT : 1);
+        const cost = Math.round(len * SC.CONFIG.ROAD_COST_PER_UNIT * mult);
+        return { len, bridge, ferry, cost };
     }
 
-    function build(a, b) {
-        const q = quote(a, b);
+    function build(a, b, opts) {
+        const q = quote(a, b, opts);
         if (!q) return { ok: false, reason: 'invalid' };
         if (!SC.canAfford(q.cost)) return { ok: false, reason: 'money', cost: q.cost };
         SC.state.money -= q.cost;
-        const edge = { a, b, len: q.len, bridge: q.bridge, cost: q.cost, level: 0 };
+        const edge = { a, b, len: q.len, bridge: q.bridge, ferry: q.ferry, cost: q.cost, level: 0 };
         SC.state.edges.push(edge);
         a.edges.push(b);
         b.edges.push(a);
@@ -69,16 +73,21 @@ SC.roads = (function() {
     }
 
     // Highways (edge.level 1, unlocked by 'pavedRoads' research) move
-    // trucks HIGHWAY_SPEED_MULT× faster on that edge; congestion (when
-    // enabled) then slows an overloaded edge back down on top of that.
+    // trucks HIGHWAY_SPEED_MULT× faster on that edge; a ferry crossing
+    // moves them FERRY_SPEED_MULT slower instead (mutually exclusive —
+    // see upgradeQuote). Congestion (when enabled) then applies on top
+    // of whichever base multiplier applies.
     function speedMult(edge) {
         if (!edge) return 1;
-        return (edge.level ? SC.CONFIG.HIGHWAY_SPEED_MULT : 1) * congestionMult(edge);
+        const base = edge.level ? SC.CONFIG.HIGHWAY_SPEED_MULT : (edge.ferry ? SC.CONFIG.FERRY_SPEED_MULT : 1);
+        return base * congestionMult(edge);
     }
 
     // Quote for upgrading a road to a highway; null when not possible.
+    // A ferry crossing can't be paved into a highway — it's a boat, not
+    // a road surface.
     function upgradeQuote(edge) {
-        if (!edge || edge.level > 0) return null;
+        if (!edge || edge.level > 0 || edge.ferry) return null;
         if (!SC.research.isDone('pavedRoads')) return null;
         const cost = Math.round(edge.len * SC.CONFIG.ROAD_UPGRADE_PER_UNIT *
             (edge.bridge ? SC.CONFIG.BRIDGE_MULT : 1));

--- a/supply-chain/js/save.js
+++ b/supply-chain/js/save.js
@@ -62,7 +62,9 @@ SC.save = (function() {
                 level: n.level || 0, stock: n.stock,
                 inv: inv.get(n.id) || {}
             })),
-            edges: st.edges.map(e => ({ a: e.a.id, b: e.b.id, cost: e.cost, level: e.level || 0 })),
+            edges: st.edges.map(e => ({
+                a: e.a.id, b: e.b.id, cost: e.cost, level: e.level || 0, ferry: !!e.ferry
+            })),
             trucks: st.trucks.map(t => ({
                 nodeId: (t.node || st.nodes[0]).id,
                 homeYardId: (t.homeYard || t.node || st.nodes[0]).id
@@ -117,7 +119,7 @@ SC.save = (function() {
             if (!a || !b) continue;
             const len = Math.hypot(a.x - b.x, a.y - b.y);
             const bridge = SC.map.segmentCrossesRiver(a.x, a.y, b.x, b.y);
-            st.edges.push({ a, b, len, bridge, cost: ed.cost, level: ed.level || 0 });
+            st.edges.push({ a, b, len, bridge, cost: ed.cost, level: ed.level || 0, ferry: !!ed.ferry });
             a.edges.push(b);
             b.edges.push(a);
         }

--- a/supply-chain/js/state.js
+++ b/supply-chain/js/state.js
@@ -50,6 +50,7 @@ SC.newState = function(difficulty) {
         highlight: null,    // { paths, color, city, until } — order route overlay
         mode: 'build',      // 'build' (default, tap-to-build) | 'upgrade' | 'inspect'
         placeMode: null,    // { kind: 'supplier'|'factory'|'yard', good } — manual placement (input.js)
+        buildFerry: false,  // Build-mode toggle: river crossings build as a ferry, not a bridge
         gameStarted: false
     };
     return SC.state;

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -58,7 +58,16 @@ SC.ui = (function() {
         updateResearchShortcut();
         updateResearchTree();
         updatePromo();
+        updateFerryMode();
         updateBuild();
+    }
+
+    // ── Ferry-crossing toggle: Build mode's river crossings build a
+    // cheaper, slower ferry instead of a bridge while this is on ──
+    function updateFerryMode() {
+        const btn = $('btn-ferry-mode');
+        btn.classList.toggle('active', SC.state.buildFerry);
+        btn.querySelector('.price').textContent = SC.state.buildFerry ? 'On' : 'Off';
     }
 
     // ── Promotions (Marketing Blitz): repeatable paid demand burst ──
@@ -511,6 +520,14 @@ SC.ui = (function() {
                 SC.emit('toast', { text: `Tap the map to place a truck yard — ${fmt(SC.yardPrice())}`, kind: 'info' });
             }
             SC.sfx.play('click');
+            updateShop();
+        });
+        $('btn-ferry-mode').addEventListener('click', () => {
+            SC.state.buildFerry = !SC.state.buildFerry;
+            SC.sfx.play('click');
+            toast(SC.state.buildFerry
+                ? 'Ferry crossings on — river roads will build cheaper and slower'
+                : 'Ferry crossings off — river roads build as bridges again', 'info');
             updateShop();
         });
         for (const key of Object.keys(SC.CONFIG.UPGRADES)) {

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -15,20 +15,20 @@
     <div id="results"></div>
 
     <!-- Pure logic only: no render/input/ui/main, no canvas needed -->
-    <script src="js/config.js?v=1.17.0"></script>
-    <script src="js/state.js?v=1.17.0"></script>
-    <script src="js/save.js?v=1.17.0"></script>
-    <script src="js/sfx.js?v=1.17.0"></script>
-    <script src="js/rng.js?v=1.17.0"></script>
-    <script src="js/map.js?v=1.17.0"></script>
-    <script src="js/camera.js?v=1.17.0"></script>
-    <script src="js/roads.js?v=1.17.0"></script>
-    <script src="js/factories.js?v=1.17.0"></script>
-    <script src="js/economy.js?v=1.17.0"></script>
-    <script src="js/vehicles.js?v=1.17.0"></script>
-    <script src="js/inspect.js?v=1.17.0"></script>
-    <script src="js/research.js?v=1.17.0"></script>
-    <script src="js/placement.js?v=1.17.0"></script>
+    <script src="js/config.js?v=1.18.0"></script>
+    <script src="js/state.js?v=1.18.0"></script>
+    <script src="js/save.js?v=1.18.0"></script>
+    <script src="js/sfx.js?v=1.18.0"></script>
+    <script src="js/rng.js?v=1.18.0"></script>
+    <script src="js/map.js?v=1.18.0"></script>
+    <script src="js/camera.js?v=1.18.0"></script>
+    <script src="js/roads.js?v=1.18.0"></script>
+    <script src="js/factories.js?v=1.18.0"></script>
+    <script src="js/economy.js?v=1.18.0"></script>
+    <script src="js/vehicles.js?v=1.18.0"></script>
+    <script src="js/inspect.js?v=1.18.0"></script>
+    <script src="js/research.js?v=1.18.0"></script>
+    <script src="js/placement.js?v=1.18.0"></script>
 
     <script>
     let passed = 0, failed = 0;
@@ -1421,6 +1421,90 @@
         SC.save.restore(SC.save.serialize());
         assert('an explicitly enabled congestion flag survives a round-trip',
             SC.state.congestionEnabled === true);
+    })();
+
+    // ── Ferries: cheaper than a bridge, only meaningful on a river crossing ──
+    (function() {
+        const { S1, F } = fixture(); // S1->F does not cross the river
+        SC.state.money = 100000;
+
+        const qDry = SC.roads.quote(S1, F, { ferry: true });
+        assert('ferry option is a no-op on a crossing that is not a bridge',
+            qDry.ferry === false && qDry.cost === Math.round(qDry.len * SC.CONFIG.ROAD_COST_PER_UNIT));
+
+        // Cross-river pair, same shape as the existing bridge-multiplier test
+        const A = SC.map.makeNode('city', 900, 500, { active: true });
+        const B = SC.map.makeNode('city', 1300, 500, { active: true });
+        const qBridge = SC.roads.quote(A, B);
+        const qFerry = SC.roads.quote(A, B, { ferry: true });
+        assert('a river crossing defaults to a bridge without the ferry option',
+            qBridge.bridge && !qBridge.ferry &&
+            qBridge.cost === Math.round(qBridge.len * SC.CONFIG.ROAD_COST_PER_UNIT * SC.CONFIG.BRIDGE_MULT));
+        assert('the ferry option marks the same crossing as a (cheaper) ferry',
+            qFerry.bridge && qFerry.ferry &&
+            qFerry.cost === Math.round(qFerry.len * SC.CONFIG.ROAD_COST_PER_UNIT * SC.CONFIG.FERRY_COST_MULT));
+        assert('a ferry crossing costs less than the equivalent bridge', qFerry.cost < qBridge.cost);
+
+        const res = SC.roads.build(A, B, { ferry: true });
+        assert('building with the ferry option marks the edge as a ferry',
+            res.ok && res.edge.ferry === true && res.edge.bridge === true);
+    })();
+
+    // ── Ferries: slower than a normal road, can't be paved, stacks with congestion ──
+    (function() {
+        const { S1 } = fixture();
+        SC.state.money = 100000;
+        const A = SC.map.makeNode('city', 900, 500, { active: true });
+        const B = SC.map.makeNode('city', 1300, 500, { active: true });
+        const edge = SC.roads.build(A, B, { ferry: true }).edge;
+
+        assert('a ferry crossing moves trucks slower than a normal road',
+            SC.roads.speedMult(edge) === SC.CONFIG.FERRY_SPEED_MULT);
+        assert('a ferry cannot be paved into a highway', (function() {
+            SC.state.research.completed.pavedRoads = true;
+            return SC.roads.upgradeQuote(edge) === null && !SC.roads.upgrade(edge).ok;
+        })());
+        assert('a ferry stays a ferry (upgrade attempt does not flip the flag)',
+            edge.ferry === true && edge.level === 0);
+
+        // Congestion (queueing for the boat) stacks multiplicatively on top
+        SC.state.congestionEnabled = true;
+        for (let i = 0; i < SC.CONFIG.CONGESTION_THRESHOLD + 2; i++) {
+            const t = SC.vehicles.addTruck(A);
+            t.path = [A, B]; t.pathIdx = 0;
+        }
+        const expected = SC.CONFIG.FERRY_SPEED_MULT * (1 - SC.CONFIG.CONGESTION_STEP * 2);
+        assert('congestion queueing stacks with the ferry base slowdown',
+            approx(SC.roads.speedMult(edge), expected, 0.001));
+    })();
+
+    // ── Ferries: Dijkstra treats them as slower, but usable when needed ──
+    (function() {
+        SC.newState('sandbox'); // congestion off by default, keeps this test simple
+        SC.map._resetSeq();
+        SC.state.river = { spine: [{ x: 1100, y: 0 }, { x: 1100, y: SC.CONFIG.WORLD_H }], halfWidths: [40, 40] };
+        const A = SC.map.makeNode('city', 900, 500, { active: true, isHQ: true });
+        const B = SC.map.makeNode('city', 1300, 500, { active: true });
+        SC.state.money = 100000;
+        const ferryEdge = SC.roads.build(A, B, { ferry: true }).edge;
+        assert('with only a ferry available, pathfinding still finds it',
+            SC.roads.findPath(A, B) && SC.roads.findPath(A, B).path.length === 2);
+        assert('a ferry crossing is weighted slower than its raw distance',
+            approx(SC.roads.pathDist(A, B), ferryEdge.len / SC.CONFIG.FERRY_SPEED_MULT, 0.01));
+    })();
+
+    // ── Save round-trip: ferry flag persists (bridge/len are recomputed) ──
+    (function() {
+        const { S1 } = fixture();
+        SC.state.money = 100000;
+        const A = SC.map.makeNode('city', 900, 500, { active: true });
+        const B = SC.map.makeNode('city', 1300, 500, { active: true });
+        SC.roads.build(A, B, { ferry: true });
+
+        SC.save.restore(SC.save.serialize());
+        const restored = SC.state.edges.find(e =>
+            (e.a.x === 900 && e.b.x === 1300) || (e.a.x === 1300 && e.b.x === 900));
+        assert('ferry flag survives a save round-trip', restored && restored.ferry === true);
     })();
 
     document.getElementById('summary').textContent = `${passed} passed / ${failed} failed`;


### PR DESCRIPTION
Follows congestion (PR #78) with the second half of the ask — river ferries:

- **Shop panel "Ferry crossings" toggle**: while on, any road drawn across the river builds `edge.ferry` instead of a bridge — `FERRY_COST_MULT` (cheaper than `BRIDGE_MULT`) but `FERRY_SPEED_MULT` (slower than a normal road), folded into `speedMult` the same way the highway boost already is.
- A ferry can't be paved into a highway (`upgradeQuote` rejects it — it's a boat, not a road surface). Congestion, if enabled, still applies on top — trucks queueing for the boat reuses the exact same mechanic as a jammed road, no separate queue simulation needed.
- Renders as a distinct teal dashed line with a small ⛴ shuttling back and forth along the crossing.
- 12 new test assertions (321 total, all passing): ferry-only-applies-to-a-river-crossing, cost comparison vs bridge, speed slowdown, can't-be-paved, congestion stacking, Dijkstra still routing across a ferry-only crossing, and a save round-trip.

Scoped down from the original PLAN.md proposal (dock pair + fixed-cadence shuttle) to an edge-level build-time choice — no new node kind or scheduling clock, while still landing "cheap but slow, with queueing" per the ask (documented in PLAN.md with the reasoning).

Verified via a probe screenshot (`&ferry=1` builds a guaranteed river crossing regardless of map seed) — caught and fixed a real bug along the way: the boat emoji initially rendered invisible because it used a plain `sans-serif` font instead of the project's emoji font fallback chain, now fixed by reusing the existing `emoji()` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS)_