### PR TITLE
CLAUDE.md: make "every change must land on master" explicit

### DIFF
--- a/supply-chain/CLAUDE.md
+++ b/supply-chain/CLAUDE.md
@@ -21,11 +21,21 @@ Don't couple the two again.)
   then **commit**, **merge in the latest `origin/master`** (fetch + merge,
   resolving any conflicts — this project runs several agent sessions in
   parallel, hence the "Merge master: reconcile…" commits throughout
-  history), and **push**, all without waiting to be asked. Only skip the
-  merge/push step if the repo's git workflow for this session pins you to
-  a review branch instead (e.g. a PR-based harness) — in that case commit
-  and push to that branch and let the normal review/merge flow take it
-  from there.
+  history), and **push**, all without waiting to be asked.
+- **The maintainer always wants every change to end up merged to
+  `master`** — that's the branch GitHub Pages deploys, so work stranded on
+  a feature branch is not "done." So:
+  - If this session is **not** pinned to a review branch, push straight to
+    `master` (after merging the latest `origin/master` in, as above).
+  - If the session **is** pinned to a review branch (e.g. a PR-based
+    harness set a designated branch you must develop on and forbade pushing
+    elsewhere), push to that branch — but the goal is still `master`.
+    Follow it through: ensure the PR is opened and merged (enable
+    auto-merge if the harness supports it) rather than leaving the branch
+    unmerged. Note "merge in the latest `origin/master`" means pulling
+    master's commits *into* your branch; it is **not** the same as landing
+    your branch *onto* master — the change isn't shipped until master
+    contains it.
 - Bump `SC.VERSION` (top of `js/config.js`) on every commit that ships a
   user-visible change, and update the `?v=X.Y.Z` cache-busting query on
   every local `<script>`/`<link>` tag in `index.html` AND `tests.html`,


### PR DESCRIPTION
Follow-up to #96 (already merged).

The maintainer always wants changes merged to `master` (the branch GitHub Pages deploys), not left on a feature branch. This clarifies the standing instructions:

- If the session is **not** pinned to a review branch, push straight to `master`.
- If it **is** pinned (PR-based harness), push to the branch but follow it through to a merged PR — the change isn't shipped until `master` contains it.
- Notes that "merge in the latest `origin/master`" (pulling master *into* the branch) is not the same as landing the branch *onto* master.

Docs-only change — no code, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rZUzZ1NDoFSaEDEfZMu7V

---
_Generated by [Claude Code](https://claude.ai/code/session_011rZUzZ1NDoFSaEDEfZMu7V)_