### PR TITLE
Add achievement detail modal and clickable unlock toast

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
                 </svg></span>
         </a>
 
-        <a href="supply-chain/index.html?v=1.52.1" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.52.2" class="card card-metal" id="card-supply-chain">
             <div class="beta-badge">BETA</div>
             <div>
                 <div class="card-icon">🏭</div>

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.52.1';</script>
+    <script>window.SC_VERSION = '1.52.2';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>
@@ -232,6 +232,16 @@
                     <button class="menu-btn danger small" id="stats-reset-career" style="margin: 0; padding: 0.5rem 1rem; font-size: 0.85rem; width: auto;">🗑 Reset Career</button>
                 </div>
             </div>
+        </div>
+    </div>
+
+    <div id="ach-detail-overlay" class="hidden">
+        <div class="ach-detail-card">
+            <span class="ach-detail-emoji" id="ach-detail-emoji"></span>
+            <h1 id="ach-detail-name"></h1>
+            <p id="ach-detail-desc"></p>
+            <div class="ach-detail-status" id="ach-detail-status"></div>
+            <button class="menu-btn" id="ach-detail-close">Close</button>
         </div>
     </div>
 

--- a/supply-chain/js/ui-bind.js
+++ b/supply-chain/js/ui-bind.js
@@ -5,7 +5,7 @@
 // lived inside the ui.js closure.
 (function () {
     const U = SC._ui;
-    const { $, fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, openStatsOverlay, closeStatsOverlay, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, focusOrder, yardLabel } = U;
+    const { $, fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, openStatsOverlay, closeStatsOverlay, openAchievementDetail, closeAchievementDetail, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, focusOrder, yardLabel } = U;
     const getDevMode = U.getDevMode;
 
     SC._ui.bind = function () {
@@ -127,6 +127,16 @@
         $('stats-close').addEventListener('click', () => { SC.sfx.play('click'); closeStatsOverlay(); });
         $('stats-overlay').addEventListener('click', e => {
             if (e.target === $('stats-overlay')) closeStatsOverlay(); // tap outside the card
+        });
+        $('stats-achievements').addEventListener('click', e => {
+            const badge = e.target.closest('[data-ach]');
+            if (!badge) return;
+            SC.sfx.play('click');
+            openAchievementDetail(badge.dataset.ach);
+        });
+        $('ach-detail-close').addEventListener('click', () => { SC.sfx.play('click'); closeAchievementDetail(); });
+        $('ach-detail-overlay').addEventListener('click', e => {
+            if (e.target === $('ach-detail-overlay')) closeAchievementDetail(); // tap outside the card
         });
         if ($('stats-reset-career')) {
             $('stats-reset-career').addEventListener('click', () => {
@@ -324,7 +334,10 @@
         SC.on('achievementUnlocked', id => {
             const a = SC.ACHIEVEMENTS[id];
             SC.sfx.play('unlock');
-            toast(`${a.emoji} Achievement unlocked: ${a.name}!`, 'good');
+            toast(`${a.emoji} Achievement unlocked: ${a.name}! (tap to view)`, 'good', () => {
+                $('menu-overlay').classList.add('hidden'); // in case it was open underneath
+                openStatsOverlay();
+            });
         });
         SC.on('debtWarning', d => {
             SC.sfx.play('error');

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -12,12 +12,25 @@ SC.ui = (function() {
 
     function fmt(n) { return '$' + Math.round(n).toLocaleString('en-US'); }
 
-    function toast(text, kind) {
+    let toastClickHandler = null;
+    function toast(text, kind, onClick) {
         const el = $('toast');
         el.textContent = text;
-        el.className = 'show ' + (kind || 'info');
+        el.className = 'show ' + (kind || 'info') + (onClick ? ' clickable' : '');
+        toastClickHandler = onClick || null;
         clearTimeout(toastTimer);
-        toastTimer = setTimeout(() => { el.className = ''; }, 3200);
+        toastTimer = setTimeout(() => { el.className = ''; toastClickHandler = null; }, 3200);
+    }
+    // Wired once here (rather than ui-bind.js) since toastClickHandler is
+    // private to this closure — bind() only sees the exported toast().
+    function bindToastClick() {
+        $('toast').addEventListener('click', () => {
+            if (!toastClickHandler) return;
+            const fn = toastClickHandler;
+            toastClickHandler = null;
+            $('toast').className = '';
+            fn();
+        });
     }
 
     function updateHUD() {
@@ -443,7 +456,7 @@ SC.ui = (function() {
         $('stats-achievements').innerHTML = SC.ACHIEVEMENT_ORDER.map(id => {
             const a = SC.ACHIEVEMENTS[id];
             const done = !!st.achievements[id];
-            return `<div class="stats-ach ${done ? 'unlocked' : 'locked'}" title="${a.desc}">
+            return `<div class="stats-ach ${done ? 'unlocked' : 'locked'}" data-ach="${id}" title="${a.desc}">
                 <span class="ach-emoji">${a.emoji}</span>${a.name}
             </div>`;
         }).join('');
@@ -476,6 +489,7 @@ SC.ui = (function() {
     }
 
     function openStatsOverlay() {
+        SC.state.paused = true; // also reachable straight from the unlock toast, not just the paused ☰ menu
         $('stats-overlay').classList.remove('hidden');
         updateStatsOverlay();
     }
@@ -483,6 +497,24 @@ SC.ui = (function() {
     function closeStatsOverlay() {
         $('stats-overlay').classList.add('hidden');
         SC.state.paused = false; // in case it was opened via the menu
+    }
+
+    // ── Achievement detail: tapping a badge in the Stats overlay explains it —
+    // the grid is too cramped for description text, and hover-only `title`
+    // tooltips don't work on touch. ──
+    function openAchievementDetail(id) {
+        const a = SC.ACHIEVEMENTS[id];
+        const done = !!SC.state.achievements[id];
+        $('ach-detail-emoji').textContent = a.emoji;
+        $('ach-detail-name').textContent = a.name;
+        $('ach-detail-desc').textContent = a.desc;
+        $('ach-detail-status').textContent = done ? '✅ Unlocked' : '🔒 Locked';
+        $('ach-detail-status').className = 'ach-detail-status ' + (done ? 'unlocked' : 'locked');
+        $('ach-detail-overlay').classList.remove('hidden');
+    }
+
+    function closeAchievementDetail() {
+        $('ach-detail-overlay').classList.add('hidden');
     }
 
     // ── River-crossing choice: input.js emits this instead of building
@@ -775,6 +807,7 @@ SC.ui = (function() {
     }
 
     function init() {
+        bindToastClick();
         SC._ui.bind();
         bindDifficultyPicker();
         drawRecipeGraph();
@@ -819,7 +852,7 @@ SC.ui = (function() {
     // smaller). getDevMode gives ui-bind live access to the devMode toggle.
     SC._ui = {
         $, getDevMode: () => devMode,
-        fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, openStatsOverlay, closeStatsOverlay, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, focusOrder, yardLabel,
+        fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, openStatsOverlay, closeStatsOverlay, openAchievementDetail, closeAchievementDetail, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, focusOrder, yardLabel,
     };
 
     return { init, update, toast, openStatsOverlay };

--- a/supply-chain/style.css
+++ b/supply-chain/style.css
@@ -650,10 +650,45 @@ html, body {
     text-align: center;
     font-size: 0.68rem;
     line-height: 1.3;
+    cursor: pointer;
+    transition: border-color 0.15s, transform 0.15s;
 }
+.stats-ach:hover, .stats-ach:active { border-color: var(--accent-color); transform: translateY(-1px); }
 .stats-ach .ach-emoji { font-size: 1.3rem; display: block; margin-bottom: 0.2rem; }
 .stats-ach.locked { opacity: 0.35; filter: grayscale(1); }
 .stats-ach.unlocked { border-color: rgba(250, 204, 21, 0.5); background: rgba(120, 90, 15, 0.2); }
+
+/* ── Achievement detail popup: tapping a badge above opens this — the
+   grid cells are too small for description text, and touch has no hover
+   for the `title` tooltip that desktop still gets. ── */
+#ach-detail-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 320;
+    background: rgba(15, 23, 42, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+}
+#ach-detail-overlay.hidden { display: none; }
+.ach-detail-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 18px;
+    padding: 1.6rem;
+    width: 320px;
+    max-width: 90vw;
+    text-align: center;
+}
+.ach-detail-emoji { font-size: 2.6rem; display: block; margin-bottom: 0.6rem; }
+.ach-detail-card h1 { font-size: 1.1rem; margin-bottom: 0.5rem; }
+.ach-detail-card p { font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 0.9rem; line-height: 1.4; }
+.ach-detail-status { font-size: 0.8rem; font-weight: 600; margin-bottom: 1rem; }
+.ach-detail-status.unlocked { color: var(--good); }
+.ach-detail-status.locked { color: var(--text-secondary); }
 .rt-edge { fill: none; stroke: rgba(148, 163, 184, 0.35); stroke-width: 2; }
 .rt-edge.rt-edge-done { stroke: var(--good); stroke-width: 2.5; }
 
@@ -708,6 +743,7 @@ html, body {
 #toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
 #toast.good { border-color: rgba(52, 211, 153, 0.5); }
 #toast.error { border-color: rgba(248, 113, 113, 0.5); }
+#toast.clickable { pointer-events: auto; cursor: pointer; }
 
 /* ── Menu overlay ────────────────────────────────── */
 #menu-overlay {

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.52.1';</script>
+    <script>window.SC_VERSION = '1.52.2';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'sfx', 'rng', 'map', 'camera',


### PR DESCRIPTION
Achievement badges in the Stats overlay are grid cells too cramped
for description text, and native title tooltips don't work on touch
— tapping one now opens a small modal with its emoji, name, description,
and locked/unlocked status. The achievement-unlock toast is also
clickable, jumping straight into the Stats & Achievements overlay
instead of requiring a trip through the ☰ menu.