### PR TITLE
Reorder shop launcher (Research, Build, Upgrade) and open research tree directly

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
                 </svg></span>
         </a>
 
-        <a href="supply-chain/index.html?v=1.51.2" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.51.3" class="card card-metal" id="card-supply-chain">
             <div class="beta-badge">BETA</div>
             <div>
                 <div class="card-icon">🏭</div>

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.51.2';</script>
+    <script>window.SC_VERSION = '1.51.3';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>
@@ -161,14 +161,14 @@
     </div>
 
     <div id="shop-launcher">
-        <button class="launcher-btn" data-sec="upgrade" title="Upgrade — buy trucks &amp; upgrades">
-            <span class="lb-icon">⚡</span><span class="lb-text">Upgrade</span>
+        <button class="launcher-btn" data-sec="research" title="Research — unlock new tech">
+            <span class="lb-icon">🔬</span><span class="lb-text">Research</span>
         </button>
         <button class="launcher-btn" data-sec="build" title="Build — yards, junctions, factories">
             <span class="lb-icon">🏗️</span><span class="lb-text">Build</span>
         </button>
-        <button class="launcher-btn" data-sec="research" title="Research — unlock new tech">
-            <span class="lb-icon">🔬</span><span class="lb-text">Research</span>
+        <button class="launcher-btn" data-sec="upgrade" title="Upgrade — buy trucks &amp; upgrades">
+            <span class="lb-icon">⚡</span><span class="lb-text">Upgrade</span>
         </button>
     </div>
 

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -1001,6 +1001,7 @@ SC.ui = (function() {
         }
         function toggleSection(sec) {
             SC.sfx.play('click');
+            if (sec === 'research') { openResearchTree(); return; } // skip the shop-panel middle step
             const open = !$('shop-panel').classList.contains('hidden');
             const btn = document.querySelector('.launcher-btn[data-sec="' + sec + '"]');
             if (open && btn && btn.classList.contains('active')) closeShopPanel();

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.51.2';</script>
+    <script>window.SC_VERSION = '1.51.3';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'sfx', 'rng', 'map', 'camera',


### PR DESCRIPTION
Research is now the leftmost launcher button, followed by Build then
Upgrade. Tapping Research also skips the shop-panel middle step and
opens the research tree overlay directly, removing the extra click.