### PR TITLE
Yard/HQ parking lots persist and size off the whole fleet

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
                 </svg></span>
         </a>
 
-        <a href="supply-chain/index.html?v=1.51.2" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.51.3" class="card card-metal" id="card-supply-chain">
             <div class="beta-badge">BETA</div>
             <div>
                 <div class="card-icon">🏭</div>

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.51.2';</script>
+    <script>window.SC_VERSION = '1.51.3';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>

--- a/supply-chain/js/render.js
+++ b/supply-chain/js/render.js
@@ -2495,9 +2495,12 @@ SC.render = (function() {
     // a building (HQ/DC). Screen-space, so it must be called while drawing the
     // owning node (depth-sorted with it).
     function drawYardParking(node, g, z, full) {
-        const parked = SC.state.trucks.filter(
-            t => t.homeYard === node && !t.path && t.jobs.length === 0);
-        if (!full && parked.length === 0) return; // no apron under an empty building
+        // Size the lot off the whole fleet homed here, not just who's currently
+        // parked, so it doesn't blink away every time a truck heads out on a
+        // job and keeps growing as the roster does.
+        const homed = SC.state.trucks.filter(t => t.homeYard === node);
+        if (!full && homed.length === 0) return; // no apron until this building has ever hosted a truck
+        const parked = homed.filter(t => !t.path && t.jobs.length === 0);
         // iso ground basis in screen space (already includes zoom)
         const o = S(node.x, node.y);
         const ux = S(node.x + 1, node.y).x - o.x, uy = S(node.x + 1, node.y).y - o.y;
@@ -2507,8 +2510,8 @@ SC.render = (function() {
 
         const cols = 2;
         const colGap = 15 * z, rowGap = 25 * z; // screen spacing between stalls
-        const shown = Math.min(parked.length, 8); // cap the sprite count
-        const rows = Math.max(full ? 2 : 1, Math.ceil(shown / cols));
+        const fleet = Math.min(homed.length, 8); // cap the lot size (stalls), not just the sprite count
+        const rows = Math.max(full ? 2 : 1, Math.ceil(fleet / cols));
 
         // Apron centered on the grid. For a building we push the lot forward
         // (toward the camera, +v) so it sits in front of the doors, not under
@@ -2553,6 +2556,7 @@ SC.render = (function() {
         // down its stall between the painted dividers. Fill the front row
         // (nearest the camera) first.
         const parkAng = Math.atan2(vhy, vhx);
+        const shown = Math.min(parked.length, fleet); // trucks out on a job just leave their stall empty
         for (let i = 0; i < shown; i++) {
             const c = i % cols, r = rows - 1 - ((i / cols) | 0);
             const s = stall(c, r);

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.51.2';</script>
+    <script>window.SC_VERSION = '1.51.3';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'sfx', 'rng', 'map', 'camera',


### PR DESCRIPTION
## Summary
- The parking apron under HQ/DC nodes only drew when a truck happened to be currently parked there, so it disappeared the instant every truck homed at that node was out on a delivery.
- `drawYardParking` (supply-chain/js/render.js) now sizes the lot off the whole fleet ever homed at a node (capped at 8 stalls), not the currently-idle snapshot — trucks out on jobs just leave their stall visually empty instead of the whole lot vanishing.
- Dedicated truck-yard nodes get the same fleet-sized lot, so it keeps expanding as more trucks are stationed there (around HQ or any truck depot).
- Bumped `SC_VERSION` (1.51.2 → 1.51.3) per the project's cache-busting convention.

## Test plan
- [x] Headless logic suite: `tests.html` → 853 passed / 0 failed
- [x] Visual smoke: `index.html?probe=40&yard=1` screenshot — confirmed HQ's apron stays visible with empty stalls while trucks are out, and the dedicated Yard node shows its own persistent lot


---
_Generated by [Claude Code](https://claude.ai/code/session_01LRgYCLHFgmT7FhmM3zVm97)_