### PR TITLE
Auto-hide factory production pills at low zoom, with a ☰-menu toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
                 </svg></span>
         </a>
 
-        <a href="supply-chain/index.html?v=1.52.0" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.53.0" class="card card-metal" id="card-supply-chain">
             <div class="beta-badge">BETA</div>
             <div>
                 <div class="card-icon">🏭</div>

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.52.0';</script>
+    <script>window.SC_VERSION = '1.53.0';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>
@@ -258,6 +258,7 @@
             <button class="menu-btn primary" id="menu-resume">▶ Resume</button>
             <button class="menu-btn" id="menu-save">💾 Save now</button>
             <button class="menu-btn" id="menu-sound">🔊 Sound</button>
+            <button class="menu-btn" id="menu-pills">🏷 Factory labels</button>
             <button class="menu-btn" id="menu-fullscreen">⛶ Full screen</button>
             <button class="menu-btn" id="menu-achievements">📊 Stats &amp; Achievements</button>
             <button class="menu-btn" id="menu-dev">🛠 Dev tools</button>

--- a/supply-chain/js/render-network.js
+++ b/supply-chain/js/render-network.js
@@ -12,6 +12,23 @@
     let shadowSprite = null;
     let glowSprite = null;
 
+    // Factory production pills (the floating "3/5" stock badges) get dense
+    // once several factories are on screen at once while zoomed out — most
+    // noticeable on a small mobile viewport. Auto-hide is opt-out via the
+    // ☰ menu's "Factory labels" toggle (SC._ui.getHidePills). The threshold
+    // is a fraction of the camera's current zoom range (0 = as far out as
+    // this map/viewport currently allows, 1 = closest in) rather than a raw
+    // zoom number, since minZoom/maxZoom themselves shift as the playing
+    // field expands (see camera.js setViewport).
+    function pillsVisible() {
+        if (!SC._ui || !SC._ui.getHidePills()) return true;
+        const cam = SC.camera.cam;
+        const range = cam.maxZoom - cam.minZoom;
+        const frac = range > 0 ? (zoom() - cam.minZoom) / range : 1;
+        const isMobile = window.innerWidth <= 768;
+        return frac >= (isMobile ? 0.35 : 0.12);
+    }
+
     function strokeEdge(e, width, color, dash) { strokeEdgeRange(e, 0, 1, width, color, dash); }
 
     function strokeEdgeRange(e, t0, t1, width, color, dash) {
@@ -750,7 +767,7 @@
             }
             const needsKeys = Object.keys(queueNeeds);
 
-            if (ordered > 0 || inStock > 0) {
+            if ((ordered > 0 || inStock > 0) && pillsVisible()) {
                 const z = clampZoom();
                 const sy = tc.y - 28 * z;
                 const interFont = `600 ${9 * z}px Inter, system-ui, sans-serif`;

--- a/supply-chain/js/ui-bind.js
+++ b/supply-chain/js/ui-bind.js
@@ -5,8 +5,9 @@
 // lived inside the ui.js closure.
 (function () {
     const U = SC._ui;
-    const { $, fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, openStatsOverlay, closeStatsOverlay, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, focusOrder, yardLabel } = U;
+    const { $, fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, setHidePills, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, openStatsOverlay, closeStatsOverlay, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, focusOrder, yardLabel } = U;
     const getDevMode = U.getDevMode;
+    const getHidePills = U.getHidePills;
 
     SC._ui.bind = function () {
         $('speed-toggle').addEventListener('click', e => {
@@ -99,6 +100,11 @@
         });
         $('menu-sound').addEventListener('click', () => {
             SC.sfx.toggleMute();
+            updateMenuInfo();
+        });
+        $('menu-pills').addEventListener('click', () => {
+            setHidePills(!getHidePills());
+            SC.sfx.play('click');
             updateMenuInfo();
         });
         $('menu-fullscreen').addEventListener('click', () => {

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -9,6 +9,11 @@ SC.ui = (function() {
     // so it's a lasting ☰-menu choice, not something to retype ?dev=1 for
     // every visit. The query param still works too (e.g. a fresh browser).
     let devMode = localStorage.getItem('scTycoonDevMode') === 'true';
+    // Factory production pills (the "3/5" stock badges floating over
+    // factories) get dense and cluttered once several are visible while
+    // zoomed out — worst on a small mobile screen. Default on; a ☰-menu
+    // toggle lets anyone who prefers always-on pills opt back in.
+    let hidePills = localStorage.getItem('scTycoonHidePills') !== 'false';
 
     function fmt(n) { return '$' + Math.round(n).toLocaleString('en-US'); }
 
@@ -45,6 +50,11 @@ SC.ui = (function() {
         localStorage.setItem('scTycoonDevMode', String(devMode));
         $('dev-panel').classList.toggle('hidden', !devMode);
         if (devMode) updateDevPanel();
+    }
+
+    function setHidePills(on) {
+        hidePills = on;
+        localStorage.setItem('scTycoonHidePills', String(hidePills));
     }
 
     function updateDevPanel() {
@@ -709,6 +719,7 @@ SC.ui = (function() {
         $('menu-sound').textContent = SC.sfx.isMuted() ? '🔇 Sound: off' : '🔊 Sound: on';
         $('menu-fullscreen').textContent = document.fullscreenElement ? '⛶ Exit full screen' : '⛶ Full screen';
         $('menu-dev').textContent = devMode ? '🛠 Dev tools: on' : '🛠 Dev tools: off';
+        $('menu-pills').textContent = hidePills ? '🏷 Factory labels: auto-hide' : '🏷 Factory labels: always on';
     }
 
     function toggleFullscreen() {
@@ -817,9 +828,13 @@ SC.ui = (function() {
 
     // Published for ui-bind.js (event wiring lives there to keep this file
     // smaller). getDevMode gives ui-bind live access to the devMode toggle.
+    // getHidePills is also read directly by render-network.js each frame to
+    // decide whether the factory production pills should auto-hide at low
+    // zoom — the only cross-module read of a ☰-menu toggle from the render
+    // layer, since drawing (not just event wiring) needs to react to it live.
     SC._ui = {
-        $, getDevMode: () => devMode,
-        fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, openStatsOverlay, closeStatsOverlay, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, focusOrder, yardLabel,
+        $, getDevMode: () => devMode, getHidePills: () => hidePills,
+        fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, setHidePills, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, openStatsOverlay, closeStatsOverlay, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, focusOrder, yardLabel,
     };
 
     return { init, update, toast, openStatsOverlay };

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.51.3';</script>
+    <script>window.SC_VERSION = '1.53.0';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'sfx', 'rng', 'map', 'camera',


### PR DESCRIPTION
The floating "3/5" stock pills over factories get cluttered once several
are visible at once while zoomed out, especially on mobile screens. Pills
now fade out below a zoom threshold (stricter on mobile, more lenient on
desktop so they stay visible further out there), and a new "Factory
labels" toggle in the ☰ menu lets players force them always-on.