### PR TITLE
Tighten yard/HQ parking lot spacing and cap fleet display at 6

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
                 </svg></span>
         </a>
 
-        <a href="supply-chain/index.html?v=1.52.1" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.52.2" class="card card-metal" id="card-supply-chain">
             <div class="beta-badge">BETA</div>
             <div>
                 <div class="card-icon">🏭</div>

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.52.1';</script>
+    <script>window.SC_VERSION = '1.52.2';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>

--- a/supply-chain/js/render-network.js
+++ b/supply-chain/js/render-network.js
@@ -878,8 +878,8 @@
         const uhx = ux / ul, uhy = uy / ul, vhx = vx / vl, vhy = vy / vl;
 
         const cols = 2;
-        const colGap = 15 * z, rowGap = 25 * z; // screen spacing between stalls
-        const fleet = Math.min(homed.length, 8); // cap the lot size (stalls), not just the sprite count
+        const colGap = 11 * z, rowGap = 25 * z; // screen spacing between stalls
+        const fleet = Math.min(homed.length, 6); // cap the lot size (stalls), not just the sprite count
         const rows = Math.max(full ? 2 : 1, Math.ceil(fleet / cols));
 
         // Apron centered on the grid. For a building we push the lot forward

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.52.1';</script>
+    <script>window.SC_VERSION = '1.52.2';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'sfx', 'rng', 'map', 'camera',


### PR DESCRIPTION
## Summary
- `drawYardParking` (`supply-chain/js/render-network.js`) now spaces stalls closer side-by-side (`colGap` 15→11 * z) for a denser-looking lot. Row spacing (front-to-back) is left at 25 * z — trucks are already close to nose-to-tail there relative to their own footprint length, so tightening it further visibly clips consecutive rows (verified by screenshot before settling on this value).
- The displayed fleet cap (lot size + sprite count) drops from 8 to 6 trucks per yard/HQ apron.

## Test plan
- [x] Headless logic suite: `tests.html` → 853 passed / 0 failed
- [x] Visual smoke: scripted an 11-truck HQ fleet and screenshotted the apron — confirmed it caps at 6 stalls and sits noticeably tighter than before, with no new visual clipping beyond the pre-existing baseline


---
_Generated by [Claude Code](https://claude.ai/code/session_01LRgYCLHFgmT7FhmM3zVm97)_