### PR TITLE
Factory status pill: only count on-site ingredient stock, not in-transit

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
                 </svg></span>
         </a>
 
-        <a href="supply-chain/index.html?v=1.51.0" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.51.1" class="card card-metal" id="card-supply-chain">
             <div class="beta-badge">BETA</div>
             <div>
                 <div class="card-icon">🏭</div>

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Supply Chain Tycoon | Niklas Billgren</title>
-    <link rel="stylesheet" href="style.css?v=1.51.0">
+    <link rel="stylesheet" href="style.css?v=1.51.1">
 </head>
 <body>
     <canvas id="gameCanvas"></canvas>
@@ -311,24 +311,24 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=1.51.0"></script>
-    <script src="js/state.js?v=1.51.0"></script>
-    <script src="js/save.js?v=1.51.0"></script>
-    <script src="js/sfx.js?v=1.51.0"></script>
-    <script src="js/rng.js?v=1.51.0"></script>
-    <script src="js/map.js?v=1.51.0"></script>
-    <script src="js/camera.js?v=1.51.0"></script>
-    <script src="js/roads.js?v=1.51.0"></script>
-    <script src="js/factories.js?v=1.51.0"></script>
-    <script src="js/economy.js?v=1.51.0"></script>
-    <script src="js/vehicles.js?v=1.51.0"></script>
-    <script src="js/stats.js?v=1.51.0"></script>
-    <script src="js/inspect.js?v=1.51.0"></script>
-    <script src="js/research.js?v=1.51.0"></script>
-    <script src="js/placement.js?v=1.51.0"></script>
-    <script src="js/render.js?v=1.51.0"></script>
-    <script src="js/input.js?v=1.51.0"></script>
-    <script src="js/ui.js?v=1.51.0"></script>
-    <script src="js/main.js?v=1.51.0"></script>
+    <script src="js/config.js?v=1.51.1"></script>
+    <script src="js/state.js?v=1.51.1"></script>
+    <script src="js/save.js?v=1.51.1"></script>
+    <script src="js/sfx.js?v=1.51.1"></script>
+    <script src="js/rng.js?v=1.51.1"></script>
+    <script src="js/map.js?v=1.51.1"></script>
+    <script src="js/camera.js?v=1.51.1"></script>
+    <script src="js/roads.js?v=1.51.1"></script>
+    <script src="js/factories.js?v=1.51.1"></script>
+    <script src="js/economy.js?v=1.51.1"></script>
+    <script src="js/vehicles.js?v=1.51.1"></script>
+    <script src="js/stats.js?v=1.51.1"></script>
+    <script src="js/inspect.js?v=1.51.1"></script>
+    <script src="js/research.js?v=1.51.1"></script>
+    <script src="js/placement.js?v=1.51.1"></script>
+    <script src="js/render.js?v=1.51.1"></script>
+    <script src="js/input.js?v=1.51.1"></script>
+    <script src="js/ui.js?v=1.51.1"></script>
+    <script src="js/main.js?v=1.51.1"></script>
 </body>
 </html>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -1,7 +1,7 @@
 // Supply Chain Tycoon — constants, materials, recipes, prices
 window.SC = window.SC || {};
 
-SC.VERSION = '1.51.0';
+SC.VERSION = '1.51.1';
 
 SC.CONFIG = {
     // Base playing-field size. The *current* size lives in

--- a/supply-chain/js/render.js
+++ b/supply-chain/js/render.js
@@ -2257,7 +2257,8 @@ SC.render = (function() {
         // "in stock / ordered" — how many units are crafted and sitting at
         // the factory waiting for a truck, over how many are still outstanding
         // (waiting + queued + currently crafting). If actively producing, a
-        // second group shows each ingredient's stock (have / need).
+        // second group shows each ingredient's stock (have / need) — "have"
+        // being what's physically on-site, not counting units still in transit.
         if (n.kind === 'factory' && !forSale) {
             // Finished goods waiting at the factory: crafted output becomes a
             // pickup job here and stays on site until a truck actually loads
@@ -2289,25 +2290,12 @@ SC.render = (function() {
                 for (const m in n.inv) {
                     if (queueNeeds[m]) queueHave[m] = (queueHave[m] || 0) + n.inv[m];
                 }
-                // Raw materials en route (unassigned jobs + on trucks).
-                let incoming = {};
-                if (SC.state.jobs) {
-                    for (const job of SC.state.jobs) {
-                        if (job.type === 'raw' && job.drop === n) incoming[job.item] = (incoming[job.item] || 0) + 1;
-                    }
-                }
-                if (SC.state.trucks) {
-                    for (const truck of SC.state.trucks) {
-                        if (truck.jobs) {
-                            for (const job of truck.jobs) {
-                                if (job.type === 'raw' && job.drop === n) incoming[job.item] = (incoming[job.item] || 0) + 1;
-                            }
-                        }
-                    }
-                }
-                for (const m in incoming) {
-                    if (queueNeeds[m]) queueHave[m] = (queueHave[m] || 0) + incoming[m];
-                }
+                // NOTE: material still en route (unassigned jobs or riding a
+                // truck) is deliberately NOT counted here. "have / need" means
+                // stock physically on-site — a unit only counts once a truck
+                // has actually dropped it (task.have via receiveRaw, or loose
+                // n.inv). Counting in-transit units made the pill read 1/1
+                // (full, green) before anything had been delivered.
             }
             const needsKeys = Object.keys(queueNeeds);
 

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -15,21 +15,21 @@
     <div id="results"></div>
 
     <!-- Pure logic only: no render/input/ui/main, no canvas needed -->
-    <script src="js/config.js?v=1.51.0"></script>
-    <script src="js/state.js?v=1.51.0"></script>
-    <script src="js/save.js?v=1.51.0"></script>
-    <script src="js/sfx.js?v=1.51.0"></script>
-    <script src="js/rng.js?v=1.51.0"></script>
-    <script src="js/map.js?v=1.51.0"></script>
-    <script src="js/camera.js?v=1.51.0"></script>
-    <script src="js/roads.js?v=1.51.0"></script>
-    <script src="js/factories.js?v=1.51.0"></script>
-    <script src="js/economy.js?v=1.51.0"></script>
-    <script src="js/vehicles.js?v=1.51.0"></script>
-    <script src="js/stats.js?v=1.51.0"></script>
-    <script src="js/inspect.js?v=1.51.0"></script>
-    <script src="js/research.js?v=1.51.0"></script>
-    <script src="js/placement.js?v=1.51.0"></script>
+    <script src="js/config.js?v=1.51.1"></script>
+    <script src="js/state.js?v=1.51.1"></script>
+    <script src="js/save.js?v=1.51.1"></script>
+    <script src="js/sfx.js?v=1.51.1"></script>
+    <script src="js/rng.js?v=1.51.1"></script>
+    <script src="js/map.js?v=1.51.1"></script>
+    <script src="js/camera.js?v=1.51.1"></script>
+    <script src="js/roads.js?v=1.51.1"></script>
+    <script src="js/factories.js?v=1.51.1"></script>
+    <script src="js/economy.js?v=1.51.1"></script>
+    <script src="js/vehicles.js?v=1.51.1"></script>
+    <script src="js/stats.js?v=1.51.1"></script>
+    <script src="js/inspect.js?v=1.51.1"></script>
+    <script src="js/research.js?v=1.51.1"></script>
+    <script src="js/placement.js?v=1.51.1"></script>
 
     <script>
     let passed = 0, failed = 0;


### PR DESCRIPTION
The per-ingredient "have / need" group counted raw materials still en
route (unassigned jobs + units riding a truck) toward "have", so the
pill read 1/1 (full, green) before anything had actually been delivered.
Count only what's physically on-site (task.have via receiveRaw, plus
loose n.inv); a unit now flips to "have" when a truck actually drops it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011rZUzZ1NDoFSaEDEfZMu7V