### PR TITLE
supply-chain: replace Shop/Build tabs with Upgrade/Build/Research launchers

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
                 </svg></span>
         </a>
 
-        <a href="supply-chain/index.html?v=1.50.7" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.51.0" class="card card-metal" id="card-supply-chain">
             <div class="beta-badge">BETA</div>
             <div>
                 <div class="card-icon">🏭</div>

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Supply Chain Tycoon | Niklas Billgren</title>
-    <link rel="stylesheet" href="style.css?v=1.50.7">
+    <link rel="stylesheet" href="style.css?v=1.51.0">
 </head>
 <body>
     <canvas id="gameCanvas"></canvas>
@@ -84,18 +84,14 @@
         <div class="panel-body" id="orders-list"></div>
     </div>
 
-    <div id="shop-panel" class="panel">
-        <div class="panel-header" id="shop-header">
-            <h2>Shop</h2>
-            <div class="shop-tabs">
-                <button class="shop-tab active" id="shop-tab-shop">🛒 Shop</button>
-                <button class="shop-tab" id="shop-tab-build">🏗️ Build</button>
-            </div>
-            <span class="panel-toggle">▾</span>
-        </div>
+    <!-- Bottom-left: three launcher buttons (Upgrade / Build / Research) open
+         a shared popover panel above them. On desktop each button shows an icon
+         + text label; on mobile they collapse to icon-only circles. Replaces the
+         old collapsible Shop panel with its Shop/Build header tabs. -->
+    <div id="shop-panel" class="panel hidden">
         <div class="panel-body">
-            <!-- ── SHOP TAB ── -->
-            <div id="shop-tab-shop-content">
+            <!-- ── UPGRADE SECTION ── -->
+            <div id="shop-sec-upgrade" class="shop-section">
                 <button class="shop-btn" id="btn-truck">
                     <span class="sname">🚚 Buy truck</span>
                     <span class="price">$500</span>
@@ -121,19 +117,14 @@
                     <span class="price">$450</span>
                 </button>
 
-                <button class="shop-btn" id="btn-research-tree">
-                    <span class="sname">🔬 Research</span>
-                    <span class="price" id="research-shortcut-status">Open tree</span>
-                </button>
-
                 <button class="shop-btn hidden" id="btn-promo">
                     <span class="sname">📣 Run promotion</span>
                     <span class="price">$600</span>
                 </button>
             </div>
 
-            <!-- ── BUILD TAB ── -->
-            <div id="shop-tab-build-content" class="hidden">
+            <!-- ── BUILD SECTION ── -->
+            <div id="shop-sec-build" class="shop-section hidden">
                 <button class="shop-btn build-btn" id="btn-yard">
                     <span class="sname">🅿️ Build truck yard</span>
                     <span class="price">$1,200</span>
@@ -150,7 +141,29 @@
                 <div class="shop-section-title hidden" id="build-title">📍 Place supplier / factory</div>
                 <div id="build-list"></div>
             </div>
+
+            <!-- ── RESEARCH SECTION ── -->
+            <div id="shop-sec-research" class="shop-section hidden">
+                <button class="shop-btn" id="btn-research-tree">
+                    <span class="sname">🔬 Open research tree</span>
+                    <span class="price" id="research-shortcut-status">Open tree</span>
+                </button>
+                <p class="shop-hint">Invest upfront and wait it out to unlock manual site
+                   placement, a bigger credit line, highways, junctions and more.</p>
+            </div>
         </div>
+    </div>
+
+    <div id="shop-launcher">
+        <button class="launcher-btn" data-sec="upgrade" title="Upgrade — buy trucks &amp; upgrades">
+            <span class="lb-icon">⚡</span><span class="lb-text">Upgrade</span>
+        </button>
+        <button class="launcher-btn" data-sec="build" title="Build — yards, junctions, factories">
+            <span class="lb-icon">🏗️</span><span class="lb-text">Build</span>
+        </button>
+        <button class="launcher-btn" data-sec="research" title="Research — unlock new tech">
+            <span class="lb-icon">🔬</span><span class="lb-text">Research</span>
+        </button>
     </div>
 
     <div id="toast"></div>
@@ -298,24 +311,24 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=1.50.7"></script>
-    <script src="js/state.js?v=1.50.7"></script>
-    <script src="js/save.js?v=1.50.7"></script>
-    <script src="js/sfx.js?v=1.50.7"></script>
-    <script src="js/rng.js?v=1.50.7"></script>
-    <script src="js/map.js?v=1.50.7"></script>
-    <script src="js/camera.js?v=1.50.7"></script>
-    <script src="js/roads.js?v=1.50.7"></script>
-    <script src="js/factories.js?v=1.50.7"></script>
-    <script src="js/economy.js?v=1.50.7"></script>
-    <script src="js/vehicles.js?v=1.50.7"></script>
-    <script src="js/stats.js?v=1.50.7"></script>
-    <script src="js/inspect.js?v=1.50.7"></script>
-    <script src="js/research.js?v=1.50.7"></script>
-    <script src="js/placement.js?v=1.50.7"></script>
-    <script src="js/render.js?v=1.50.7"></script>
-    <script src="js/input.js?v=1.50.7"></script>
-    <script src="js/ui.js?v=1.50.7"></script>
-    <script src="js/main.js?v=1.50.7"></script>
+    <script src="js/config.js?v=1.51.0"></script>
+    <script src="js/state.js?v=1.51.0"></script>
+    <script src="js/save.js?v=1.51.0"></script>
+    <script src="js/sfx.js?v=1.51.0"></script>
+    <script src="js/rng.js?v=1.51.0"></script>
+    <script src="js/map.js?v=1.51.0"></script>
+    <script src="js/camera.js?v=1.51.0"></script>
+    <script src="js/roads.js?v=1.51.0"></script>
+    <script src="js/factories.js?v=1.51.0"></script>
+    <script src="js/economy.js?v=1.51.0"></script>
+    <script src="js/vehicles.js?v=1.51.0"></script>
+    <script src="js/stats.js?v=1.51.0"></script>
+    <script src="js/inspect.js?v=1.51.0"></script>
+    <script src="js/research.js?v=1.51.0"></script>
+    <script src="js/placement.js?v=1.51.0"></script>
+    <script src="js/render.js?v=1.51.0"></script>
+    <script src="js/input.js?v=1.51.0"></script>
+    <script src="js/ui.js?v=1.51.0"></script>
+    <script src="js/main.js?v=1.51.0"></script>
 </body>
 </html>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -1,7 +1,7 @@
 // Supply Chain Tycoon — constants, materials, recipes, prices
 window.SC = window.SC || {};
 
-SC.VERSION = '1.50.7';
+SC.VERSION = '1.51.0';
 
 SC.CONFIG = {
     // Base playing-field size. The *current* size lives in

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -981,32 +981,33 @@ SC.ui = (function() {
         });
         $('orders-header').addEventListener('click', () =>
             $('orders-panel').classList.toggle('collapsed'));
-        // Shop tab pills — switch between Shop and Build content sections.
-        // Clicking the panel header (h2/toggle arrow) still collapses the whole panel.
-        function switchShopTab(tab) {
-            const isShop = tab === 'shop';
-            $('shop-tab-shop').classList.toggle('active', isShop);
-            $('shop-tab-build').classList.toggle('active', !isShop);
-            $('shop-tab-shop-content').classList.toggle('hidden', !isShop);
-            $('shop-tab-build-content').classList.toggle('hidden', isShop);
+        // ── Bottom-left launcher buttons (Upgrade / Build / Research) ──
+        // Each button opens the shared popover panel to its own section. Tapping
+        // the button of the already-open section closes the panel again, so the
+        // launcher row doubles as the show/hide toggle. Every button carries its
+        // own click handler (no header/tab propagation dance), which is what made
+        // the old Shop/Build tabs "do nothing" on some mobile browsers.
+        const SHOP_SECTIONS = ['upgrade', 'build', 'research'];
+        function showSection(sec) {
+            SHOP_SECTIONS.forEach(s =>
+                $('shop-sec-' + s).classList.toggle('hidden', s !== sec));
+            document.querySelectorAll('.launcher-btn').forEach(b =>
+                b.classList.toggle('active', b.dataset.sec === sec));
+            $('shop-panel').classList.remove('hidden');
         }
-        function openShopTab(tab) {
-            $('shop-panel').classList.remove('collapsed');
-            switchShopTab(tab);
+        function closeShopPanel() {
+            $('shop-panel').classList.add('hidden');
+            document.querySelectorAll('.launcher-btn').forEach(b => b.classList.remove('active'));
+        }
+        function toggleSection(sec) {
             SC.sfx.play('click');
+            const open = !$('shop-panel').classList.contains('hidden');
+            const btn = document.querySelector('.launcher-btn[data-sec="' + sec + '"]');
+            if (open && btn && btn.classList.contains('active')) closeShopPanel();
+            else showSection(sec);
         }
-        $('shop-tab-shop').addEventListener('click', e => { e.stopPropagation(); openShopTab('shop'); });
-        $('shop-tab-build').addEventListener('click', e => { e.stopPropagation(); openShopTab('build'); });
-        // Collapse/expand when the header itself is tapped — but never when the
-        // tap lands on a tab pill. Relying on the tab's stopPropagation alone
-        // was fragile on some mobile browsers: the header's handler still ran,
-        // toggling the panel shut again right after the tab opened it, so the
-        // Shop/Build buttons appeared to "do nothing". This target check is
-        // deterministic regardless of event-propagation quirks.
-        $('shop-header').addEventListener('click', e => {
-            if (e.target.closest('.shop-tab')) return;
-            $('shop-panel').classList.toggle('collapsed');
-        });
+        document.querySelectorAll('.launcher-btn').forEach(b =>
+            b.addEventListener('click', e => { e.stopPropagation(); toggleSection(b.dataset.sec); }));
 
         $('gameover-restart').addEventListener('click', () => {
             SC.save.clear();
@@ -1133,9 +1134,10 @@ SC.ui = (function() {
         updateDifficultyPicker();
         if (window.innerWidth <= 768) {
             $('orders-panel').classList.add('collapsed');
-            $('shop-panel').classList.add('collapsed');
             $('dev-panel').classList.add('collapsed');
         }
+        // The bottom-left Shop popover (#shop-panel) starts hidden on every
+        // viewport now — it opens only when a launcher button is tapped.
         // Headless verification hook (see CLAUDE.md): open the menu on load
         if (new URLSearchParams(location.search).has('menu')) openMenu();
         // ...and/or the research tree overlay

--- a/supply-chain/style.css
+++ b/supply-chain/style.css
@@ -233,7 +233,11 @@ html, body {
     overflow: hidden;
 }
 #orders-panel { top: 1rem; right: 1rem; }
-#shop-panel { bottom: 1rem; left: 1rem; }
+/* Popover for the bottom-left launcher: sits just above the launcher row,
+   grows upward as its section fills in, and hides entirely when no section
+   is open. */
+#shop-panel { bottom: 4.7rem; left: 1rem; }
+#shop-panel.hidden { display: none; }
 
 .panel-header {
     display: flex;
@@ -362,39 +366,58 @@ html, body {
     margin: 0.7rem 0 0.4rem;
 }
 .shop-section-title.hidden { display: none; }
+/* Only the launcher's selected section shows; the others are display:none.
+   (`.hidden` isn't a global utility in this stylesheet — every use is scoped
+   to its element, so the section divs need their own rule.) */
+.shop-section.hidden { display: none; }
 
-/* ── Shop tab pills ─────────────────────────────── */
-.shop-tabs {
+/* ── Bottom-left launcher (Upgrade / Build / Research) ──
+   A row of three big pill buttons that open the #shop-panel popover above
+   them. Desktop shows icon + text; mobile (below) collapses each to an
+   icon-only circle. Same glassy card language as the other floating controls. */
+#shop-launcher {
+    position: fixed;
+    bottom: 1rem;
+    left: 1rem;
+    z-index: 101;
     display: flex;
-    gap: 0.3rem;
-    flex: 1;
-    justify-content: flex-end;
-    margin-right: 0.5rem;
+    gap: 0.5rem;
 }
-.shop-tab {
-    padding: 0.2rem 0.55rem;
-    border-radius: 6px;
+.launcher-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.6rem 1.05rem;
+    border-radius: 999px;
     border: 1px solid var(--card-border);
-    background: rgba(15, 23, 42, 0.4);
+    background: var(--card-bg);
     color: var(--text-secondary);
-    font-size: 0.7rem;
+    font-size: 0.92rem;
+    font-weight: 600;
     cursor: pointer;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
     transition: background 0.15s, color 0.15s, border-color 0.15s;
-    white-space: nowrap;
+}
+.launcher-btn .lb-icon { font-size: 1.2rem; line-height: 1; }
+.launcher-btn:hover { border-color: var(--accent-color); color: var(--text-primary); }
+.launcher-btn.active {
+    background: var(--accent-color);
+    border-color: var(--accent-color);
+    color: #0f172a;
+}
+.shop-hint {
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+    line-height: 1.4;
+    margin: 0.3rem 0.1rem 0.1rem;
 }
 /* Treat every in-game control as a discrete tap target: skip the browser's
    ~300ms double-tap-zoom detection so a single tap fires immediately on
    touch devices (some Android/iOS browsers otherwise swallow quick taps on
    small buttons — the "buttons do nothing on mobile" symptom). */
-.shop-tab, .shop-btn, .icon-btn, .panel-header, .panel-toggle,
+.launcher-btn, .shop-btn, .icon-btn, .panel-header, .panel-toggle,
 .mode-btn, button, select { touch-action: manipulation; }
-.shop-tab:hover { border-color: var(--accent-color); color: var(--text-primary); }
-.shop-tab.active {
-    background: rgba(56, 189, 248, 0.15);
-    border-color: var(--accent-color);
-    color: var(--text-primary);
-    font-weight: 600;
-}
 
 /* ── Research ────────────────────────────────────── */
 .research-row {
@@ -894,16 +917,18 @@ html, body {
     .hud-label-short { display: block; }
 
     #orders-panel { top: 0.5rem; right: 0.5rem; width: 170px; }
-    #shop-panel { bottom: 0.5rem; left: 0.5rem; width: 212px; }
     .panel-header { padding: 0.6rem 0.8rem; }
     .panel-header h2 { font-size: 0.85rem; }
-    /* The Shop/Build tabs already label the panel, so drop the redundant
-       "Shop" heading on phones — it was pushing the two tabs past the fixed
-       panel width, clipping "Build" (overflow:hidden) so it couldn't be
-       tapped. Tighten the tabs a touch too. */
-    #shop-header h2 { display: none; }
-    #shop-panel .shop-tabs { margin-right: 0.3rem; }
-    #shop-panel .shop-tab { padding: 0.22rem 0.45rem; font-size: 0.68rem; }
+    /* Launcher: icon-only circles on phones (text hidden), matching the
+       bottom-right mode/speed pills. The popover sits just above the row. */
+    #shop-launcher { bottom: 0.5rem; left: 0.5rem; gap: 0.4rem; }
+    .launcher-btn {
+        width: 44px; height: 44px; padding: 0;
+        justify-content: center; border-radius: 50%;
+    }
+    .launcher-btn .lb-text { display: none; }
+    .launcher-btn .lb-icon { font-size: 1.25rem; }
+    #shop-panel { bottom: 3.7rem; left: 0.5rem; width: 212px; }
     /* Float toasts above the bottom control cluster (shop / speed / mode)
        instead of on top of it. */
     #toast { bottom: 6rem; }
@@ -916,8 +941,8 @@ html, body {
    bar and the Orders panel keep clear of each other. */
 @media (max-width: 380px) {
     #orders-panel { width: 148px; }
-    /* Shop stays wide enough for both tabs (it's bottom-left, clear of the
-       top-left/orders squeeze that forces #orders-panel narrow). */
+    /* Shop popover stays roomy (it's bottom-left, clear of the top-left/
+       orders squeeze that forces #orders-panel narrow). */
     #shop-panel { width: 200px; }
     .hud-item { padding: 0.3rem 0.4rem; }
     .hud-label { font-size: 0.5rem; }

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -15,21 +15,21 @@
     <div id="results"></div>
 
     <!-- Pure logic only: no render/input/ui/main, no canvas needed -->
-    <script src="js/config.js?v=1.50.7"></script>
-    <script src="js/state.js?v=1.50.7"></script>
-    <script src="js/save.js?v=1.50.7"></script>
-    <script src="js/sfx.js?v=1.50.7"></script>
-    <script src="js/rng.js?v=1.50.7"></script>
-    <script src="js/map.js?v=1.50.7"></script>
-    <script src="js/camera.js?v=1.50.7"></script>
-    <script src="js/roads.js?v=1.50.7"></script>
-    <script src="js/factories.js?v=1.50.7"></script>
-    <script src="js/economy.js?v=1.50.7"></script>
-    <script src="js/vehicles.js?v=1.50.7"></script>
-    <script src="js/stats.js?v=1.50.7"></script>
-    <script src="js/inspect.js?v=1.50.7"></script>
-    <script src="js/research.js?v=1.50.7"></script>
-    <script src="js/placement.js?v=1.50.7"></script>
+    <script src="js/config.js?v=1.51.0"></script>
+    <script src="js/state.js?v=1.51.0"></script>
+    <script src="js/save.js?v=1.51.0"></script>
+    <script src="js/sfx.js?v=1.51.0"></script>
+    <script src="js/rng.js?v=1.51.0"></script>
+    <script src="js/map.js?v=1.51.0"></script>
+    <script src="js/camera.js?v=1.51.0"></script>
+    <script src="js/roads.js?v=1.51.0"></script>
+    <script src="js/factories.js?v=1.51.0"></script>
+    <script src="js/economy.js?v=1.51.0"></script>
+    <script src="js/vehicles.js?v=1.51.0"></script>
+    <script src="js/stats.js?v=1.51.0"></script>
+    <script src="js/inspect.js?v=1.51.0"></script>
+    <script src="js/research.js?v=1.51.0"></script>
+    <script src="js/placement.js?v=1.51.0"></script>
 
     <script>
     let passed = 0, failed = 0;


### PR DESCRIPTION
The bottom-left Shop panel's header tabs were unreliable on mobile — and
the section divs were never actually hidden (`.hidden` is only ever scoped
per-element in this stylesheet, and there was no rule for the content
divs), so switching tabs did nothing visible.

Replace the collapsible panel + header tabs with a row of three launcher
buttons (⚡ Upgrade / 🏗️ Build / 🔬 Research) in the bottom-left. Each opens
a shared popover above the row to its own section; tapping the active one
closes it. Desktop shows big icon+text pills; mobile collapses them to
icon-only circles. Every button carries its own click handler, dropping
the fragile header/tab event-propagation dance.

Also adds `.shop-section.hidden { display:none }` so only the selected
section renders, and moves the Research shortcut into its own section.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Stiwds2PiUdJ6AR7wnAGY9