### PR TITLE
Supply Chain Tycoon: congestion is difficulty-only + dev A/B panel (v1.23.0)

### DIFF
--- a/supply-chain/CLAUDE.md
+++ b/supply-chain/CLAUDE.md
@@ -101,7 +101,12 @@ then (any headless Chromium works; on sandboxed Linux add `--no-sandbox`):
   📜) order in the Orders panel. `&crossing=1` fires the Bridge-vs-Ferry
   `crossingChoice` modal directly (same mirrored-node trick as
   `&ferry=1`) for screenshotting the choice UI without tapping a real
-  river-crossing road.
+  river-crossing road. `?dev=1` (a standing dev flag, not a one-shot
+  probe modifier — usable on a normal run too, not just `?probe=`) shows
+  a small pill under the top-left HUD bar that live-toggles
+  `SC.state.congestionEnabled`; congestion is otherwise fixed by
+  difficulty for the whole run and isn't a player-facing option, so this
+  is the way to A/B a map with/without it during development.
 - **Mobile layout**: same screenshot with `--window-size=390,844`. Caveat
   found while building the research-tree overlay: this Chromium build
   enforces a **hard ~500px minimum layout viewport** in headless mode —

--- a/supply-chain/PLAN.md
+++ b/supply-chain/PLAN.md
@@ -35,6 +35,9 @@ pan/pinch camera).
 
 ## Shipped
 
+- v1.23.0: **congestion is difficulty-only**; the ☰-menu toggle is gone,
+  replaced by a `?dev=1` dev-only A/B panel. Per item 8 below — details
+  there.
 - v1.20.0: **river-crossing choice modal** replaces the ferry build-mode
   toggle. Per item 9 below — details there.
 - v1.19.0: **contracts**. Per item 10 below — details there.
@@ -207,8 +210,13 @@ actually shipped.)*
    weighting, so dispatch actually prefers a quieter parallel road. A
    busy road glows warmer (`render.drawRoads`). Shipped as a **feature
    flag** (`SC.state.congestionEnabled`) per the owner's request: on by
-   default for Normal/Hard, off for Easy/Sandbox, toggle anytime from
-   the ☰ menu regardless of difficulty.
+   default for Normal/Hard, off for Easy/Sandbox. v1.17.0-v1.22.0 also
+   exposed a live ☰-menu toggle so any run could override the default;
+   v1.23.0 removed that player-facing toggle — congestion is now purely
+   a difficulty trait, fixed for the run like interest rate or deadlines
+   — and replaced it with a `?dev=1` dev-only panel (pill under the
+   top-left HUD bar) that flips `congestionEnabled` live for the owner's
+   own A/B comparison during development, not for normal play.
 9. ~~River ferries~~ — shipped v1.18.0, scoped down from the original
    "dock pair + fixed-cadence shuttle" proposal to an edge-level
    alternative: a road across the river builds as `edge.ferry` instead

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -121,9 +121,10 @@ that ambient animation as its background — it now lives independently at
   paves it (`edge.level 1`) — trucks cross it `HIGHWAY_SPEED_MULT`×
   faster, and pathfinding weighs edges by travel time so routes prefer
   paved legs.
-- **Congestion** (feature-flagged via `SC.state.congestionEnabled`,
-  toggle anytime from the ☰ menu; defaults per difficulty — on for
-  Normal/Hard, off for Easy/Sandbox): once more than
+- **Congestion** (`SC.state.congestionEnabled`, a difficulty trait fixed
+  for the run — on for Normal/Hard, off for Easy/Sandbox; not a normal
+  player-facing toggle, see the `?dev=1` dev panel below for A/B
+  comparison): once more than
   `CONGESTION_THRESHOLD` trucks share an edge at once, each additional
   truck slows it multiplicatively (`CONGESTION_STEP`, floored at
   `CONGESTION_FLOOR` — never a full stop). `SC.roads.speedMult` folds

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Supply Chain Tycoon | Niklas Billgren</title>
-    <link rel="stylesheet" href="style.css?v=1.22.0">
+    <link rel="stylesheet" href="style.css?v=1.23.0">
 </head>
 <body>
     <canvas id="gameCanvas"></canvas>
@@ -15,6 +15,14 @@
             <div class="hud-item money" id="hud-money-item"><span class="hud-label" id="hud-money-label">Money</span><span id="hud-money">$0</span></div>
             <div class="hud-item"><span class="hud-label hud-label-full">Trucks idle</span><span class="hud-label hud-label-short">🚚</span><span id="hud-trucks">0/0</span></div>
         </div>
+    </div>
+
+    <!-- Dev-only A/B comparison panel: hidden unless ?dev=1 is on the URL.
+         Not a normal gameplay option — congestion is otherwise fixed by
+         difficulty for the whole run, this just lets the developer flip
+         it live to compare. -->
+    <div id="dev-panel" class="hidden">
+        <button id="dev-congestion" class="dev-btn" title="Dev-only: override congestion live to compare with/without it">🚦 Congestion</button>
     </div>
 
     <div id="speed-toggle">
@@ -155,7 +163,6 @@
             <button class="menu-btn primary" id="menu-resume">▶ Resume</button>
             <button class="menu-btn" id="menu-save">💾 Save now</button>
             <button class="menu-btn" id="menu-sound">🔊 Sound</button>
-            <button class="menu-btn" id="menu-congestion">🚦 Congestion</button>
             <button class="menu-btn" id="menu-fullscreen">⛶ Full screen</button>
             <button class="menu-btn" id="menu-help">❓ How to play</button>
             <button class="menu-btn danger" id="menu-newgame">🗑 New game</button>
@@ -183,7 +190,7 @@
                 <li><b>Truck yards:</b> HQ is your first yard. Build more (Shop panel) to station trucks closer to distant routes — idle trucks head home to their yard, so they stay ready near their own region.</li>
                 <li><b>Supplier stock:</b> suppliers hold a finite stock that refills over time — trucks wait at a dry supplier. Upgrade mode (⬆️, bottom right): tap a supplier twice to raise its stock cap and refill rate.</li>
                 <li><b>Highways:</b> after the Asphalt Paving research, use Upgrade mode on a road to pave it — trucks drive 60% faster there.</li>
-                <li><b>Congestion:</b> on by default (Normal/Hard difficulty), a busy road glows warmer and slows down past a few trucks — build parallel routes instead of one mega-highway. Toggle it anytime from the ☰ menu.</li>
+                <li><b>Congestion:</b> a difficulty trait (on for Normal/Hard, off for Easy/Sandbox) — a busy road glows warmer and slows down past a few trucks, so build parallel routes instead of one mega-highway.</li>
                 <li><b>Fast-forward:</b> the 1×/2×/4× toggle under the HUD speeds up the whole sim — orders, crafting, trucks, interest, everything.</li>
                 <li><b>Contracts:</b> occasionally a bulk-order card offers a locked-in premium rate — Accept or Decline before the timer runs out. An accepted contract is a big order with its own deadline; miss it and you pay a penalty on top of the failure, not just a missed order.</li>
                 <li><b>Move around:</b> drag to pan, scroll or pinch to zoom. Tap a road twice to demolish it.</li>
@@ -206,23 +213,23 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=1.22.0"></script>
-    <script src="js/state.js?v=1.22.0"></script>
-    <script src="js/save.js?v=1.22.0"></script>
-    <script src="js/sfx.js?v=1.22.0"></script>
-    <script src="js/rng.js?v=1.22.0"></script>
-    <script src="js/map.js?v=1.22.0"></script>
-    <script src="js/camera.js?v=1.22.0"></script>
-    <script src="js/roads.js?v=1.22.0"></script>
-    <script src="js/factories.js?v=1.22.0"></script>
-    <script src="js/economy.js?v=1.22.0"></script>
-    <script src="js/vehicles.js?v=1.22.0"></script>
-    <script src="js/inspect.js?v=1.22.0"></script>
-    <script src="js/research.js?v=1.22.0"></script>
-    <script src="js/placement.js?v=1.22.0"></script>
-    <script src="js/render.js?v=1.22.0"></script>
-    <script src="js/input.js?v=1.22.0"></script>
-    <script src="js/ui.js?v=1.22.0"></script>
-    <script src="js/main.js?v=1.22.0"></script>
+    <script src="js/config.js?v=1.23.0"></script>
+    <script src="js/state.js?v=1.23.0"></script>
+    <script src="js/save.js?v=1.23.0"></script>
+    <script src="js/sfx.js?v=1.23.0"></script>
+    <script src="js/rng.js?v=1.23.0"></script>
+    <script src="js/map.js?v=1.23.0"></script>
+    <script src="js/camera.js?v=1.23.0"></script>
+    <script src="js/roads.js?v=1.23.0"></script>
+    <script src="js/factories.js?v=1.23.0"></script>
+    <script src="js/economy.js?v=1.23.0"></script>
+    <script src="js/vehicles.js?v=1.23.0"></script>
+    <script src="js/inspect.js?v=1.23.0"></script>
+    <script src="js/research.js?v=1.23.0"></script>
+    <script src="js/placement.js?v=1.23.0"></script>
+    <script src="js/render.js?v=1.23.0"></script>
+    <script src="js/input.js?v=1.23.0"></script>
+    <script src="js/ui.js?v=1.23.0"></script>
+    <script src="js/main.js?v=1.23.0"></script>
 </body>
 </html>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -1,7 +1,7 @@
 // Supply Chain Tycoon — constants, materials, recipes, prices
 window.SC = window.SC || {};
 
-SC.VERSION = '1.22.0';
+SC.VERSION = '1.23.0';
 
 SC.CONFIG = {
     WORLD_W: 2200,
@@ -146,8 +146,9 @@ SC.CONFIG = {
 // interest and 20% shorter order deadlines than the original tuning.
 // Easy keeps the pre-1.13 pace; Sandbox never forecloses (noFail) and
 // starts rich, for players who just want to build networks. `congestion`
-// is only the DEFAULT for SC.state.congestionEnabled — a live toggle in
-// the pause menu overrides it for the rest of the run either way.
+// sets SC.state.congestionEnabled for the whole run — it's purely a
+// difficulty trait, not a player-facing toggle (the ?dev=1 dev panel can
+// still override it live, for A/B comparison during development).
 SC.DIFFICULTIES = {
     easy: {
         label: 'Easy', emoji: '🌱', startMoney: 1500,

--- a/supply-chain/js/state.js
+++ b/supply-chain/js/state.js
@@ -47,7 +47,7 @@ SC.newState = function(difficulty) {
         defaultIn: null,    // default countdown while below -creditLimit (null = safe)
         gameOver: false,    // defaulted — sim frozen, overlay shown
         speed: 1,           // fast-forward multiplier: 1/2/4, see main.js's loop
-        congestionEnabled: SC.DIFFICULTIES[difficulty].congestion, // live toggle, see roads.speedMult
+        congestionEnabled: SC.DIFFICULTIES[difficulty].congestion, // fixed by difficulty, see roads.speedMult (dev panel can override for A/B comparison)
 
         selectedNode: null, // node picked as road start (input.js)
         highlight: null,    // { paths, color, city, until } — order route overlay

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -28,6 +28,16 @@ SC.ui = (function() {
         for (const btn of $('speed-toggle').children) {
             btn.classList.toggle('active', +btn.dataset.speed === st.speed);
         }
+        updateDevPanel();
+    }
+
+    // ── Dev-only A/B panel (?dev=1): congestion is otherwise fixed by
+    // difficulty for the whole run — this lets the developer flip it live
+    // to compare with/without it. Not shown to normal players. ──
+    function updateDevPanel() {
+        const btn = $('dev-congestion');
+        btn.classList.toggle('active', SC.state.congestionEnabled);
+        btn.textContent = SC.state.congestionEnabled ? '🚦 Congestion: on' : '🚦 Congestion: off';
     }
 
     function setSpeed(n) {
@@ -429,7 +439,6 @@ SC.ui = (function() {
             ? `Autosaves every ${SC.CONFIG.AUTOSAVE_INTERVAL}s · last saved ${fmtDuration((Date.now() - at) / 1000)} ago`
             : `Autosaves every ${SC.CONFIG.AUTOSAVE_INTERVAL}s · not saved yet this session`;
         $('menu-sound').textContent = SC.sfx.isMuted() ? '🔇 Sound: off' : '🔊 Sound: on';
-        $('menu-congestion').textContent = st.congestionEnabled ? '🚦 Congestion: on' : '🚦 Congestion: off';
         $('menu-fullscreen').textContent = document.fullscreenElement ? '⛶ Exit full screen' : '⛶ Full screen';
     }
 
@@ -494,6 +503,12 @@ SC.ui = (function() {
         $('crossing-ferry').addEventListener('click', () => chooseCrossing(true));
         $('crossing-cancel').addEventListener('click', () => { SC.sfx.play('click'); closeCrossingChoice(); });
 
+        $('dev-congestion').addEventListener('click', () => {
+            SC.state.congestionEnabled = !SC.state.congestionEnabled;
+            SC.sfx.play('click');
+            updateDevPanel();
+        });
+
         $('mode-build').addEventListener('click', () => setMode('build'));
         $('mode-upgrade').addEventListener('click', () => setMode('upgrade'));
         $('mode-inspect').addEventListener('click', () => setMode('inspect'));
@@ -520,11 +535,6 @@ SC.ui = (function() {
         });
         $('menu-sound').addEventListener('click', () => {
             SC.sfx.toggleMute();
-            updateMenuInfo();
-        });
-        $('menu-congestion').addEventListener('click', () => {
-            SC.state.congestionEnabled = !SC.state.congestionEnabled;
-            SC.sfx.play('click');
             updateMenuInfo();
         });
         $('menu-fullscreen').addEventListener('click', () => {
@@ -744,6 +754,13 @@ SC.ui = (function() {
         if (new URLSearchParams(location.search).has('menu')) openMenu();
         // ...and/or the research tree overlay
         if (new URLSearchParams(location.search).has('techtree')) openResearchTree();
+        // Dev-only A/B panel (?dev=1): lets the developer flip congestion
+        // live to compare with/without it, outside the normal difficulty-
+        // locked flow.
+        if (params.has('dev')) {
+            $('dev-panel').classList.remove('hidden');
+            updateDevPanel();
+        }
     }
 
     return { init, update, toast };

--- a/supply-chain/style.css
+++ b/supply-chain/style.css
@@ -102,6 +102,41 @@ html, body {
 .hud-item.money span:last-child { color: var(--good); }
 .hud-item.money.debt span:last-child { color: var(--bad); }
 
+/* ── Dev-only A/B panel: same segmented-pill language as #speed-toggle/
+   #mode-toggle, stacked under the top-left HUD bar. Only shown for
+   ?dev=1 — congestion is otherwise fixed by difficulty for a run; this
+   lets the developer flip it live to compare, it's not a player option. */
+#dev-panel {
+    position: fixed;
+    top: 4.2rem;
+    left: 1rem;
+    z-index: 100;
+    display: flex;
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 999px;
+    padding: 3px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+}
+#dev-panel.hidden { display: none; }
+.dev-btn {
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    font-weight: 700;
+    cursor: pointer;
+    white-space: nowrap;
+}
+.dev-btn:hover { color: var(--text-primary); }
+.dev-btn.active {
+    background: var(--accent-color);
+    color: #0f172a;
+}
+
 /* ── Fast-forward toggle: stacked above the build/upgrade/inspect
    selector in the bottom-right corner — same segmented-pill language
    (padding/gap/border-radius) as #mode-toggle below it, just sized for
@@ -714,6 +749,7 @@ html, body {
        #top-left/#orders-panel share one top; #shop-panel/#mode-toggle
        (and #speed-toggle stacked above it) share one bottom. */
     #top-left { top: 0.5rem; }
+    #dev-panel { top: 3.7rem; left: 0.5rem; }
     #mode-toggle { bottom: 0.5rem; }
     .icon-btn { width: 38px; height: 38px; }
     .mode-btn { width: 32px; height: 32px; font-size: 0.85rem; }

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -15,20 +15,20 @@
     <div id="results"></div>
 
     <!-- Pure logic only: no render/input/ui/main, no canvas needed -->
-    <script src="js/config.js?v=1.22.0"></script>
-    <script src="js/state.js?v=1.22.0"></script>
-    <script src="js/save.js?v=1.22.0"></script>
-    <script src="js/sfx.js?v=1.22.0"></script>
-    <script src="js/rng.js?v=1.22.0"></script>
-    <script src="js/map.js?v=1.22.0"></script>
-    <script src="js/camera.js?v=1.22.0"></script>
-    <script src="js/roads.js?v=1.22.0"></script>
-    <script src="js/factories.js?v=1.22.0"></script>
-    <script src="js/economy.js?v=1.22.0"></script>
-    <script src="js/vehicles.js?v=1.22.0"></script>
-    <script src="js/inspect.js?v=1.22.0"></script>
-    <script src="js/research.js?v=1.22.0"></script>
-    <script src="js/placement.js?v=1.22.0"></script>
+    <script src="js/config.js?v=1.23.0"></script>
+    <script src="js/state.js?v=1.23.0"></script>
+    <script src="js/save.js?v=1.23.0"></script>
+    <script src="js/sfx.js?v=1.23.0"></script>
+    <script src="js/rng.js?v=1.23.0"></script>
+    <script src="js/map.js?v=1.23.0"></script>
+    <script src="js/camera.js?v=1.23.0"></script>
+    <script src="js/roads.js?v=1.23.0"></script>
+    <script src="js/factories.js?v=1.23.0"></script>
+    <script src="js/economy.js?v=1.23.0"></script>
+    <script src="js/vehicles.js?v=1.23.0"></script>
+    <script src="js/inspect.js?v=1.23.0"></script>
+    <script src="js/research.js?v=1.23.0"></script>
+    <script src="js/placement.js?v=1.23.0"></script>
 
     <script>
     let passed = 0, failed = 0;


### PR DESCRIPTION
## Summary
- Congestion (`SC.state.congestionEnabled`) was previously a live toggle in the ☰ pause menu, letting any player override the difficulty default mid-run. It's now purely a **difficulty trait** — fixed for the whole run, like interest rate or deadlines — matching how the other difficulty knobs work
- Removed the "🚦 Congestion" button and its handlers from the normal pause menu
- Added a `?dev=1` **dev-only A/B panel**: a small pill under the top-left HUD bar (hidden unless that query param is present) that still flips `congestionEnabled` live, for comparing a map with/without congestion during development — not a normal player-facing option
- Updated help text and docs (README/PLAN/CLAUDE.md) to describe congestion as difficulty-fixed and document the `?dev=1` flag
- Bumped `SC.VERSION` to `1.23.0`

## Test plan
- [x] `node --check` on all modified JS files
- [x] Headless test suite (`tests.html`): 343 passed / 0 failed (congestion's pure-logic behavior is unchanged — this is a UI-layer-only change)
- [x] Screenshot verification: the dev panel showing "🚦 Congestion: on" under the HUD with `?dev=1`, and the pause menu confirmed to no longer show a Congestion button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS)_