### PR TITLE
supply-chain: add Standing Orders research to auto-accept contracts

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
                 </svg></span>
         </a>
 
-        <a href="supply-chain/index.html?v=1.52.0" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.52.1" class="card card-metal" id="card-supply-chain">
             <div class="beta-badge">BETA</div>
             <div>
                 <div class="card-icon">🏭</div>

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -121,19 +121,19 @@ that ambient animation as its background — it now lives independently at
   ~3× faster order arrivals plus a higher concurrent-order cap. One at
   a time; the timer survives saves (`promoUntil`).
 - **Research**: one project at a time, paid upfront, takes real time,
-  then unlocks its effect — `SC.RESEARCH` in `config.js`. Fourteen techs:
-  standalone Road Junctions (cheap, early — unlocks placeable junctions,
-  see Growth above); Site Requisition (manual placement); then four
-  branches — Credit Line II/III → Premium Contracts (+15% payouts) →
-  Regional Marketing (customer DCs arrive 40% sooner), Marketing Blitz
-  (unlocks promotions, above), and Standing Orders (unlocks a Shop toggle
-  that auto-accepts every contract offer instantly instead of showing the
-  Accept/Decline card — 56s research, 30% shorter than a same-tier
-  single-effect tech); Asphalt Paving (highways) →
-  Overdrive Engines (+3 truck-speed cap) → Bulk Logistics (+2 capacity
-  cap); Fertilizer Program (+50% supplier regen) → Factory Automation
-  (+3 factory-speed cap) and Preservatives (+25% order deadlines).
-  Effect fields are generic — additive bonuses (`creditBonus`,
+  then unlocks its effect — `SC.RESEARCH` in `config.js`. Every tech's
+  time is ×0.7 of its original value (research trains 30% faster across
+  the board). Fourteen techs: standalone Road Junctions (cheap, early —
+  unlocks placeable junctions, see Growth above); Site Requisition
+  (manual placement); then four branches — Credit Line II/III → Premium
+  Contracts (+15% payouts) → Regional Marketing (customer DCs arrive 40%
+  sooner), Marketing Blitz (unlocks promotions, above), and Standing
+  Orders (unlocks a Shop toggle that auto-accepts every contract offer
+  instantly instead of showing the Accept/Decline card); Asphalt Paving
+  (highways) → Overdrive Engines (+3 truck-speed cap) → Bulk Logistics
+  (+2 capacity cap); Fertilizer Program (+50% supplier regen) → Factory
+  Automation (+3 factory-speed cap) and Preservatives (+25% order
+  deadlines). Effect fields are generic — additive bonuses (`creditBonus`,
   `payoutBonus`, `deadlineBonus`, `supplierRegenBonus`) sum via
   `research.bonusSum`, `customerSpawnMult` multiplies, and
   `upgradeMaxBonus` raises upgrade caps. The Shop panel keeps a

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -121,12 +121,15 @@ that ambient animation as its background — it now lives independently at
   ~3× faster order arrivals plus a higher concurrent-order cap. One at
   a time; the timer survives saves (`promoUntil`).
 - **Research**: one project at a time, paid upfront, takes real time,
-  then unlocks its effect — `SC.RESEARCH` in `config.js`. Thirteen techs:
+  then unlocks its effect — `SC.RESEARCH` in `config.js`. Fourteen techs:
   standalone Road Junctions (cheap, early — unlocks placeable junctions,
   see Growth above); Site Requisition (manual placement); then four
   branches — Credit Line II/III → Premium Contracts (+15% payouts) →
-  Regional Marketing (customer DCs arrive 40% sooner) and Marketing Blitz
-  (unlocks promotions, above); Asphalt Paving (highways) →
+  Regional Marketing (customer DCs arrive 40% sooner), Marketing Blitz
+  (unlocks promotions, above), and Standing Orders (unlocks a Shop toggle
+  that auto-accepts every contract offer instantly instead of showing the
+  Accept/Decline card — 56s research, 30% shorter than a same-tier
+  single-effect tech); Asphalt Paving (highways) →
   Overdrive Engines (+3 truck-speed cap) → Bulk Logistics (+2 capacity
   cap); Fertilizer Program (+50% supplier regen) → Factory Automation
   (+3 factory-speed cap) and Preservatives (+25% order deadlines).
@@ -197,7 +200,11 @@ that ambient animation as its background — it now lives independently at
   panel. Unlike a normal missed order (just a tally, no cost), missing
   an accepted contract's deadline (`expireOrder`) charges a penalty
   proportional to however many units are still undelivered
-  (`CONTRACT_PENALTY_MULT × missingUnits × perUnitRate`).
+  (`CONTRACT_PENALTY_MULT × missingUnits × perUnitRate`). Standing
+  Orders research unlocks a Shop toggle (`SC.state.autoAcceptContracts`,
+  persisted in saves) that skips the Accept/Decline card entirely —
+  `economy.tick` calls `acceptContract` right after `rollContractOffer`
+  whenever the tech is done and the toggle is on.
 - **Dev tools panel**: a lasting ☰-menu toggle ("🛠 Dev tools", persisted
   in localStorage like Sound — `?dev=1` also forces it on for one load).
   Not a normal gameplay feature. Shows a collapsible panel under the

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.52.0';</script>
+    <script>window.SC_VERSION = '1.52.1';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>
@@ -126,6 +126,11 @@
                 <button class="shop-btn hidden" id="btn-promo">
                     <span class="sname">📣 Run promotion</span>
                     <span class="price">$600</span>
+                </button>
+
+                <button class="shop-btn build-btn hidden" id="btn-auto-accept" title="Auto-accept every contract offer instantly instead of showing the Accept/Decline card">
+                    <span class="sname">🤝 Auto-accept contracts</span>
+                    <span class="price">Off</span>
                 </button>
             </div>
 

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -242,73 +242,75 @@ SC.DIFFICULTY_ORDER = ['easy', 'normal', 'hard', 'sandbox'];
 // seconds, then unlocks its effect. `requires` lists prerequisite ids.
 // RESEARCH_ORDER fixes menu display order (object key order isn't a
 // contract to rely on across engines).
+// Research times are all ×0.7 of their original values (30% quicker
+// across the board) — e.g. intersections was 20s, junctions 50s, etc.
 SC.RESEARCH = {
     intersections: {
-        name: 'Road Crossings', emoji: '➕', cost: 150, time: 20, requires: [],
+        name: 'Road Crossings', emoji: '➕', cost: 150, time: 14, requires: [],
         desc: 'Unlocks intersections — place a junction exactly where two roads cross to connect them.'
     },
     junctions: {
-        name: 'Road Junctions', emoji: '🔀', cost: 350, time: 50, requires: ['intersections'],
+        name: 'Road Junctions', emoji: '🔀', cost: 350, time: 35, requires: ['intersections'],
         desc: 'Unlocks placeable junctions — waypoints to fork, merge or reroute roads.'
     },
     manualPlacement: {
-        name: 'Site Requisition', emoji: '📍', cost: 900, time: 70, requires: [],
+        name: 'Site Requisition', emoji: '📍', cost: 900, time: 49, requires: [],
         desc: 'Place a supplier or factory anywhere on the map yourself, for a premium.'
     },
     creditLine2: {
-        name: 'Credit Line II', emoji: '💳', cost: 700, time: 50, requires: [],
+        name: 'Credit Line II', emoji: '💳', cost: 700, time: 35, requires: [],
         desc: 'Raises your credit limit by $1,000.', creditBonus: 1000
     },
     creditLine3: {
-        name: 'Credit Line III', emoji: '💳', cost: 1800, time: 100, requires: ['creditLine2'],
+        name: 'Credit Line III', emoji: '💳', cost: 1800, time: 70, requires: ['creditLine2'],
         desc: 'Raises your credit limit by another $2,000.', creditBonus: 2000
     },
     pavedRoads: {
-        name: 'Asphalt Paving', emoji: '🛣️', cost: 800, time: 60, requires: [],
+        name: 'Asphalt Paving', emoji: '🛣️', cost: 800, time: 42, requires: [],
         desc: 'Upgrade individual roads to highways — trucks drive 60% faster on them.'
     },
     overdrive: {
-        name: 'Overdrive Engines', emoji: '⚡', cost: 1600, time: 90, requires: ['pavedRoads'],
+        name: 'Overdrive Engines', emoji: '⚡', cost: 1600, time: 63, requires: ['pavedRoads'],
         desc: 'Raises the Truck Speed upgrade cap by 3 levels.',
         upgradeMaxBonus: { truckSpeed: 3 }
     },
     fertilizer: {
-        name: 'Fertilizer Program', emoji: '🌱', cost: 1000, time: 70, requires: [],
+        name: 'Fertilizer Program', emoji: '🌱', cost: 1000, time: 49, requires: [],
         desc: 'All suppliers regenerate stock 50% faster.',
         supplierRegenBonus: 0.5
     },
     automation: {
-        name: 'Factory Automation', emoji: '🦾', cost: 2000, time: 110, requires: ['fertilizer'],
+        name: 'Factory Automation', emoji: '🦾', cost: 2000, time: 77, requires: ['fertilizer'],
         desc: 'Raises the Factory Speed upgrade cap by 3 levels.',
         upgradeMaxBonus: { factorySpeed: 3 }
     },
     premiumContracts: {
-        name: 'Premium Contracts', emoji: '💰', cost: 1400, time: 80, requires: ['creditLine2'],
+        name: 'Premium Contracts', emoji: '💰', cost: 1400, time: 56, requires: ['creditLine2'],
         desc: 'Negotiate better rates — all order payouts +15%.',
         payoutBonus: 0.15
     },
     rapidExpansion: {
-        name: 'Regional Marketing', emoji: '🏙️', cost: 2200, time: 120, requires: ['premiumContracts'],
+        name: 'Regional Marketing', emoji: '🏙️', cost: 2200, time: 84, requires: ['premiumContracts'],
         desc: 'Word gets around — new customer DCs appear 40% sooner.',
         customerSpawnMult: 0.6
     },
     coldStorage: {
-        name: 'Preservatives', emoji: '🧊', cost: 1200, time: 80, requires: ['fertilizer'],
+        name: 'Preservatives', emoji: '🧊', cost: 1200, time: 56, requires: ['fertilizer'],
         desc: 'Goods keep longer — order deadlines +25%.',
         deadlineBonus: 0.25
     },
     bulkLogistics: {
-        name: 'Bulk Logistics', emoji: '🏗️', cost: 2400, time: 120, requires: ['overdrive'],
+        name: 'Bulk Logistics', emoji: '🏗️', cost: 2400, time: 84, requires: ['overdrive'],
         desc: 'Raises the Truck Capacity upgrade cap by 2 levels.',
         upgradeMaxBonus: { truckCapacity: 2 }
     },
     promotions: {
-        name: 'Marketing Blitz', emoji: '📣', cost: 1800, time: 100, requires: ['premiumContracts'],
+        name: 'Marketing Blitz', emoji: '📣', cost: 1800, time: 70, requires: ['premiumContracts'],
         desc: 'Unlocks paid promotions: a 45s burst of extra orders, repeatable from the Shop.'
     },
     autoAcceptContracts: {
-        // Baseline for a single-effect tech at this tier is ~80s (see
-        // premiumContracts/coldStorage); 30% shorter puts this at 56s.
+        // Same-tier single-effect techs (premiumContracts/coldStorage)
+        // land at 56s post-reduction, so this one matches.
         name: 'Standing Orders', emoji: '🤝', cost: 1000, time: 56, requires: ['premiumContracts'],
         desc: 'Unlocks a Shop toggle to auto-accept every contract offer instantly.'
     }

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -305,11 +305,17 @@ SC.RESEARCH = {
     promotions: {
         name: 'Marketing Blitz', emoji: '📣', cost: 1800, time: 100, requires: ['premiumContracts'],
         desc: 'Unlocks paid promotions: a 45s burst of extra orders, repeatable from the Shop.'
+    },
+    autoAcceptContracts: {
+        // Baseline for a single-effect tech at this tier is ~80s (see
+        // premiumContracts/coldStorage); 30% shorter puts this at 56s.
+        name: 'Standing Orders', emoji: '🤝', cost: 1000, time: 56, requires: ['premiumContracts'],
+        desc: 'Unlocks a Shop toggle to auto-accept every contract offer instantly.'
     }
 };
 SC.RESEARCH_ORDER = ['intersections', 'junctions', 'manualPlacement', 'creditLine2', 'pavedRoads', 'fertilizer',
                      'creditLine3', 'premiumContracts', 'overdrive', 'automation', 'coldStorage',
-                     'rapidExpansion', 'promotions', 'bulkLogistics'];
+                     'rapidExpansion', 'promotions', 'autoAcceptContracts', 'bulkLogistics'];
 
 // Goods tree. Raw goods come from suppliers; crafted goods are made in a
 // factory dedicated to that recipe. Only `orderable` goods appear in city

--- a/supply-chain/js/economy.js
+++ b/supply-chain/js/economy.js
@@ -371,7 +371,15 @@ SC.economy = (function() {
             if (SC.state.contractOffer.timeLeft <= 0) declineContract();
         } else if (!SC.state.orders.some(o => o.contract)) {
             SC.state.nextContractIn -= dt;
-            if (SC.state.nextContractIn <= 0) rollContractOffer();
+            if (SC.state.nextContractIn <= 0) {
+                rollContractOffer();
+                // Standing Orders research + the player's toggle: skip the
+                // Accept/Decline card and take every offer immediately.
+                if (SC.state.contractOffer && SC.state.autoAcceptContracts &&
+                    SC.research.isDone('autoAcceptContracts')) {
+                    acceptContract();
+                }
+            }
         }
 
         // New customer DCs (cities) unlock on their own clock, independent

--- a/supply-chain/js/save.js
+++ b/supply-chain/js/save.js
@@ -42,6 +42,7 @@ SC.save = (function() {
             seed: st.seed,
             worldW: st.worldW, worldH: st.worldH, expansions: st.expansions,
             congestionEnabled: st.congestionEnabled,
+            autoAcceptContracts: st.autoAcceptContracts,
             money: st.money, earnedTotal: st.earnedTotal,
             interestPaid: st.interestPaid,
             delivered: st.delivered, missed: st.missed,
@@ -122,6 +123,7 @@ SC.save = (function() {
         st.expansions = data.expansions || 0;
         st.congestionEnabled = data.congestionEnabled !== undefined
             ? data.congestionEnabled : SC.DIFFICULTIES[st.difficulty].congestion;
+        st.autoAcceptContracts = !!data.autoAcceptContracts;
         st.upgrades = Object.assign(st.upgrades, data.upgrades);
         if (data.research) {
             st.research.completed = Object.assign({}, data.research.completed);

--- a/supply-chain/js/state.js
+++ b/supply-chain/js/state.js
@@ -41,6 +41,7 @@ SC.newState = function(difficulty) {
         contractOffer: null, // { product, city, qty, payout, deadline, timeLeft } awaiting Accept/Decline
         nextContractIn: SC.CONFIG.CONTRACT_INTERVAL[0] +
             Math.random() * (SC.CONFIG.CONTRACT_INTERVAL[1] - SC.CONFIG.CONTRACT_INTERVAL[0]),
+        autoAcceptContracts: false, // player toggle, only effective once 'autoAcceptContracts' is researched
 
         trucks: [],         // see vehicles.js
         jobs: [],           // pending haul jobs

--- a/supply-chain/js/ui-bind.js
+++ b/supply-chain/js/ui-bind.js
@@ -219,6 +219,12 @@
             else if (res.reason === 'money') { SC.sfx.play('error'); toast(`Credit limit reached — promotion costs ${fmt(res.cost)}`, 'error'); }
             updateShop();
         });
+        $('btn-auto-accept').addEventListener('click', () => {
+            SC.state.autoAcceptContracts = !SC.state.autoAcceptContracts;
+            SC.sfx.play('click');
+            toast(SC.state.autoAcceptContracts ? '🤝 Contracts will auto-accept' : 'Auto-accept off', 'info');
+            updateShop();
+        });
         $('btn-research-tree').addEventListener('click', () => { SC.sfx.play('click'); openResearchTree(); });
         $('research-tree-close').addEventListener('click', () => { SC.sfx.play('click'); closeResearchTree(); });
         $('research-overlay').addEventListener('click', e => {

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -85,6 +85,7 @@ SC.ui = (function() {
         updateResearchShortcut();
         updateResearchTree();
         updatePromo();
+        updateAutoAccept();
         updateBuild();
     }
 
@@ -100,6 +101,16 @@ SC.ui = (function() {
             btn.disabled = !SC.canAfford(SC.CONFIG.PROMO_COST);
             btn.querySelector('.price').textContent = fmt(SC.CONFIG.PROMO_COST);
         }
+    }
+
+    // ── Standing Orders (auto-accept contracts): a Shop toggle, only
+    // shown once researched — mirrors the dev-panel Congestion toggle. ──
+    function updateAutoAccept() {
+        const btn = $('btn-auto-accept');
+        btn.classList.toggle('hidden', !SC.research.isDone('autoAcceptContracts'));
+        if (btn.classList.contains('hidden')) return;
+        btn.classList.toggle('active', SC.state.autoAcceptContracts);
+        btn.querySelector('.price').textContent = SC.state.autoAcceptContracts ? 'On' : 'Off';
     }
 
     // ── Truck yards: HQ is always one; more can be built (not research-
@@ -265,6 +276,7 @@ SC.ui = (function() {
             premiumContracts: { col: 2, row: 1 },
             rapidExpansion: { col: 1.5, row: 2 },
             promotions: { col: 2.5, row: 2 },
+            autoAcceptContracts: { col: 2, row: 3 },
 
             // Asphalt Paving subtree (shifted by 1 column to the left)
             pavedRoads: { col: 3.5, row: 0 },

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.51.3';</script>
+    <script>window.SC_VERSION = '1.52.1';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'sfx', 'rng', 'map', 'camera',
@@ -1837,6 +1837,34 @@
         SC.economy.tick(0.1); // offer's own countdown auto-declines it
         assert('an unanswered offer auto-declines once its own timer runs out',
             SC.state.contractOffer === null);
+    })();
+
+    // ── Contracts: Standing Orders research auto-accepts new offers ─
+    (function() {
+        fixture();
+        SC.state.money = 100000;
+        SC.state.nextContractIn = 0.05;
+        SC.economy.tick(0.1);
+        assert('with the toggle off, a rolled offer still waits for Accept/Decline',
+            SC.state.contractOffer !== null);
+
+        SC.economy.declineContract();
+        SC.state.research.completed.autoAcceptContracts = true;
+        SC.state.autoAcceptContracts = false;
+        SC.state.nextContractIn = 0.05;
+        SC.economy.tick(0.1);
+        assert('researched but toggled off still waits for Accept/Decline',
+            SC.state.contractOffer !== null);
+
+        SC.economy.declineContract();
+        SC.state.autoAcceptContracts = true;
+        SC.state.nextContractIn = 0.05;
+        SC.economy.tick(0.1);
+        assert('researched and toggled on auto-accepts the offer into a real order',
+            SC.state.contractOffer === null && SC.state.orders.some(o => o.contract));
+
+        SC.save.restore(SC.save.serialize());
+        assert('the auto-accept toggle survives a save round-trip', SC.state.autoAcceptContracts === true);
     })();
 
     // ── Contracts: save round-trip for offer, order flag and timer ─


### PR DESCRIPTION
New tech (requires Premium Contracts) unlocks a Shop toggle that skips
the Accept/Decline card and takes every contract offer instantly. Its
research time is 56s — 30% shorter than the ~80s baseline for a
same-tier single-effect tech, so it clears quickly once affordable.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UVxBxk6nYVfMG5bF9iWi1L