### PR TITLE
Supply Chain Tycoon: contracts (v1.19.0)

### DIFF
--- a/supply-chain/CLAUDE.md
+++ b/supply-chain/CLAUDE.md
@@ -49,7 +49,7 @@ then (any headless Chromium works; on sandboxed Linux add `--no-sandbox`):
 - **Logic tests**: `<chromium> --headless=new --disable-gpu
   --virtual-time-budget=15000 --dump-dom
   http://localhost:8199/supply-chain/tests.html`, grep for `id="summary"`
-  — must say "N passed / **0 failed**" (110 tests at last count; N grows,
+  — must say "N passed / **0 failed**" (343 tests at last count; N grows,
   0 failed is the bar).
 - **Visual/gameplay smoke**: `index.html?probe=40` auto-builds the starter
   roads, spawns an order, and fast-forwards 40 simulated seconds
@@ -95,6 +95,10 @@ then (any headless Chromium works; on sandboxed Linux add `--no-sandbox`):
   deterministically. `&ferry=1` builds a ferry crossing from HQ to a
   node mirrored across the river (guaranteed to cross it regardless of
   map seed) for screenshotting the teal dashed line/shuttling boat.
+  `&contract=1` force-rolls a contract offer (skips the random
+  `CONTRACT_INTERVAL` wait) for screenshotting the Accept/Decline card;
+  `&contract=accept` also auto-accepts it into a real (gold-outlined,
+  📜) order in the Orders panel.
 - **Mobile layout**: same screenshot with `--window-size=390,844`. Caveat
   found while building the research-tree overlay: this Chromium build
   enforces a **hard ~500px minimum layout viewport** in headless mode —

--- a/supply-chain/PLAN.md
+++ b/supply-chain/PLAN.md
@@ -35,6 +35,7 @@ pan/pinch camera).
 
 ## Shipped
 
+- v1.19.0: **contracts**. Per item 10 below — details there.
 - v1.18.0: **river ferries**. Per item 9 below — details there.
 - v1.17.0: **road congestion**, feature-flagged. Per item 8 below —
   details there.
@@ -217,9 +218,19 @@ actually shipped.)*
    boat without a separate queue simulation. A boat emoji shuttles back
    and forth along the crossing for the promised visual, short of a full
    dock/sprite treatment (that's Decision C's dedicated visual pass).
-10. **Contracts** — occasional long-running deals: "3× green every 60s for
-    5 minutes at a locked-in rate". Creates steady demand you can build
-    dedicated infrastructure for.
+10. ~~Contracts~~ — shipped v1.19.0, scoped to reuse the existing order
+    machinery instead of a parallel demand system: `rollContractOffer`
+    proposes a bulk deal (bigger `qty`, `CONTRACT_RATE_BONUS` premium
+    per-unit rate) on its own clock; the player Accepts or Declines a
+    non-blocking card within `CONTRACT_OFFER_EXPIRE`. Accepting
+    (`acceptContract`) turns the offer into a regular order flagged
+    `contract: true`, planned/delivered/paid through the normal pipeline.
+    The owner's requested twist — "penalty if you miss it" — lives in
+    `expireOrder`: a missed contract charges `CONTRACT_PENALTY_MULT ×
+    missingUnits × perUnitRate` on top of the miss, scaled so a
+    near-complete contract stings less than an untouched one; a normal
+    order still misses for free. One contract (offer or active) at a
+    time.
 10b. ~~Promotions research~~ — shipped v1.13.0 as Marketing Blitz: a
     one-shot tech unlocking a *repeatable paid Shop action* (global
     demand burst), which settled the repeatable-research question

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -143,6 +143,17 @@ that ambient animation as its background — it now lives independently at
   top, so trucks queueing for the boat reuses the exact same mechanic
   as a jammed road queue. Renders as a distinct teal dashed line with a
   small ⛴ shuttling back and forth along the crossing.
+- **Contracts**: `rollContractOffer` occasionally proposes a bulk order
+  at a locked-in `CONTRACT_RATE_BONUS` premium rate. A non-blocking card
+  lets you Accept or Decline within `CONTRACT_OFFER_EXPIRE` before it's
+  withdrawn (one offer/active contract at a time). Accepting
+  (`acceptContract`) is implemented as a regular order flagged
+  `contract: true` — reuses the same planning/delivery/expiry pipeline
+  as any other order, styled with a gold outline and 📜 in the Orders
+  panel. Unlike a normal missed order (just a tally, no cost), missing
+  an accepted contract's deadline (`expireOrder`) charges a penalty
+  proportional to however many units are still undelivered
+  (`CONTRACT_PENALTY_MULT × missingUnits × perUnitRate`).
 - **Per-yard truck prices**: the truck price ladder tracks trucks homed
   at the *active yard* (`SC.trucksAtYard`), so a new yard resets the
   ladder to base price — the ever-growing yard price is the balance
@@ -190,7 +201,7 @@ they signal the UI through the tiny `SC.on`/`SC.emit` pub/sub in state.js.
 | `js/map.js` | World gen: river, node sites, starter cluster (seeded via `js/rng.js`, `generateWorld(seed)`); `unlockNext(filterFn)` for milestone (supplier/factory) and customer-DC (city) unlock tracks |
 | `js/roads.js` | Road build/demolish/quote (incl. ferry-vs-bridge), highway upgrades, congestion (`speedMult`/`congestionMult`), Dijkstra pathfinding weighted by travel time |
 | `js/factories.js` | Craft tasks (incl. intermediates), raw intake, production ticks, site purchase |
-| `js/economy.js` | Orders (spawn/plan/deliver/expire) with recursive multi-tier sourcing, money, interest + default countdown, upgrades, supplier stock regen/upgrades, promotions, customer-DC spawn timer |
+| `js/economy.js` | Orders (spawn/plan/deliver/expire) with recursive multi-tier sourcing, money, interest + default countdown, upgrades, supplier stock regen/upgrades, promotions, customer-DC spawn timer, contract offers (roll/accept/decline) and miss penalties |
 | `js/vehicles.js` | Trucks (each with a home yard), haul jobs, dispatcher (globally nearest idle truck per job, bundles same-route jobs up to capacity, sends idle trucks home), supplier-stock loading waits, reassignment, movement, `truckCountOnEdge` (feeds congestion) |
 | `js/inspect.js` | Inspect-mode data: node → its connections/routes, for the hover/hold tooltip and highlight |
 | `js/research.js` | Tech tree engine: one active project, cost/time, generic effect accessors (`bonusSum`, `customerSpawnMult`, `upgradeMaxBonus`) |

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Supply Chain Tycoon | Niklas Billgren</title>
-    <link rel="stylesheet" href="style.css?v=1.18.0">
+    <link rel="stylesheet" href="style.css?v=1.19.0">
 </head>
 <body>
     <canvas id="gameCanvas"></canvas>
@@ -30,6 +30,18 @@
     </div>
 
     <div id="inspect-tooltip"></div>
+
+    <div id="contract-offer" class="hidden">
+        <div class="contract-card">
+            <div class="contract-header">📜 Contract Offer</div>
+            <div id="contract-terms"></div>
+            <div class="contract-timer-bar"><div id="contract-timer"></div></div>
+            <div class="contract-actions">
+                <button class="menu-btn primary" id="contract-accept">✔ Accept</button>
+                <button class="menu-btn" id="contract-decline">✕ Decline</button>
+            </div>
+        </div>
+    </div>
 
     <div id="orders-panel" class="panel">
         <div class="panel-header" id="orders-header">
@@ -161,6 +173,7 @@
                 <li><b>Highways:</b> after the Asphalt Paving research, use Upgrade mode on a road to pave it — trucks drive 60% faster there.</li>
                 <li><b>Congestion:</b> on by default (Normal/Hard difficulty), a busy road glows warmer and slows down past a few trucks — build parallel routes instead of one mega-highway. Toggle it anytime from the ☰ menu.</li>
                 <li><b>Fast-forward:</b> the 1×/2×/4× toggle under the HUD speeds up the whole sim — orders, crafting, trucks, interest, everything.</li>
+                <li><b>Contracts:</b> occasionally a bulk-order card offers a locked-in premium rate — Accept or Decline before the timer runs out. An accepted contract is a big order with its own deadline; miss it and you pay a penalty on top of the failure, not just a missed order.</li>
                 <li><b>Move around:</b> drag to pan, scroll or pinch to zoom. Tap a road twice to demolish it.</li>
                 <li><b>Inspect mode (🔍, bottom right):</b> hover (or tap on mobile) a node to see its connections — a factory's needed ingredients, a supplier's factories, or a city's open orders — with the relevant roads lit up. Tap again to dismiss.</li>
             </ul>
@@ -181,23 +194,23 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=1.18.0"></script>
-    <script src="js/state.js?v=1.18.0"></script>
-    <script src="js/save.js?v=1.18.0"></script>
-    <script src="js/sfx.js?v=1.18.0"></script>
-    <script src="js/rng.js?v=1.18.0"></script>
-    <script src="js/map.js?v=1.18.0"></script>
-    <script src="js/camera.js?v=1.18.0"></script>
-    <script src="js/roads.js?v=1.18.0"></script>
-    <script src="js/factories.js?v=1.18.0"></script>
-    <script src="js/economy.js?v=1.18.0"></script>
-    <script src="js/vehicles.js?v=1.18.0"></script>
-    <script src="js/inspect.js?v=1.18.0"></script>
-    <script src="js/research.js?v=1.18.0"></script>
-    <script src="js/placement.js?v=1.18.0"></script>
-    <script src="js/render.js?v=1.18.0"></script>
-    <script src="js/input.js?v=1.18.0"></script>
-    <script src="js/ui.js?v=1.18.0"></script>
-    <script src="js/main.js?v=1.18.0"></script>
+    <script src="js/config.js?v=1.19.0"></script>
+    <script src="js/state.js?v=1.19.0"></script>
+    <script src="js/save.js?v=1.19.0"></script>
+    <script src="js/sfx.js?v=1.19.0"></script>
+    <script src="js/rng.js?v=1.19.0"></script>
+    <script src="js/map.js?v=1.19.0"></script>
+    <script src="js/camera.js?v=1.19.0"></script>
+    <script src="js/roads.js?v=1.19.0"></script>
+    <script src="js/factories.js?v=1.19.0"></script>
+    <script src="js/economy.js?v=1.19.0"></script>
+    <script src="js/vehicles.js?v=1.19.0"></script>
+    <script src="js/inspect.js?v=1.19.0"></script>
+    <script src="js/research.js?v=1.19.0"></script>
+    <script src="js/placement.js?v=1.19.0"></script>
+    <script src="js/render.js?v=1.19.0"></script>
+    <script src="js/input.js?v=1.19.0"></script>
+    <script src="js/ui.js?v=1.19.0"></script>
+    <script src="js/main.js?v=1.19.0"></script>
 </body>
 </html>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -1,7 +1,7 @@
 // Supply Chain Tycoon — constants, materials, recipes, prices
 window.SC = window.SC || {};
 
-SC.VERSION = '1.18.0';
+SC.VERSION = '1.19.0';
 
 SC.CONFIG = {
     WORLD_W: 2200,
@@ -103,6 +103,21 @@ SC.CONFIG = {
     ORDER_DEPTH_SLACK: 0.5,    // extra deadline fraction per chain tier past 1
     ORDER_DEPTH_VALUE: 0.25,   // extra payout fraction per chain tier past 1
     SALVAGE_PAY: 15,           // cargo delivered after its order expired
+
+    // Contracts: occasional bulk-order offers at a locked-in premium
+    // rate. A card lets you Accept or Decline within CONTRACT_OFFER_EXPIRE
+    // before it's withdrawn; accepting turns it into a regular (large)
+    // order with a longer deadline. Unlike a normal missed order (just a
+    // tally, no cost), failing to deliver the full quantity in time
+    // charges a penalty on top — proportional to however many units are
+    // still missing, so a near-complete contract stings less than an
+    // untouched one. Only one contract (offer or active) at a time.
+    CONTRACT_INTERVAL: [150, 240],  // seconds between offer attempts
+    CONTRACT_OFFER_EXPIRE: 25,      // seconds to accept before withdrawn
+    CONTRACT_QTY: [4, 7],
+    CONTRACT_DURATION: [150, 220],  // seconds to fulfil once accepted
+    CONTRACT_RATE_BONUS: 1.35,      // locked-in premium over the normal per-unit value
+    CONTRACT_PENALTY_MULT: 0.6,     // × missing units' value, charged on failure
 
     // A new locked supplier/factory site activates every N deliveries.
     // New customer DCs (cities) are separate: they unlock on their own

--- a/supply-chain/js/economy.js
+++ b/supply-chain/js/economy.js
@@ -170,7 +170,16 @@ SC.economy = (function() {
         SC.state.missed++;
         SC.factories.cancelTasksForOrder(order);
         SC.vehicles.cancelJobsForOrder(order);
-        SC.emit('orderExpired', order);
+        if (order.contract) {
+            // Penalty scales with however many units are still missing, so
+            // a near-complete contract stings less than an untouched one.
+            const missingUnits = order.qty - order.deliveredUnits;
+            const penalty = Math.round(missingUnits * (order.payout / order.qty) * C().CONTRACT_PENALTY_MULT);
+            SC.state.money -= penalty;
+            SC.emit('contractFailed', { order, penalty });
+        } else {
+            SC.emit('orderExpired', order);
+        }
     }
 
     // Roads/factories changed: retry orders that had no route
@@ -204,6 +213,65 @@ SC.economy = (function() {
         SC.state.money -= C().PROMO_COST;
         SC.state.promoUntil = SC.state.time + C().PROMO_DURATION;
         SC.emit('promoStarted', { until: SC.state.promoUntil });
+        return { ok: true };
+    }
+
+    // ── Contracts: occasional bulk-order offers at a locked-in premium
+    // rate. rollContractOffer proposes one; the player Accepts (turns it
+    // into a real order via acceptContract) or Declines/lets it expire
+    // (declineContract) within CONTRACT_OFFER_EXPIRE. ──
+    function rollContractOffer() {
+        // Only one contract (offer or active) at a time.
+        if (SC.state.contractOffer || SC.state.orders.some(o => o.contract)) return null;
+        const cities = activeCities();
+        const products = craftableProducts();
+        if (!cities.length || !products.length) return null;
+        const city = cities[Math.floor(Math.random() * cities.length)];
+        const product = products[Math.floor(Math.random() * products.length)];
+        const qty = Math.floor(rand(C().CONTRACT_QTY[0], C().CONTRACT_QTY[1] + 1));
+
+        let nearest = Infinity;
+        for (const f of SC.factories.all()) {
+            if (f.recipe === product) nearest = Math.min(nearest, Math.hypot(f.x - city.x, f.y - city.y));
+        }
+        if (nearest === Infinity) nearest = 400;
+
+        // Same shape as spawnOrder's payout formula, plus the locked-in
+        // CONTRACT_RATE_BONUS premium that's the whole appeal of accepting.
+        const depthMult = 1 + C().ORDER_DEPTH_VALUE * (SC.depthOf(product) - 1);
+        const payout = Math.round((qty * (SC.GOODS[product].value * depthMult * C().CONTRACT_RATE_BONUS +
+            C().ORDER_DIST_PAY * nearest) * (1 + SC.research.payoutBonus())) / 5) * 5;
+        const deadline = rand(C().CONTRACT_DURATION[0], C().CONTRACT_DURATION[1]) * SC.diff().deadlineMult;
+
+        SC.state.contractOffer = { product, city, qty, payout, deadline, timeLeft: C().CONTRACT_OFFER_EXPIRE };
+        SC.emit('contractOffered', SC.state.contractOffer);
+        return SC.state.contractOffer;
+    }
+
+    function acceptContract() {
+        const offer = SC.state.contractOffer;
+        if (!offer) return { ok: false, reason: 'none' };
+        const order = {
+            id: ++SC.state.orderSeq,
+            city: offer.city, product: offer.product, qty: offer.qty,
+            deliveredUnits: 0,
+            payout: offer.payout,
+            deadline: offer.deadline, deadlineTotal: offer.deadline,
+            planned: false, noRoute: false, done: false,
+            contract: true
+        };
+        SC.state.orders.push(order);
+        planOrder(order);
+        SC.state.contractOffer = null;
+        SC.emit('contractAccepted', order);
+        return { ok: true, order };
+    }
+
+    function declineContract() {
+        if (!SC.state.contractOffer) return { ok: false };
+        SC.emit('contractDeclined', SC.state.contractOffer);
+        SC.state.contractOffer = null;
+        SC.state.nextContractIn = rand(C().CONTRACT_INTERVAL[0], C().CONTRACT_INTERVAL[1]);
         return { ok: true };
     }
 
@@ -261,6 +329,17 @@ SC.economy = (function() {
             SC.emit('debtRecovered');
         }
 
+        // Contract offers: a pending one just counts down to auto-decline;
+        // a new one is only rolled when nothing is pending or already
+        // accepted (one contract, offer or active, at a time).
+        if (SC.state.contractOffer) {
+            SC.state.contractOffer.timeLeft -= dt;
+            if (SC.state.contractOffer.timeLeft <= 0) declineContract();
+        } else if (!SC.state.orders.some(o => o.contract)) {
+            SC.state.nextContractIn -= dt;
+            if (SC.state.nextContractIn <= 0) rollContractOffer();
+        }
+
         // New customer DCs (cities) unlock on their own clock, independent
         // of delivery milestones — HQ is the only order-placing location
         // until one appears.
@@ -309,5 +388,6 @@ SC.economy = (function() {
     return { spawnOrder, planOrder, deliverProduct, expireOrder,
              onNetworkChanged, tick, tickSuppliers, buyUpgrade, upgradeSupplier,
              craftableProducts, bestSourceFor, maxActiveOrders,
-             isPromoActive, promoTimeLeft, startPromotion };
+             isPromoActive, promoTimeLeft, startPromotion,
+             rollContractOffer, acceptContract, declineContract };
 })();

--- a/supply-chain/js/main.js
+++ b/supply-chain/js/main.js
@@ -187,6 +187,14 @@ SC.runProbe = function(seconds) {
             }
         }
     }
+    // Force a contract offer card (&contract=1), or an already-accepted
+    // contract order (&contract=accept), so both UI states are screenshotable
+    // without waiting on the random CONTRACT_INTERVAL timer.
+    if (p.has('contract')) {
+        SC.state.money = Math.max(SC.state.money, 50000);
+        SC.economy.rollContractOffer();
+        if (p.get('contract') === 'accept') SC.economy.acceptContract();
+    }
     // Arm placement mode so the ghost preview can be screenshotted, e.g.
     // ?placemode=supplier:wheat
     if (p.has('placemode')) {

--- a/supply-chain/js/save.js
+++ b/supply-chain/js/save.js
@@ -50,6 +50,12 @@ SC.save = (function() {
             time: st.time, nextOrderIn: st.nextOrderIn, orderSeq: st.orderSeq,
             nextCustomerIn: st.nextCustomerIn,
             promoUntil: st.promoUntil, defaultIn: st.defaultIn,
+            nextContractIn: st.nextContractIn,
+            contractOffer: st.contractOffer ? {
+                cityId: st.contractOffer.city.id, product: st.contractOffer.product,
+                qty: st.contractOffer.qty, payout: st.contractOffer.payout,
+                deadline: st.contractOffer.deadline, timeLeft: st.contractOffer.timeLeft
+            } : null,
             upgrades: Object.assign({}, st.upgrades),
             research: {
                 completed: Object.assign({}, st.research.completed),
@@ -72,7 +78,8 @@ SC.save = (function() {
             orders: st.orders.map(o => ({
                 id: o.id, cityId: o.city.id, product: o.product,
                 qty: o.qty, deliveredUnits: o.deliveredUnits, payout: o.payout,
-                deadline: o.deadline, deadlineTotal: o.deadlineTotal
+                deadline: o.deadline, deadlineTotal: o.deadlineTotal,
+                contract: !!o.contract
             }))
         };
     }
@@ -94,6 +101,7 @@ SC.save = (function() {
         st.nextCustomerIn = data.nextCustomerIn !== undefined ? data.nextCustomerIn : st.nextCustomerIn;
         st.promoUntil = data.promoUntil || 0;
         st.defaultIn = data.defaultIn !== undefined ? data.defaultIn : null;
+        st.nextContractIn = data.nextContractIn !== undefined ? data.nextContractIn : st.nextContractIn;
         st.seed = data.seed || null;
         st.congestionEnabled = data.congestionEnabled !== undefined
             ? data.congestionEnabled : SC.DIFFICULTIES[st.difficulty].congestion;
@@ -136,8 +144,19 @@ SC.save = (function() {
                 id: od.id, city, product: od.product, qty: od.qty,
                 deliveredUnits: od.deliveredUnits, payout: od.payout,
                 deadline: od.deadline, deadlineTotal: od.deadlineTotal,
-                planned: false, noRoute: false, done: false
+                planned: false, noRoute: false, done: false,
+                contract: !!od.contract
             });
+        }
+        if (data.contractOffer) {
+            const city = byId.get(data.contractOffer.cityId);
+            if (city) {
+                st.contractOffer = {
+                    product: data.contractOffer.product, city,
+                    qty: data.contractOffer.qty, payout: data.contractOffer.payout,
+                    deadline: data.contractOffer.deadline, timeLeft: data.contractOffer.timeLeft
+                };
+            }
         }
         SC.economy.onNetworkChanged(); // rebuild plans, tasks and haul jobs
         return st;

--- a/supply-chain/js/state.js
+++ b/supply-chain/js/state.js
@@ -27,11 +27,14 @@ SC.newState = function(difficulty) {
         river: null,        // { spine: [{x,y}], halfWidths: [w] }
         edges: [],          // { a, b, len, bridge, cost }
 
-        orders: [],         // see economy.js
+        orders: [],         // see economy.js — a contract is a regular order with `contract: true`
         nextOrderIn: 8,
         orderSeq: 0,
         nextCustomerIn: SC.CONFIG.CUSTOMER_SPAWN_FIRST[0] +
             Math.random() * (SC.CONFIG.CUSTOMER_SPAWN_FIRST[1] - SC.CONFIG.CUSTOMER_SPAWN_FIRST[0]),
+        contractOffer: null, // { product, city, qty, payout, deadline, timeLeft } awaiting Accept/Decline
+        nextContractIn: SC.CONFIG.CONTRACT_INTERVAL[0] +
+            Math.random() * (SC.CONFIG.CONTRACT_INTERVAL[1] - SC.CONFIG.CONTRACT_INTERVAL[0]),
 
         trucks: [],         // see vehicles.js
         jobs: [],           // pending haul jobs

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -247,7 +247,7 @@ SC.ui = (function() {
         const p = SC.GOODS[o.product];
         const frac = Math.max(0, o.deadline / o.deadlineTotal);
         const left = o.qty - o.deliveredUnits;
-        return `<div class="order ${frac < 0.25 ? 'urgent' : ''}" data-order="${o.id}">
+        return `<div class="order ${frac < 0.25 ? 'urgent' : ''} ${o.contract ? 'contract' : ''}" data-order="${o.id}">
             <span class="chip">${p.emoji}</span>
             <span class="oname">${left}× ${p.name}</span>
             <span class="opay">${fmt(o.payout)}</span>
@@ -262,6 +262,22 @@ SC.ui = (function() {
             ? SC.state.orders.map(orderRow).join('')
             : '<div class="orders-empty">No open orders — they arrive on their own.</div>';
         $('orders-count').textContent = SC.state.orders.length;
+    }
+
+    // ── Contract offer: Accept/Decline card, non-blocking ──
+    function updateContractOffer() {
+        const offer = SC.state.contractOffer;
+        const card = $('contract-offer');
+        card.classList.toggle('hidden', !offer);
+        if (!offer) return;
+        const g = SC.GOODS[offer.product];
+        const dest = offer.city.isHQ ? 'HQ' : 'a customer DC';
+        const penalty = Math.round(offer.payout * SC.CONFIG.CONTRACT_PENALTY_MULT);
+        $('contract-terms').innerHTML = `
+            <div class="contract-title">${g.emoji} ${offer.qty}× ${g.name} for ${dest}</div>
+            <div class="contract-detail">Deadline: ${fmtDuration(offer.deadline)} · Payout: <b>${fmt(offer.payout)}</b></div>
+            <div class="contract-penalty">⚠ Miss it and pay up to ${fmt(penalty)} in penalties</div>`;
+        $('contract-timer').style.width = `${Math.max(0, offer.timeLeft / SC.CONFIG.CONTRACT_OFFER_EXPIRE) * 100}%`;
     }
 
     // ── Inspect mode: hover/hold tooltip ────────
@@ -337,6 +353,7 @@ SC.ui = (function() {
             ordersTimer = 0;
             updateOrders();
             updateShop();
+            updateContractOffer(); // keeps the offer's countdown bar ticking
             if (menuOpen()) updateMenuInfo(); // keep "last saved Xs ago" ticking
         }
     }
@@ -432,6 +449,21 @@ SC.ui = (function() {
             if (!row) return;
             const order = SC.state.orders.find(o => o.id === +row.dataset.order);
             if (order) focusOrder(order);
+        });
+
+        $('contract-accept').addEventListener('click', () => {
+            const res = SC.economy.acceptContract();
+            if (res.ok) {
+                SC.sfx.play('cash');
+                toast(`📜 Contract accepted: ${res.order.qty}× ${SC.nameOf(res.order.product)}`, 'good');
+            }
+            updateContractOffer();
+            updateOrders();
+        });
+        $('contract-decline').addEventListener('click', () => {
+            SC.economy.declineContract();
+            SC.sfx.play('click');
+            updateContractOffer();
         });
 
         $('mode-build').addEventListener('click', () => setMode('build'));
@@ -592,8 +624,13 @@ SC.ui = (function() {
 
         // Game event feedback
         SC.on('toast', d => toast(d.text, d.kind));
-        SC.on('orderComplete', o => { SC.sfx.play('cash'); toast(`Order filled: +${fmt(o.payout)}`, 'good'); });
+        SC.on('orderComplete', o => {
+            SC.sfx.play('cash');
+            toast(o.contract ? `📜 Contract fulfilled! +${fmt(o.payout)}` : `Order filled: +${fmt(o.payout)}`, 'good');
+        });
         SC.on('orderExpired', () => { SC.sfx.play('expire'); toast('An order expired — customer walked away', 'error'); });
+        SC.on('contractOffered', () => { SC.sfx.play('unlock'); toast('📜 New contract offer available!', 'info'); });
+        SC.on('contractFailed', d => { SC.sfx.play('expire'); toast(`📜 Contract failed — penalty ${fmt(d.penalty)}`, 'error'); });
         SC.on('crafted', () => SC.sfx.play('craft'));
         SC.on('salvage', () => toast(`Late delivery salvaged for ${fmt(SC.CONFIG.SALVAGE_PAY)}`, 'info'));
         SC.on('unlock', n => {

--- a/supply-chain/style.css
+++ b/supply-chain/style.css
@@ -280,6 +280,43 @@ html, body {
 }
 .obar div { height: 100%; border-radius: 2px; }
 .orders-empty { color: var(--text-secondary); font-size: 0.8rem; padding: 0.5rem; }
+.order.contract { outline: 1px solid rgba(250, 204, 21, 0.5); background: rgba(120, 90, 15, 0.25); }
+.order.contract .oname::before { content: "📜 "; }
+
+/* ── Contract offer card ─────────────────────────── */
+#contract-offer {
+    position: fixed;
+    top: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 110;
+    width: 300px;
+    max-width: 92vw;
+}
+#contract-offer.hidden { display: none; }
+.contract-card {
+    background: var(--card-bg);
+    border: 1px solid rgba(250, 204, 21, 0.4);
+    border-radius: 14px;
+    padding: 0.9rem 1rem;
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+}
+.contract-header { font-weight: 700; margin-bottom: 0.4rem; }
+.contract-title { font-size: 0.85rem; margin-bottom: 0.2rem; }
+.contract-detail { color: var(--text-secondary); font-size: 0.78rem; margin-bottom: 0.3rem; }
+.contract-detail b { color: var(--good); }
+.contract-penalty { color: var(--bad); font-size: 0.72rem; margin-bottom: 0.5rem; }
+.contract-timer-bar {
+    height: 4px;
+    border-radius: 2px;
+    background: rgba(255, 255, 255, 0.1);
+    overflow: hidden;
+    margin-bottom: 0.6rem;
+}
+#contract-timer { height: 100%; background: rgba(250, 204, 21, 0.8); border-radius: 2px; }
+.contract-actions { display: flex; gap: 0.5rem; }
+.contract-actions .menu-btn { flex: 1; width: auto; margin-bottom: 0; text-align: center; }
 
 /* ── Shop ────────────────────────────────────────── */
 .shop-btn {

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -15,20 +15,20 @@
     <div id="results"></div>
 
     <!-- Pure logic only: no render/input/ui/main, no canvas needed -->
-    <script src="js/config.js?v=1.18.0"></script>
-    <script src="js/state.js?v=1.18.0"></script>
-    <script src="js/save.js?v=1.18.0"></script>
-    <script src="js/sfx.js?v=1.18.0"></script>
-    <script src="js/rng.js?v=1.18.0"></script>
-    <script src="js/map.js?v=1.18.0"></script>
-    <script src="js/camera.js?v=1.18.0"></script>
-    <script src="js/roads.js?v=1.18.0"></script>
-    <script src="js/factories.js?v=1.18.0"></script>
-    <script src="js/economy.js?v=1.18.0"></script>
-    <script src="js/vehicles.js?v=1.18.0"></script>
-    <script src="js/inspect.js?v=1.18.0"></script>
-    <script src="js/research.js?v=1.18.0"></script>
-    <script src="js/placement.js?v=1.18.0"></script>
+    <script src="js/config.js?v=1.19.0"></script>
+    <script src="js/state.js?v=1.19.0"></script>
+    <script src="js/save.js?v=1.19.0"></script>
+    <script src="js/sfx.js?v=1.19.0"></script>
+    <script src="js/rng.js?v=1.19.0"></script>
+    <script src="js/map.js?v=1.19.0"></script>
+    <script src="js/camera.js?v=1.19.0"></script>
+    <script src="js/roads.js?v=1.19.0"></script>
+    <script src="js/factories.js?v=1.19.0"></script>
+    <script src="js/economy.js?v=1.19.0"></script>
+    <script src="js/vehicles.js?v=1.19.0"></script>
+    <script src="js/inspect.js?v=1.19.0"></script>
+    <script src="js/research.js?v=1.19.0"></script>
+    <script src="js/placement.js?v=1.19.0"></script>
 
     <script>
     let passed = 0, failed = 0;
@@ -1505,6 +1505,139 @@
         const restored = SC.state.edges.find(e =>
             (e.a.x === 900 && e.b.x === 1300) || (e.a.x === 1300 && e.b.x === 900));
         assert('ferry flag survives a save round-trip', restored && restored.ferry === true);
+    })();
+
+    // ── Contracts: offer generation ─────────────────────────
+    (function() {
+        const { F, C } = fixture();
+        SC.state.money = 100000;
+        const offer = SC.economy.rollContractOffer();
+        assert('offer is generated with a city, product, qty and payout',
+            offer && offer.city && offer.product && offer.qty > 0 && offer.payout > 0);
+        assert('offer starts with the full countdown', offer.timeLeft === SC.CONFIG.CONTRACT_OFFER_EXPIRE);
+        assert('offer is stashed on state.contractOffer', SC.state.contractOffer === offer);
+        assert('a second roll is a no-op while one is pending (one at a time)', (function() {
+            const before = SC.state.contractOffer;
+            SC.economy.rollContractOffer();
+            return SC.state.contractOffer === before;
+        })());
+    })();
+
+    // ── Contracts: accept turns the offer into a real order ────
+    (function() {
+        const { S1, S2, F, C } = fixture();
+        SC.state.money = 100000;
+        SC.roads.build(S1, F);
+        SC.roads.build(S2, F);
+        SC.roads.build(F, C);
+        const offer = SC.economy.rollContractOffer();
+        const qty = offer.qty, payout = offer.payout;
+        const res = SC.economy.acceptContract();
+        assert('accept succeeds and returns the new order', res.ok && res.order);
+        assert('offer is cleared once accepted', SC.state.contractOffer === null);
+        assert('the resulting order carries the offer terms and the contract flag',
+            res.order.contract === true && res.order.qty === qty && res.order.payout === payout);
+        assert('the contract order is planned like a normal order (route exists)',
+            SC.state.orders.includes(res.order) && res.order.planned);
+        assert('accepting with no pending offer fails cleanly',
+            !SC.economy.acceptContract().ok);
+    })();
+
+    // ── Contracts: decline clears the offer and resets the timer ─
+    (function() {
+        fixture();
+        SC.state.money = 100000;
+        SC.economy.rollContractOffer();
+        const res = SC.economy.declineContract();
+        assert('decline succeeds', res.ok);
+        assert('offer is cleared on decline', SC.state.contractOffer === null);
+        assert('nextContractIn is reset to a fresh interval', SC.state.nextContractIn > 0);
+        assert('declining with no pending offer fails cleanly', !SC.economy.declineContract().ok);
+    })();
+
+    // ── Contracts: missing one charges a penalty proportional to the shortfall ─
+    (function() {
+        const { S1, S2, F, C } = fixture();
+        SC.state.money = 100000;
+        SC.roads.build(S1, F);
+        SC.roads.build(S2, F);
+        SC.roads.build(F, C);
+        SC.economy.rollContractOffer();
+        const { order } = SC.economy.acceptContract();
+        const moneyBefore = SC.state.money;
+        const expectedPenalty = Math.round(order.qty * (order.payout / order.qty) * SC.CONFIG.CONTRACT_PENALTY_MULT);
+        SC.economy.expireOrder(order);
+        assert('a fully-missed contract charges the full proportional penalty',
+            SC.state.money === moneyBefore - expectedPenalty);
+        assert('expiring a contract does not count as a plain missed order tally bump only',
+            SC.state.missed === 1);
+    })();
+
+    // ── Contracts: a normal (non-contract) order still misses for free ─
+    (function() {
+        const { S1, S2, F, C } = fixture();
+        SC.state.money = 100000;
+        SC.roads.build(S1, F);
+        SC.roads.build(S2, F);
+        SC.roads.build(F, C);
+        const order = SC.economy.spawnOrder();
+        SC.economy.planOrder(order);
+        const moneyBefore = SC.state.money;
+        SC.economy.expireOrder(order);
+        assert('a plain missed order carries no monetary penalty', SC.state.money === moneyBefore);
+    })();
+
+    // ── Contracts: partial delivery reduces the penalty ─────────
+    (function() {
+        const { S1, S2, F, C } = fixture();
+        SC.state.money = 100000;
+        SC.roads.build(S1, F);
+        SC.roads.build(S2, F);
+        SC.roads.build(F, C);
+        SC.economy.rollContractOffer();
+        const { order } = SC.economy.acceptContract();
+        order.deliveredUnits = Math.floor(order.qty / 2);
+        const moneyBefore = SC.state.money;
+        const missingUnits = order.qty - order.deliveredUnits;
+        const expectedPenalty = Math.round(missingUnits * (order.payout / order.qty) * SC.CONFIG.CONTRACT_PENALTY_MULT);
+        SC.economy.expireOrder(order);
+        assert('a partially-delivered contract is penalized less than a fully-missed one',
+            SC.state.money === moneyBefore - expectedPenalty && expectedPenalty > 0);
+    })();
+
+    // ── Contracts: tick-loop countdown, auto-decline and re-roll ─
+    (function() {
+        fixture();
+        SC.state.money = 100000;
+        SC.state.nextContractIn = 0.05;
+        SC.economy.tick(0.1); // rolls an offer once nextContractIn elapses
+        assert('an offer appears once nextContractIn elapses', SC.state.contractOffer !== null);
+        SC.state.contractOffer.timeLeft = 0.05;
+        SC.economy.tick(0.1); // offer's own countdown auto-declines it
+        assert('an unanswered offer auto-declines once its own timer runs out',
+            SC.state.contractOffer === null);
+    })();
+
+    // ── Contracts: save round-trip for offer, order flag and timer ─
+    (function() {
+        const { S1, S2, F, C } = fixture();
+        SC.state.money = 100000;
+        SC.roads.build(S1, F);
+        SC.roads.build(S2, F);
+        SC.roads.build(F, C);
+        SC.economy.rollContractOffer();
+        SC.state.nextContractIn = 42;
+        const data = SC.save.serialize();
+        SC.save.restore(data);
+        assert('a pending contract offer survives a save round-trip',
+            SC.state.contractOffer && SC.state.contractOffer.city && SC.state.contractOffer.qty > 0);
+        assert('nextContractIn survives a save round-trip', SC.state.nextContractIn === 42);
+
+        SC.economy.acceptContract();
+        const data2 = SC.save.serialize();
+        SC.save.restore(data2);
+        assert('an accepted contract order keeps its contract flag across a round-trip',
+            SC.state.orders.some(o => o.contract === true));
     })();
 
     document.getElementById('summary').textContent = `${passed} passed / ${failed} failed`;


### PR DESCRIPTION
## Summary
- Adds **contracts**: `rollContractOffer` occasionally proposes a bulk order at a locked-in `CONTRACT_RATE_BONUS` premium rate; a non-blocking card lets the player Accept or Decline within `CONTRACT_OFFER_EXPIRE` before it's withdrawn (one offer/active contract at a time)
- Accepting (`acceptContract`) turns the offer into a regular order flagged `contract: true`, reusing the existing planning/delivery/expiry pipeline rather than a parallel system — styled with a gold outline and 📜 in the Orders panel
- Missing an accepted contract's deadline charges a penalty proportional to however many units are still undelivered (`CONTRACT_PENALTY_MULT × missingUnits × perUnitRate`), unlike a normal order's consequence-free miss
- Save/restore round-trips `contractOffer`, `nextContractIn`, and `order.contract` without a FORMAT bump
- New `&contract=1` / `&contract=accept` debug probe hooks for deterministic screenshotting
- Bumped `SC.VERSION` to `1.19.0` and all cache-busting `?v=` query strings

## Test plan
- [x] `node --check` on all modified JS files
- [x] Headless test suite (`tests.html`): 343 passed / 0 failed, including new coverage for offer generation, accept/decline, penalty computation (full and partial delivery), the tick-loop countdown/auto-decline/re-roll, and save round-trips
- [x] Screenshot verification: the Accept/Decline offer card, and an accepted contract's distinct styling in the Orders panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS)_