### PR TITLE
supply-chain: cache parsed colors and hoist nodeSpec lookup sets

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
                 </svg></span>
         </a>
 
-        <a href="supply-chain/index.html?v=1.52.0" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.52.1" class="card card-metal" id="card-supply-chain">
             <div class="beta-badge">BETA</div>
             <div>
                 <div class="card-icon">🏭</div>

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.52.0';</script>
+    <script>window.SC_VERSION = '1.52.1';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>

--- a/supply-chain/js/render-core.js
+++ b/supply-chain/js/render-core.js
@@ -34,6 +34,14 @@ SC.render = (function() {
     const ISO = SC.camera.ISO;
     let floaters = [];                      // (unused placeholder; floaters live in render-actors)
 
+    // Parsed-colour cache. mix()/shade()/rgba()/hexToRgb() are called dozens of
+    // times per entity per frame, almost always with a constant '#rrggbb'
+    // palette colour, and each call otherwise re-parses the same string. We
+    // memoise ONLY the '#hex' inputs — that set is small and fixed (goods
+    // colours, node bases, sky keyframes) so the cache is bounded — and leave
+    // the dynamic 'rgb(...)' blend strings (which vary every frame) uncached so
+    // the map can't grow without limit.
+    const _rgbCache = new Map();
     function hexToRgb(hex) {
         // Accept both '#rrggbb' and 'rgb(r, g, b)' so mix()/shade() output can
         // be fed back in (the day/night sky blends colours in several steps).
@@ -41,8 +49,11 @@ SC.render = (function() {
             const m = hex.match(/-?\d+/g);
             return { r: +m[0], g: +m[1], b: +m[2] };
         }
-        const h = hex.replace('#', '');
-        return { r: parseInt(h.slice(0, 2), 16), g: parseInt(h.slice(2, 4), 16), b: parseInt(h.slice(4, 6), 16) };
+        let c = _rgbCache.get(hex);
+        if (c) return c;
+        c = { r: parseInt(hex.slice(1, 3), 16), g: parseInt(hex.slice(3, 5), 16), b: parseInt(hex.slice(5, 7), 16) };
+        _rgbCache.set(hex, c);
+        return c;
     }
 
     function shade(hex, amt) {

--- a/supply-chain/js/render-network.js
+++ b/supply-chain/js/render-network.js
@@ -176,6 +176,10 @@
         R.ctx.lineCap = 'butt';   // pasture fence) inherit this animated offset
     }
 
+    // Hoisted out of nodeSpec (called ~2×/node/frame) so these lookup sets
+    // aren't reallocated on every call.
+    const FACTORY_LOW = new Set(['bread', 'shoes', 'steel', 'wire']);
+    const FACTORY_TALL = new Set(['circuit', 'car']);
     function nodeSpec(n) {
         if (n.kind === 'supplier') {
             const base = SC.colorOf(n.mat);
@@ -185,9 +189,9 @@
         }
         if (n.kind === 'factory') {
             let base = '#6b7a90', h = 32, stories = 3, stack = true;
-            if (['bread', 'shoes', 'steel', 'wire'].includes(n.recipe)) {
+            if (FACTORY_LOW.has(n.recipe)) {
                 base = '#7c8b9f'; h = 24; stories = 2; stack = true;
-            } else if (['circuit', 'car'].includes(n.recipe)) {
+            } else if (FACTORY_TALL.has(n.recipe)) {
                 base = '#5c6b7e'; h = 42; stories = 4; stack = false;
             } else if (n.recipe === 'robot') {
                 base = '#4b5563'; h = 52; stories = 5; stack = false;

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.51.3';</script>
+    <script>window.SC_VERSION = '1.52.1';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'sfx', 'rng', 'map', 'camera',


### PR DESCRIPTION
Memoize hexToRgb for constant '#rrggbb' palette inputs so mix/shade/rgba
(140+ call sites, many per-entity per-frame) stop re-parsing the same
fixed palette strings each frame. Dynamic 'rgb(...)' blend strings stay
uncached so the map can't grow unbounded. Also hoist nodeSpec's factory
recipe .includes() arrays into module-level Sets so they aren't
reallocated ~2x per node per frame.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0111jGyTP4uY4zTgVC43sW2H