### PR TITLE
Supply Chain Tycoon: Dev tools panel (v1.26.0)

### DIFF
--- a/supply-chain/CLAUDE.md
+++ b/supply-chain/CLAUDE.md
@@ -103,10 +103,15 @@ then (any headless Chromium works; on sandboxed Linux add `--no-sandbox`):
   `&ferry=1`) for screenshotting the choice UI without tapping a real
   river-crossing road. `?dev=1` (a standing dev flag, not a one-shot
   probe modifier — usable on a normal run too, not just `?probe=`) shows
-  a small pill under the top-left HUD bar that live-toggles
-  `SC.state.congestionEnabled`; congestion is otherwise fixed by
-  difficulty for the whole run and isn't a player-facing option, so this
-  is the way to A/B a map with/without it during development.
+  a collapsible **Dev tools** panel under the top-left HUD bar: an FPS
+  readout, a Congestion toggle (`SC.state.congestionEnabled` is
+  otherwise fixed by difficulty for the whole run, not player-facing —
+  this is the way to A/B a map with/without it), Add money (+$10,000),
+  Roll contract (force `rollContractOffer` now instead of waiting out
+  `CONTRACT_INTERVAL`), Finish research (completes the active project
+  instantly, disabled with none active), and Spawn next customer
+  (zeroes `nextCustomerIn` and re-ticks so the next customer DC unlocks
+  immediately). None of this is reachable by normal players.
 - **Mobile layout**: same screenshot with `--window-size=390,844`. Caveat
   found while building the research-tree overlay: this Chromium build
   enforces a **hard ~500px minimum layout viewport** in headless mode —

--- a/supply-chain/PLAN.md
+++ b/supply-chain/PLAN.md
@@ -35,6 +35,10 @@ pan/pinch camera).
 
 ## Shipped
 
+- v1.24.0: **Dev tools panel** (`?dev=1`) grows from a single congestion
+  pill into a small collapsible panel: FPS readout, Add money, Roll
+  contract, Finish research, Spawn next customer. Per item 8 below —
+  details there.
 - v1.23.0: **congestion is difficulty-only**; the ☰-menu toggle is gone,
   replaced by a `?dev=1` dev-only A/B panel. Per item 8 below — details
   there.
@@ -214,9 +218,13 @@ actually shipped.)*
    exposed a live ☰-menu toggle so any run could override the default;
    v1.23.0 removed that player-facing toggle — congestion is now purely
    a difficulty trait, fixed for the run like interest rate or deadlines
-   — and replaced it with a `?dev=1` dev-only panel (pill under the
+   — and replaced it with a `?dev=1` dev-only panel (a pill under the
    top-left HUD bar) that flips `congestionEnabled` live for the owner's
-   own A/B comparison during development, not for normal play.
+   own A/B comparison during development, not for normal play. v1.24.0
+   grew that pill into a full collapsible **Dev tools** panel (FPS
+   readout + Add money / Roll contract / Finish research / Spawn next
+   customer, alongside the congestion toggle) per the owner's request
+   for "a dev menu with some settings for game tuning and other stuff."
 9. ~~River ferries~~ — shipped v1.18.0, scoped down from the original
    "dock pair + fixed-cadence shuttle" proposal to an edge-level
    alternative: a road across the river builds as `edge.ferry` instead

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -123,7 +123,7 @@ that ambient animation as its background — it now lives independently at
   paved legs.
 - **Congestion** (`SC.state.congestionEnabled`, a difficulty trait fixed
   for the run — on for Normal/Hard, off for Easy/Sandbox; not a normal
-  player-facing toggle, see the `?dev=1` dev panel below for A/B
+  player-facing toggle, see the Dev tools panel further down for A/B
   comparison): once more than
   `CONGESTION_THRESHOLD` trucks share an edge at once, each additional
   truck slows it multiplicatively (`CONGESTION_STEP`, floored at
@@ -157,6 +157,13 @@ that ambient animation as its background — it now lives independently at
   an accepted contract's deadline (`expireOrder`) charges a penalty
   proportional to however many units are still undelivered
   (`CONTRACT_PENALTY_MULT × missingUnits × perUnitRate`).
+- **Dev tools panel** (`?dev=1`, not reachable by normal players): a
+  collapsible panel under the top-left HUD bar with an FPS readout and
+  one-off testing aids — Congestion (A/B override, see above), Add
+  money, Roll contract, Finish research, Spawn next customer. Lives
+  entirely in `ui.js`; each button reuses the same public logic
+  functions a normal action would call (`rollContractOffer`,
+  `research.tick`, etc.) rather than duplicating them.
 - **Per-yard truck prices**: the truck price ladder tracks trucks homed
   at the *active yard* (`SC.trucksAtYard`), so a new yard resets the
   ladder to base price — the ever-growing yard price is the balance

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Supply Chain Tycoon | Niklas Billgren</title>
-    <link rel="stylesheet" href="style.css?v=1.23.0">
+    <link rel="stylesheet" href="style.css?v=1.24.0">
 </head>
 <body>
     <canvas id="gameCanvas"></canvas>
@@ -17,12 +17,36 @@
         </div>
     </div>
 
-    <!-- Dev-only A/B comparison panel: hidden unless ?dev=1 is on the URL.
-         Not a normal gameplay option — congestion is otherwise fixed by
-         difficulty for the whole run, this just lets the developer flip
-         it live to compare. -->
-    <div id="dev-panel" class="hidden">
-        <button id="dev-congestion" class="dev-btn" title="Dev-only: override congestion live to compare with/without it">🚦 Congestion</button>
+    <!-- Dev-only tools: hidden unless ?dev=1 is on the URL. Not part of
+         normal gameplay — quick tuning/testing aids for development. -->
+    <div id="dev-panel" class="panel hidden">
+        <div class="panel-header" id="dev-header">
+            <h2>🛠 Dev tools</h2>
+            <span class="panel-toggle">▾</span>
+        </div>
+        <div class="panel-body">
+            <div class="dev-stat"><span>FPS</span><span id="dev-fps">60</span></div>
+            <button class="shop-btn build-btn" id="dev-congestion" title="Congestion is otherwise fixed by difficulty for the run — this overrides it live to compare">
+                <span class="sname">🚦 Congestion</span>
+                <span class="price" id="dev-congestion-state">On</span>
+            </button>
+            <button class="shop-btn" id="dev-money">
+                <span class="sname">💰 Add money</span>
+                <span class="price">+$10,000</span>
+            </button>
+            <button class="shop-btn" id="dev-contract">
+                <span class="sname">📜 Roll contract</span>
+                <span class="price">now</span>
+            </button>
+            <button class="shop-btn" id="dev-research">
+                <span class="sname">🔬 Finish research</span>
+                <span class="price">instant</span>
+            </button>
+            <button class="shop-btn" id="dev-customer">
+                <span class="sname">🏢 Spawn next customer</span>
+                <span class="price">now</span>
+            </button>
+        </div>
     </div>
 
     <div id="speed-toggle">
@@ -213,23 +237,23 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=1.23.0"></script>
-    <script src="js/state.js?v=1.23.0"></script>
-    <script src="js/save.js?v=1.23.0"></script>
-    <script src="js/sfx.js?v=1.23.0"></script>
-    <script src="js/rng.js?v=1.23.0"></script>
-    <script src="js/map.js?v=1.23.0"></script>
-    <script src="js/camera.js?v=1.23.0"></script>
-    <script src="js/roads.js?v=1.23.0"></script>
-    <script src="js/factories.js?v=1.23.0"></script>
-    <script src="js/economy.js?v=1.23.0"></script>
-    <script src="js/vehicles.js?v=1.23.0"></script>
-    <script src="js/inspect.js?v=1.23.0"></script>
-    <script src="js/research.js?v=1.23.0"></script>
-    <script src="js/placement.js?v=1.23.0"></script>
-    <script src="js/render.js?v=1.23.0"></script>
-    <script src="js/input.js?v=1.23.0"></script>
-    <script src="js/ui.js?v=1.23.0"></script>
-    <script src="js/main.js?v=1.23.0"></script>
+    <script src="js/config.js?v=1.24.0"></script>
+    <script src="js/state.js?v=1.24.0"></script>
+    <script src="js/save.js?v=1.24.0"></script>
+    <script src="js/sfx.js?v=1.24.0"></script>
+    <script src="js/rng.js?v=1.24.0"></script>
+    <script src="js/map.js?v=1.24.0"></script>
+    <script src="js/camera.js?v=1.24.0"></script>
+    <script src="js/roads.js?v=1.24.0"></script>
+    <script src="js/factories.js?v=1.24.0"></script>
+    <script src="js/economy.js?v=1.24.0"></script>
+    <script src="js/vehicles.js?v=1.24.0"></script>
+    <script src="js/inspect.js?v=1.24.0"></script>
+    <script src="js/research.js?v=1.24.0"></script>
+    <script src="js/placement.js?v=1.24.0"></script>
+    <script src="js/render.js?v=1.24.0"></script>
+    <script src="js/input.js?v=1.24.0"></script>
+    <script src="js/ui.js?v=1.24.0"></script>
+    <script src="js/main.js?v=1.24.0"></script>
 </body>
 </html>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -1,7 +1,7 @@
 // Supply Chain Tycoon — constants, materials, recipes, prices
 window.SC = window.SC || {};
 
-SC.VERSION = '1.23.0';
+SC.VERSION = '1.24.0';
 
 SC.CONFIG = {
     WORLD_W: 2200,
@@ -59,10 +59,11 @@ SC.CONFIG = {
     ROAD_UPGRADE_PER_UNIT: 0.9,
     HIGHWAY_SPEED_MULT: 1.6,
 
-    // Congestion (toggle: SC.state.congestionEnabled, defaulted per
-    // difficulty below, flippable anytime from the pause menu): once
-    // more than CONGESTION_THRESHOLD trucks share an edge at the same
-    // moment, each additional truck slows that edge by CONGESTION_STEP
+    // Congestion (SC.state.congestionEnabled, fixed per difficulty
+    // below — see DIFFICULTIES; the ?dev=1 panel can override it live
+    // for comparison): once more than CONGESTION_THRESHOLD trucks share
+    // an edge at the same moment, each additional truck slows that edge
+    // by CONGESTION_STEP
     // (multiplicative), down to a CONGESTION_FLOOR minimum — never a
     // full stop. Applies to both truck movement and Dijkstra's routing
     // weight, so dispatch naturally prefers a parallel, less-jammed road.

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -4,6 +4,7 @@ window.SC = window.SC || {};
 SC.ui = (function() {
     const $ = id => document.getElementById(id);
     let toastTimer = null;
+    let fpsSmoothed = 60; // dev-panel FPS readout, see update(dt)
 
     function fmt(n) { return '$' + Math.round(n).toLocaleString('en-US'); }
 
@@ -31,13 +32,16 @@ SC.ui = (function() {
         updateDevPanel();
     }
 
-    // ── Dev-only A/B panel (?dev=1): congestion is otherwise fixed by
-    // difficulty for the whole run — this lets the developer flip it live
-    // to compare with/without it. Not shown to normal players. ──
+    // ── Dev-only tools (?dev=1): quick tuning/testing aids, not part of
+    // normal gameplay. Congestion is otherwise fixed by difficulty for the
+    // whole run — this lets the developer flip it live to compare; the
+    // rest are one-off actions for testing without grinding. ──
     function updateDevPanel() {
+        $('dev-fps').textContent = Math.round(fpsSmoothed);
         const btn = $('dev-congestion');
         btn.classList.toggle('active', SC.state.congestionEnabled);
-        btn.textContent = SC.state.congestionEnabled ? '🚦 Congestion: on' : '🚦 Congestion: off';
+        $('dev-congestion-state').textContent = SC.state.congestionEnabled ? 'On' : 'Off';
+        $('dev-research').disabled = !SC.state.research.active;
     }
 
     function setSpeed(n) {
@@ -376,6 +380,7 @@ SC.ui = (function() {
 
     let ordersTimer = 0, lastOrderCount = -1;
     function update(dt) {
+        if (dt > 0) fpsSmoothed += (1 / dt - fpsSmoothed) * 0.1;
         updateHUD();
         updateInspectTooltip();
         ordersTimer += dt;
@@ -503,10 +508,37 @@ SC.ui = (function() {
         $('crossing-ferry').addEventListener('click', () => chooseCrossing(true));
         $('crossing-cancel').addEventListener('click', () => { SC.sfx.play('click'); closeCrossingChoice(); });
 
+        $('dev-header').addEventListener('click', () =>
+            $('dev-panel').classList.toggle('collapsed'));
         $('dev-congestion').addEventListener('click', () => {
             SC.state.congestionEnabled = !SC.state.congestionEnabled;
             SC.sfx.play('click');
             updateDevPanel();
+        });
+        $('dev-money').addEventListener('click', () => {
+            SC.state.money += 10000;
+            SC.sfx.play('cash');
+            toast('💰 +$10,000 (dev)', 'good');
+            updateShop();
+        });
+        $('dev-contract').addEventListener('click', () => {
+            const offer = SC.economy.rollContractOffer();
+            SC.sfx.play('click');
+            if (!offer) toast('Contract already offered/active (dev)', 'info');
+        });
+        $('dev-research').addEventListener('click', () => {
+            const a = SC.state.research.active;
+            if (!a) { toast('No active research (dev)', 'info'); return; }
+            a.t = SC.RESEARCH[a.id].time;
+            SC.research.tick(0);
+            SC.sfx.play('unlock');
+            updateShop();
+            updateDevPanel();
+        });
+        $('dev-customer').addEventListener('click', () => {
+            SC.state.nextCustomerIn = 0;
+            SC.economy.tick(0);
+            SC.sfx.play('click');
         });
 
         $('mode-build').addEventListener('click', () => setMode('build'));
@@ -749,14 +781,14 @@ SC.ui = (function() {
         if (window.innerWidth <= 768) {
             $('orders-panel').classList.add('collapsed');
             $('shop-panel').classList.add('collapsed');
+            $('dev-panel').classList.add('collapsed');
         }
         // Headless verification hook (see CLAUDE.md): open the menu on load
         if (new URLSearchParams(location.search).has('menu')) openMenu();
         // ...and/or the research tree overlay
         if (new URLSearchParams(location.search).has('techtree')) openResearchTree();
-        // Dev-only A/B panel (?dev=1): lets the developer flip congestion
-        // live to compare with/without it, outside the normal difficulty-
-        // locked flow.
+        // Dev-only tools panel (?dev=1): tuning/testing aids for
+        // development, not shown to normal players.
         if (params.has('dev')) {
             $('dev-panel').classList.remove('hidden');
             updateDevPanel();

--- a/supply-chain/style.css
+++ b/supply-chain/style.css
@@ -102,40 +102,19 @@ html, body {
 .hud-item.money span:last-child { color: var(--good); }
 .hud-item.money.debt span:last-child { color: var(--bad); }
 
-/* ── Dev-only A/B panel: same segmented-pill language as #speed-toggle/
-   #mode-toggle, stacked under the top-left HUD bar. Only shown for
-   ?dev=1 — congestion is otherwise fixed by difficulty for a run; this
-   lets the developer flip it live to compare, it's not a player option. */
-#dev-panel {
-    position: fixed;
-    top: 4.2rem;
-    left: 1rem;
-    z-index: 100;
-    display: flex;
-    background: var(--card-bg);
-    border: 1px solid var(--card-border);
-    border-radius: 999px;
-    padding: 3px;
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-}
+/* ── Dev-only tools panel: reuses the .panel/.shop-btn language from
+   Orders/Shop, stacked under the top-left HUD bar. Only shown for
+   ?dev=1 — quick tuning/testing aids, not part of normal gameplay. */
+#dev-panel { top: 4.2rem; left: 1rem; width: 230px; }
 #dev-panel.hidden { display: none; }
-.dev-btn {
-    padding: 0.4rem 0.9rem;
-    border-radius: 999px;
-    border: none;
-    background: transparent;
+.dev-stat {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.35rem 0.5rem;
+    font-size: 0.8rem;
     color: var(--text-secondary);
-    font-size: 0.78rem;
-    font-weight: 700;
-    cursor: pointer;
-    white-space: nowrap;
 }
-.dev-btn:hover { color: var(--text-primary); }
-.dev-btn.active {
-    background: var(--accent-color);
-    color: #0f172a;
-}
+.dev-stat span:last-child { color: var(--text-primary); font-weight: 700; }
 
 /* ── Fast-forward toggle: stacked above the build/upgrade/inspect
    selector in the bottom-right corner — same segmented-pill language

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -15,20 +15,20 @@
     <div id="results"></div>
 
     <!-- Pure logic only: no render/input/ui/main, no canvas needed -->
-    <script src="js/config.js?v=1.23.0"></script>
-    <script src="js/state.js?v=1.23.0"></script>
-    <script src="js/save.js?v=1.23.0"></script>
-    <script src="js/sfx.js?v=1.23.0"></script>
-    <script src="js/rng.js?v=1.23.0"></script>
-    <script src="js/map.js?v=1.23.0"></script>
-    <script src="js/camera.js?v=1.23.0"></script>
-    <script src="js/roads.js?v=1.23.0"></script>
-    <script src="js/factories.js?v=1.23.0"></script>
-    <script src="js/economy.js?v=1.23.0"></script>
-    <script src="js/vehicles.js?v=1.23.0"></script>
-    <script src="js/inspect.js?v=1.23.0"></script>
-    <script src="js/research.js?v=1.23.0"></script>
-    <script src="js/placement.js?v=1.23.0"></script>
+    <script src="js/config.js?v=1.24.0"></script>
+    <script src="js/state.js?v=1.24.0"></script>
+    <script src="js/save.js?v=1.24.0"></script>
+    <script src="js/sfx.js?v=1.24.0"></script>
+    <script src="js/rng.js?v=1.24.0"></script>
+    <script src="js/map.js?v=1.24.0"></script>
+    <script src="js/camera.js?v=1.24.0"></script>
+    <script src="js/roads.js?v=1.24.0"></script>
+    <script src="js/factories.js?v=1.24.0"></script>
+    <script src="js/economy.js?v=1.24.0"></script>
+    <script src="js/vehicles.js?v=1.24.0"></script>
+    <script src="js/inspect.js?v=1.24.0"></script>
+    <script src="js/research.js?v=1.24.0"></script>
+    <script src="js/placement.js?v=1.24.0"></script>
 
     <script>
     let passed = 0, failed = 0;


### PR DESCRIPTION
## Summary
- Grows the `?dev=1` congestion pill into a full collapsible **Dev tools** panel under the top-left HUD bar, for game tuning/testing during development (not reachable by normal players)
- Adds: an FPS readout (smoothed), Add money (+$10,000), Roll contract (forces `rollContractOffer` now), Finish research (completes the active project instantly, disabled with none active), alongside the existing Congestion A/B toggle
- Each action reuses existing public logic (`rollContractOffer`, `research.tick`, `economy.tick`) rather than duplicating it
- Bumped `SC.VERSION` to `1.26.0` and merged the parallel iso-scenery work from master

## Test plan
- [x] `node --check` on all modified JS files
- [x] Headless test suite (`tests.html`): 343 passed / 0 failed (UI-layer-only change)
- [x] Screenshot verification: the panel showing FPS, Congestion on, and all dev actions, rendering correctly against the new terrain/scenery from master

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSVkeQeEZXfUJvc53ppsbS)_