### PR TITLE
audio: ambient soundscape + generative music, separate from sfx

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
                 </svg></span>
         </a>
 
-        <a href="supply-chain/index.html?v=1.54.0" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.55.0" class="card card-metal" id="card-supply-chain">
             <div class="beta-badge">BETA</div>
             <div>
                 <div class="card-icon">🏭</div>

--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
                 </svg></span>
         </a>
 
-        <a href="supply-chain/index.html?v=1.53.2" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.54.0" class="card card-metal" id="card-supply-chain">
             <div class="beta-badge">BETA</div>
             <div>
                 <div class="card-icon">🏭</div>

--- a/supply-chain/CLAUDE.md
+++ b/supply-chain/CLAUDE.md
@@ -74,10 +74,12 @@ Don't couple the two again.)
 - New script files are added by **module name** to the `mods` array in the
   inline loader (in `index.html`; logic modules also in `tests.html`'s loader)
   — not as a hand-written `<script>` tag. Load order matters and is the array
-  order: config → state → save → sfx → rng → map → camera → roads → factories
+  order: config → state → save → audio → sfx → rng → map → camera → roads → factories
   → economy → vehicles → stats → inspect → research → placement →
   (render → input → ui → main). (`rng.js` must precede `map.js`: `SC.map`'s
-  IIFE calls `SC.rng.create(...)` at load time to seed its default RNG.)
+  IIFE calls `SC.rng.create(...)` at load time to seed its default RNG.
+  `audio.js` must precede `sfx.js`: audio owns the AudioContext and the
+  music/sfx buses, and sfx.js asks it for its bus on every blip.)
 
 ## Verification (headless — works in any environment)
 Serve the repo root, e.g. `python3 -m http.server 8199` from the repo root,
@@ -86,8 +88,20 @@ then (any headless Chromium works; on sandboxed Linux add `--no-sandbox`):
 - **Logic tests**: `<chromium> --headless=new --disable-gpu
   --virtual-time-budget=15000 --dump-dom
   http://localhost:8199/supply-chain/tests.html`, grep for `id="summary"`
-  — must say "N passed / **0 failed**" (386 tests at last count; N grows,
+  — must say "N passed / **0 failed**" (857 tests at last count; N grows,
   0 failed is the bar).
+- **Audio check**: the WebAudio layer can't live in `tests.html` — it needs a
+  real user gesture to open an AudioContext, which headless only permits with
+  `--autoplay-policy=no-user-gesture-required`. `audio-check.html` fakes the
+  gesture and asserts the graph is wired and scheduling:
+  `<chromium> --headless=new --disable-gpu --autoplay-policy=no-user-gesture-required
+  --virtual-time-budget=8000 --dump-dom
+  http://localhost:8199/supply-chain/audio-check.html`, grep for `id="summary"`
+  — "N passed / **0 failed**". Worth running after ANY change to `audio.js`/
+  `sfx.js`: `SC.audio.update()` runs inside main.js's rAF loop, so a throw in
+  it freezes the entire game, and the plain `?probe=` smoke can't catch that
+  (no gesture ever fires there, so the context stays suspended and update()
+  returns early).
 - **Visual/gameplay smoke**: `index.html?probe=40` auto-builds the starter
   roads, spawns an order, and fast-forwards 40 simulated seconds
   synchronously (rAF does NOT tick reliably under `--virtual-time-budget`,

--- a/supply-chain/CLAUDE.md
+++ b/supply-chain/CLAUDE.md
@@ -126,7 +126,13 @@ then (any headless Chromium works; on sandboxed Linux add `--no-sandbox`):
   and sets it as the active yard, for screenshotting the yard marker/
   per-yard truck counts. `&junction=1` places a junction near HQ (same
   ring-search as `&yard=1`) and roads it in, for screenshotting the
-  small roundabout marker (`drawJunction`). `&stats=1` forces sample
+  small roundabout marker (`drawJunction`). `&tutorial=N` drops a fresh
+  world straight onto guided-tutorial step N (1-based, default 1) for
+  screenshotting the banner and the focus dim/rings; pair it with
+  `nohelp=1`. Deliberately NOT part of `?probe=`, which builds the starter
+  roads and would satisfy the first three steps before the shot is taken —
+  though `?tutorial=1&probe=40` is useful the other way round, verifying the
+  sequence auto-completes and the banner retires. `&stats=1` forces sample
   deliveries/money-history/road-trips and a few unlocked achievements,
   then opens the ☰ menu's Stats & Achievements overlay directly, for
   screenshotting it without a long real playthrough. `&highway=1` completes

--- a/supply-chain/PLAN.md
+++ b/supply-chain/PLAN.md
@@ -188,9 +188,18 @@ shipped.)*
 3. ~~Order → map linking~~ — shipped v1.1.0 (tap an order row → route
    highlight). Generalized by item 6 below.
 4. ~~Truck capacity upgrade track~~ — shipped v1.6.0.
-5. **Tutorialize the first order** — instead of only the text overlay:
-   dim the map, arrow at HQ + nearest supplier, "build a road here". The
-   overlay stays as reference.
+5. ~~Tutorialize the first order~~ — shipped v1.55.0, as scoped: the help
+   overlay stays as reference, and a fresh run now also gets a four-step
+   guided walkthrough (`js/tutorial.js`) that dims the map, rings + arrows
+   the nodes each step names, and captions the exact next tap in a banner.
+   Steps are written as **goals rather than actions** and re-checked on the
+   events that can satisfy them (`roadBuilt`/`roadDemolished`/
+   `orderComplete`) instead of being advanced by the taps that caused them —
+   so a single road can retire two steps at once, and the sequence can't
+   desync from the world. `SC.state.tutorialStep` persists so a reload
+   resumes mid-sequence; −1 means finished or skipped, which is also what a
+   pre-tutorial save restores as, so an existing run is never dropped into
+   step 1. Skippable from the banner. Dev: `&tutorial=N`.
 6. ~~Interaction modes: Build vs Inspect~~ — shipped v1.8.0. Detail kept
    below for reference:
    - **Build** (current behaviour, default): tap-tap builds/demolishes

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -254,6 +254,27 @@ that ambient animation as its background — it now lives independently at
   Truck yards use the same tap-to-place flow and ghost preview but are
   **not** research-gated (`SC.placement.place('yard', ...)`) — a base
   mechanic, not a premium bailout.
+- **Sound & music**: two independent ☰-menu toggles, both persisted.
+  **🔊 Sound** covers one-shot blips (build/cash/error/…) *and* the world
+  ambience; **🎵 Music** covers the score. Everything is synthesised at
+  runtime in `js/audio.js` — there are no audio files in the repo, which
+  keeps the folder self-contained and lets the sound react to game state:
+  - *Ambience* is three looping filtered-noise beds whose gains are ramped
+    (never rebuilt) each frame — wind rising with cloud cover/wind strength,
+    rain with the rain spell, and a traffic hum that saturates with the
+    number of trucks actually rolling (`1 - e^(-n/6)`), so a busy network is
+    audibly busy. It ducks to silence while paused or after game over.
+  - *Music* is a generative four-chord loop (Am7–Fmaj7–Cmaj7–G7, 8s per
+    chord) with a pad, a bass root and a sparse melody drawn from a fixed
+    A-minor-pentatonic scale — consonant over all four chords, so notes can
+    be picked at random without ever clashing. The day/night cycle drives it:
+    the pad's filter opens and the melody gets busier by day, darker and
+    sparser at night. Notes are scheduled on a 0.5s grid with a 0.4s
+    lookahead from `SC.audio.update()`.
+  - Audio runs on the **wall clock**, so `update()` sits outside main.js's
+    fast-forward sub-step loop — 4× speed simulates faster without pitching
+    the music up. Nothing is created until the first user gesture (autoplay
+    policy), which is why headless probes are silent.
 - **Camera**: drag to pan, wheel/pinch to zoom.
 - **Fast-forward**: the 1×/2×/4× toggle under the HUD (`SC.state.speed`)
   runs that many fixed-size sub-steps of `economy`/`factories`/
@@ -295,7 +316,8 @@ they signal the UI through the tiny `SC.on`/`SC.emit` pub/sub in state.js.
 | `js/render.js` | Canvas drawing (isometric 2.5D): sky + a **low-poly heightfield terrain backdrop** (`drawTerrain`/`ensureTerrain`) — the ground plane continues past every edge of the field: beyond the two far (low world x+y) edges it rises into faceted, faintly-wireframed mountains via ridged value-noise (`terrainHeight`/`ridged`), and beyond the two near edges it *descends* into rolling lowland foothills (negative heights, `TERRAIN.dip`), so the field reads as a plateau in one continuous landscape instead of an island floating over the sky. Flat inside the field so it never occludes play, flat-shaded per facet with the slope, and blended toward the live sky for aerial haze on both sides (so it tracks day/night + weather). Sized from `SC.worldW()`/`worldH()` + a skirt and rebuilt only when the field grows (`terrainKey`), so a field expansion just pushes the range further out. Projected land with terrain patches and scattered pines/rocks, river, road ribbons, extruded diamond-prism buildings (story lines, doors, factory smokestacks) with sprite-based soft shadows, themed supplier sites (farm/lake+pump/mine/pasture/rubber grove/fab per raw material, `drawSupplierSite`), truck yards drawn as a flat asphalt parking lot with painted stall lines and the idle trucks homed there physically parked nose-in across its bays (`drawYardSite`/`drawYardParking`, world-grounded iso grid) instead of a 🅿️ icon + count — idle trucks (no route/jobs) are skipped in the entity sort and drawn by their home node, and HQ/DC get the same apron of parked trucks in front instead of a `N 🚚` label, depth-sorted back-to-front (a small `TRUCK_DEPTH_BIAS` nudges trucks forward in the sort so one arriving at or sitting beside a node doesn't get hard-clipped by that node's own body — a single-point painter's sort has no notion of footprint size, so a truck's final approach used to sometimes lose that near-tie; the plot pad under each building is also a feathered radial fade rather than a flat fill, so it doesn't add a second hard edge on top of whatever seam remains), cab+trailer trucks and billboarded labels/order-bubbles. Static scenery (terrain/land/grid/patches/trees) renders into a cached offscreen layer re-blitted while panning (`renderBg`/`drawBg`) so mobile panning stays smooth; dpr is capped at 2. The layer is only ever blitted at its exact render zoom — a scaled blit is a ≤120ms stopgap mid-pinch, then it re-renders (a lingering scaled blit was the mobile "giant/torn scenery" glitch), and the ctx swap in `renderBg` is try/finally-guarded. `bgKey` includes `terrainKey()` so the cache re-bakes when the field expands. Distance fog fades the far edge of the land into the sky; screen-space star field behind the world; trucks get headlights while driving. Scenery uses a seeded PRNG (`makeRng`) cached so it doesn't flicker. **Night atmosphere** (all per-frame, kept out of the cached bg): a moon with a soft glow + a faint aurora band in the sky, warm lit windows on buildings/factories/HQ/DC/fab (seeded per node in `prism`'s window grid, a few flicker) over a cached warm ground light-spill, a blinking aircraft-style beacon on the HQ landmark, a moonlight shimmer streak on the river, a few drifting world-anchored fireflies, and a cached screen-edge vignette drawn last for framing. **Day/night cycle** (`DAY_LENGTH`, cosmetic/non-persisted): a slow clock sweeps the sky palette (night↔day↔dusk keyframes), arcs a crossfading sun/moon, applies a full-screen `'screen'` colour grade to lift the baked-night ground toward daylight without rebuilding the bg cache, and drives a `nightLevel` that fades windows/fireflies/light-spill/headlights out by day. **Rotating weather** (`WEATHER_ROTATION`): clear→clouds→rain→snow spells fade in/out, a slowly-turning wind vector drifts drifting sky clouds + soft ground cloud-shadows and angles pooled/capped rain & snow particles. Truck headlights are night-only soft glows. Directional cast shadows (`drawShadow`) swing opposite the sun/moon and lengthen near the horizon; animated route-flow dashes (`drawRouteFlow`) pulse along roads carrying trucks in the cargo colour; `orderComplete` fires a coin/spark burst; rain adds a road sheen (`drawWetRoads`) and snow lays a slowly-melting blanket (`drawSnowBlanket`); lit buildings, the HQ beacon and the fab antenna emit an additive `bloom()` glow at night; a crate hops into a truck on pickup and down into a node on delivery (`drawTransfer`, driven render-side by cargo-length change, depth-sorted so a nearer site clips it). Probe flags `&tod=`/`&weather=` force a time/weather for screenshots |
 | `js/input.js` | Pointer events: pan, pinch, wheel, tap-to-build, Upgrade-mode taps, Inspect hover/hold. Node picking hit-tests the whole extruded building (ground→roof capsule, `nodeAtScreen`); `getHoverNode` feeds the ghost-road snap + hover ring so previews match what a click hits |
 | `js/ui.js` | HUD, orders/shop panels, research-tree overlay, difficulty picker, game-over overlay, toasts, help overlay |
-| `js/sfx.js` | WebAudio blips (autoplay-unlock + mute pattern from cargo-lander) |
+| `js/audio.js` | Shared AudioContext + music/sfx/ambience buses; the weather- and traffic-reactive ambient bed and the generative score (all synthesised, no audio assets). `update()` is called once per frame from main.js, outside the fast-forward sub-step loop |
+| `js/sfx.js` | WebAudio one-shot blips, routed into `audio.js`'s sfx bus. Owns the **Sound** toggle (one-shots + ambience); music toggles separately |
 | `js/main.js` | Bootstrap, game loop (fast-forward runs N sub-steps/frame), `?probe=N`/`?seed=`/`?speed=` headless verification hooks |
 
 `tests.html` runs the logic modules against hand-built deterministic maps
@@ -324,7 +346,9 @@ sync with it):
   - Face textures (subtle noise/brick/metal) instead of flat-colour building faces.
   - Seasonal palettes; richer water reflections beyond the moonlight streak.
   - Weather that actually affects play (rain slowing trucks, etc.) — gameplay, not just cosmetic.
-- Sound of moving trucks / ambient loop; music toggle separate from sfx.
+- ~~Sound of moving trucks / ambient loop; music toggle separate from sfx.~~
+  Shipped: `js/audio.js` (see Sound & music above). Remaining refinement
+  if wanted: per-channel volume sliders instead of on/off toggles.
 - Touch: long-press as an alternative to double-tap for demolish/buy (the
   Inspect-mode hold gesture above uses the same long-press primitive).
 - Promotions landed in v1.13 as a research-unlocked *repeatable shop

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -275,6 +275,19 @@ that ambient animation as its background — it now lives independently at
     fast-forward sub-step loop — 4× speed simulates faster without pitching
     the music up. Nothing is created until the first user gesture (autoplay
     policy), which is why headless probes are silent.
+- **Guided tutorial**: a fresh run opens with a four-step walkthrough of the
+  first order — road the bakery to wheat, then to water, then to HQ, then
+  watch a truck fill it. A banner names the exact next tap while the map
+  dims and pulses a ring + arrow on the nodes that step means, so "tap the
+  bakery, then the wheat farm" points at two specific buildings instead of
+  leaving a new player to find them. Skippable from the banner, and it never
+  appears for a restored save that already finished it. Steps are stated as
+  **goals, not actions** (`js/tutorial.js`), re-checked on `roadBuilt`/
+  `roadDemolished`/`orderComplete` — so one road can retire two steps at
+  once, and a step can't desync from the world. `SC.state.tutorialStep`
+  persists (−1 = finished/skipped, which is also what pre-tutorial saves
+  restore as, so an existing run is never dropped into step 1). Dev:
+  `&tutorial=N`.
 - **Camera**: drag to pan, wheel/pinch to zoom.
 - **Fast-forward**: the 1×/2×/4× toggle under the HUD (`SC.state.speed`)
   runs that many fixed-size sub-steps of `economy`/`factories`/
@@ -309,6 +322,7 @@ they signal the UI through the tiny `SC.on`/`SC.emit` pub/sub in state.js.
 | `js/economy.js` | Orders (spawn/plan/deliver/expire) with recursive multi-tier sourcing, money, interest + default countdown, upgrades, supplier stock regen/upgrades, promotions, customer-DC spawn timer, contract offers (roll/accept/decline) and miss penalties |
 | `js/vehicles.js` | Trucks (each with a home yard), haul jobs, dispatcher (globally nearest idle truck per job, bundles same-route jobs up to capacity, sends idle trucks home), supplier-stock loading waits, reassignment, movement, `truckCountOnEdge` (feeds congestion) |
 | `js/stats.js` | Stats & achievements bookkeeping: deliveries per product, a periodic money-history sample for the sparkline, per-edge trip counts (`recordRoadUse`/`busiestRoad`), and milestone unlocks — all purely observational, listens to events other modules already emit (`roadBuilt`, `orderComplete`, etc.) rather than being called directly |
+| `js/tutorial.js` | Guided first-order tutorial: the step list, which nodes each step points at, and when a step is satisfied. Pure logic — ui.js renders the banner and render-network.js draws the focus dim/rings, both by reading `current()`/`focus()` |
 | `js/inspect.js` | Inspect-mode data: node → its connections/routes, for the hover/hold tooltip and highlight. Collected route paths carry a `.good` property per leg so the glow overlay tints each leg by its cargo (chain-step colors) |
 | `js/research.js` | Tech tree engine: one active project, cost/time, generic effect accessors (`bonusSum`, `customerSpawnMult`, `upgradeMaxBonus`) |
 | `js/placement.js` | Manual site placement: cost, validity (land/river/min-distance); supplier/factory locked behind research, truck yards and junctions are not |

--- a/supply-chain/audio-check.html
+++ b/supply-chain/audio-check.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Supply Chain Tycoon — audio check</title>
+<style>
+  body { background:#111827; color:#e5e7eb; font:14px/1.6 ui-monospace,Menlo,monospace; padding:24px; }
+  h1 { font-size:16px; color:#93c5fd; }
+  .pass { color:#6ee7b7; } .fail { color:#fca5a5; } .info { color:#94a3b8; }
+  #summary { margin-top:14px; font-weight:700; }
+  #summary.pass { color:#6ee7b7; } #summary.fail { color:#fca5a5; }
+</style>
+</head>
+<body>
+<h1>Audio check</h1>
+<p class="info">
+  The WebAudio layer can't be covered by <code>tests.html</code>: it needs a real
+  user gesture to open an AudioContext, and headless Chromium only allows that
+  with <code>--autoplay-policy=no-user-gesture-required</code>. This page fakes
+  the gesture and asserts the graph is actually wired and scheduling. See
+  CLAUDE.md → Verification.
+</p>
+<pre id="out">running…</pre>
+<div id="summary"></div>
+
+<script>window.SC_VERSION = 'audiocheck';</script>
+<script src="js/config.js"></script>
+<script src="js/state.js"></script>
+<script src="js/audio.js"></script>
+<script src="js/sfx.js"></script>
+<script>
+(function () {
+    const lines = [];
+    const ok = (name, cond, extra) =>
+        lines.push({ pass: !!cond, text: (cond ? 'PASS ' : 'FAIL ') + name + (extra ? ' — ' + extra : '') });
+    const info = t => lines.push({ info: true, text: 'INFO ' + t });
+
+    // --- before any gesture: nothing may exist, nothing may throw ---
+    ok('no context before gesture', SC.audio.sfxBus() === null);
+    let threw = null;
+    try { SC.audio.update(); } catch (e) { threw = e; }
+    ok('update() is a safe no-op before init', threw === null, threw && threw.message);
+
+    // --- fake the first user gesture (what opens the context in a real game) ---
+    document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+
+    const ctx = SC.audio.ctx();
+    ok('context created on gesture', !!ctx, ctx && ctx.state);
+    ok('sfx bus wired', !!SC.audio.sfxBus());
+    ok('music on by default', SC.audio.musicEnabled() === true);
+
+    if (ctx) {
+        // Tally every voice the score builds, whichever path creates it.
+        let oscCount = 0;
+        const realOsc = ctx.createOscillator.bind(ctx);
+        ctx.createOscillator = function () { oscCount++; return realOsc(); };
+
+        // A real state object with an empty fleet — exercises the traffic-hum
+        // path at zero trucks, and the no-render-layer branch of env().
+        SC.newState('normal');
+        SC.state.trucks = [];
+
+        // Drive the scheduler. This is the call that runs every frame in
+        // main.js — a throw here freezes the whole game loop, which is exactly
+        // the regression this page exists to catch.
+        let updThrew = null;
+        try { for (let i = 0; i < 40; i++) SC.audio.update(); } catch (e) { updThrew = e; }
+        ok('update() drives ambience + score without throwing', updThrew === null,
+           updThrew && updThrew.message);
+
+        info('ctx.state=' + ctx.state + ' currentTime=' + ctx.currentTime.toFixed(4));
+        ok('context running', ctx.state === 'running', ctx.state);
+        // One chord = 4 pad notes x 2 detuned oscillators + 1 bass root.
+        ok('score scheduled voices', oscCount >= 9, 'oscillators=' + oscCount);
+
+        let sfxThrew = null;
+        try {
+            ['click', 'build', 'demolish', 'cash', 'error', 'craft', 'unlock',
+             'expire', 'depart', 'science', 'warn'].forEach(n => SC.sfx.play(n));
+        } catch (e) { sfxThrew = e; }
+        ok('every sfx one-shot plays', sfxThrew === null, sfxThrew && sfxThrew.message);
+
+        // Throttled sounds must swallow a repeat inside their window.
+        const before = oscCount;
+        SC.sfx.play('depart');
+        ok('depart is throttled', oscCount === before, 'delta=' + (oscCount - before));
+
+        SC.audio.toggleMusic();
+        ok('music toggles off', SC.audio.musicEnabled() === false);
+        SC.audio.toggleMusic();
+        ok('music toggles back on', SC.audio.musicEnabled() === true);
+
+        // The Sound toggle also ducks the world ambience (see sfx.toggleMute).
+        let ambThrew = null;
+        try { SC.sfx.toggleMute(); SC.sfx.toggleMute(); } catch (e) { ambThrew = e; }
+        ok('sound toggle drives ambience', ambThrew === null, ambThrew && ambThrew.message);
+        ok('sound restored to unmuted', SC.sfx.isMuted() === false);
+    }
+
+    document.getElementById('out').innerHTML = lines
+        .map(l => '<span class="' + (l.info ? 'info' : l.pass ? 'pass' : 'fail') + '">' +
+                  l.text.replace(/</g, '&lt;') + '</span>')
+        .join('\n');
+    const checks = lines.filter(l => !l.info);
+    const failed = checks.filter(l => !l.pass).length;
+    const s = document.getElementById('summary');
+    s.className = failed ? 'fail' : 'pass';
+    s.textContent = (checks.length - failed) + ' passed / ' + failed + ' failed';
+})();
+</script>
+</body>
+</html>

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.53.2';</script>
+    <script>window.SC_VERSION = '1.54.0';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>
@@ -286,6 +286,7 @@
             <button class="menu-btn primary" id="menu-resume">▶ Resume</button>
             <button class="menu-btn" id="menu-save">💾 Save now</button>
             <button class="menu-btn" id="menu-sound">🔊 Sound</button>
+            <button class="menu-btn" id="menu-music">🎵 Music</button>
             <button class="menu-btn" id="menu-pills">🏷 Factory labels</button>
             <button class="menu-btn" id="menu-fullscreen">⛶ Full screen</button>
             <button class="menu-btn" id="menu-achievements">📊 Stats &amp; Achievements</button>
@@ -354,7 +355,7 @@
          it's a logic module). -->
     <script>
     (function () {
-        var mods = ['config', 'state', 'save', 'sfx', 'rng', 'map', 'camera',
+        var mods = ['config', 'state', 'save', 'audio', 'sfx', 'rng', 'map', 'camera',
                     'roads', 'factories', 'economy', 'vehicles', 'stats',
                     'inspect', 'research', 'placement',
                     'render-core', 'render-env', 'render-network', 'render-actors',

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.54.0';</script>
+    <script>window.SC_VERSION = '1.55.0';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>
@@ -69,6 +69,15 @@
     </div>
 
     <div id="inspect-tooltip"></div>
+
+    <!-- Guided first-order tutorial (js/tutorial.js). Hidden unless a fresh
+         run is mid-sequence; the map dims and points at the nodes each step
+         names. -->
+    <div id="tutorial-banner" class="hidden">
+        <div class="tut-step" id="tutorial-progress"></div>
+        <div class="tut-text" id="tutorial-text"></div>
+        <button class="tut-skip" id="tutorial-skip">Skip tutorial</button>
+    </div>
 
     <div id="contract-offer" class="hidden">
         <div class="contract-card">
@@ -357,7 +366,7 @@
     (function () {
         var mods = ['config', 'state', 'save', 'audio', 'sfx', 'rng', 'map', 'camera',
                     'roads', 'factories', 'economy', 'vehicles', 'stats',
-                    'inspect', 'research', 'placement',
+                    'inspect', 'research', 'placement', 'tutorial',
                     'render-core', 'render-env', 'render-network', 'render-actors',
                     'input', 'ui', 'ui-bind', 'main'];
         for (var i = 0; i < mods.length; i++)

--- a/supply-chain/js/audio.js
+++ b/supply-chain/js/audio.js
@@ -1,0 +1,266 @@
+// Ambient soundscape + generative music.
+//
+// Owns the shared AudioContext and the two mix buses every sound in the game
+// routes through, so `sfx.js`'s one-shots and the ambient bed share one
+// context, and so **Music and Sound toggle independently** (the roadmap's
+// "music toggle separate from sfx"). `sfx.js` asks this module for its bus
+// rather than opening a second context.
+//
+// Everything is synthesised at runtime — there are no audio assets. That keeps
+// the folder self-contained and the repo free of binary blobs, and it lets the
+// score react to game state (weather, day/night, traffic) in ways a fixed
+// recording can't.
+//
+// Like sfx.js this is a non-DOM-free module by nature (WebAudio + localStorage
+// + a gesture listener), so it sits beside sfx.js in the load order rather than
+// with the pure-logic modules. Nothing here reads or writes game state; it only
+// *observes* it in update(), so a headless test page can load it safely (no
+// gesture ever fires there, so no context is ever created).
+window.SC = window.SC || {};
+
+SC.audio = (function () {
+    let ctx = null;
+    let master = null, musicBus = null, sfxBus = null, ambBus = null;
+    let amb = null;            // { wind, rain, hum, humFilter } — built once
+    let noiseBuf = null;
+
+    // Music defaults ON: the player already opted into sound by opening a game,
+    // and autoplay policy means nothing is audible until they interact anyway.
+    let musicOn = localStorage.getItem('scTycoonMusic') !== 'false';
+
+    // --- generative score -------------------------------------------------
+    // A slow four-chord loop with a pad, a bass root and a sparse pentatonic
+    // melody. The melody scale is fixed A-minor-pentatonic, which is consonant
+    // over all four chords, so notes can be picked at random without ever
+    // landing on a clash.
+    const STEP = 0.5;                 // seconds per scheduler slot
+    const STEPS_PER_CHORD = 16;       // → 8s per chord, 32s per loop
+    const LOOKAHEAD = 0.4;            // schedule this far past the audio clock
+    const PROG = [
+        { root: 45, chord: [0, 3, 7, 10] },  // Am7
+        { root: 41, chord: [0, 4, 7, 11] },  // Fmaj7
+        { root: 48, chord: [0, 4, 7, 11] },  // Cmaj7
+        { root: 43, chord: [0, 4, 7, 10] }   // G7
+    ];
+    const MELODY = [69, 72, 74, 76, 79, 81, 84]; // A minor pentatonic, A4 up
+    let stepIdx = 0, nextStepAt = 0;
+
+    const midi = m => 440 * Math.pow(2, (m - 69) / 12);
+
+    // Read the render layer's cosmetic day/night + weather so the score and the
+    // ambience track what the player can see. Guarded: render may not be loaded
+    // (tests.html) and never is before the first frame.
+    function env() {
+        const R = SC._render;
+        const w = R && R.weather;
+        return {
+            day: R ? R.dayness : 0.5,
+            rain: w && w.type === 'rain' ? w.intensity : 0,
+            snow: w && w.type === 'snow' ? w.intensity : 0,
+            cloud: w ? w.cloud : 0,
+            wind: w ? w.windMag : 0.5
+        };
+    }
+
+    function makeNoise() {
+        const n = ctx.sampleRate * 2;
+        const b = ctx.createBuffer(1, n, ctx.sampleRate);
+        const d = b.getChannelData(0);
+        for (let i = 0; i < n; i++) d[i] = Math.random() * 2 - 1;
+        return b;
+    }
+
+    // One looping noise source → filter → gain, parked at silence. Ambience is
+    // shaped purely by moving these gains, so no nodes are ever created or
+    // destroyed per frame.
+    function noiseLayer(type, freq, q, dest) {
+        const src = ctx.createBufferSource();
+        src.buffer = noiseBuf;
+        src.loop = true;
+        const f = ctx.createBiquadFilter();
+        f.type = type;
+        f.frequency.value = freq;
+        if (q != null) f.Q.value = q;
+        const g = ctx.createGain();
+        g.gain.value = 0;
+        src.connect(f).connect(g).connect(dest);
+        src.start(0);
+        // `gain` is the AudioParam, not the node — update() only ever ramps it.
+        return { gain: g.gain, filter: f };
+    }
+
+    function build() {
+        master = ctx.createGain();
+        master.gain.value = 1;
+        master.connect(ctx.destination);
+
+        musicBus = ctx.createGain();
+        musicBus.gain.value = musicOn ? 0.32 : 0;
+        musicBus.connect(master);
+
+        sfxBus = ctx.createGain();
+        sfxBus.gain.value = 1;
+        sfxBus.connect(master);
+
+        // Ambience is world sound, not score — it follows the Sound (sfx)
+        // toggle, so muting "Sound" silences the world and leaves the music.
+        ambBus = ctx.createGain();
+        // The context is built on the first gesture, long after sfx.js has
+        // restored the saved Sound preference — honour it rather than fading
+        // the world in for a player who muted last session.
+        ambBus.gain.value = (SC.sfx && SC.sfx.isMuted()) ? 0 : 1;
+        ambBus.connect(master);
+
+        noiseBuf = makeNoise();
+        amb = {
+            wind: noiseLayer('lowpass', 420, null, ambBus),
+            rain: noiseLayer('highpass', 1100, null, ambBus),
+            hum: noiseLayer('bandpass', 110, 5, ambBus)
+        };
+
+        nextStepAt = ctx.currentTime + 0.1;
+    }
+
+    function init() {
+        if (ctx) {
+            if (ctx.state === 'suspended') ctx.resume();
+            return ctx;
+        }
+        try {
+            ctx = new (window.AudioContext || window.webkitAudioContext)();
+            build();
+        } catch (e) { ctx = null; /* no audio support — stay silent */ }
+        return ctx;
+    }
+    ['pointerdown', 'keydown'].forEach(ev =>
+        document.addEventListener(ev, init, { once: true }));
+
+    // --- voices -----------------------------------------------------------
+    function pad(freq, t, dur, cutoff) {
+        const f = ctx.createBiquadFilter();
+        f.type = 'lowpass';
+        f.frequency.setValueAtTime(cutoff, t);
+        const g = ctx.createGain();
+        g.gain.setValueAtTime(0.0001, t);
+        g.gain.linearRampToValueAtTime(0.09, t + 1.4);          // slow swell
+        g.gain.setValueAtTime(0.09, t + dur - 1.8);
+        g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+        f.connect(g).connect(musicBus);
+        [0, 1].forEach(i => {
+            const o = ctx.createOscillator();
+            o.type = 'triangle';
+            o.frequency.setValueAtTime(freq * (i ? 1.006 : 0.997), t); // detune
+            o.connect(f);
+            o.start(t);
+            o.stop(t + dur + 0.1);
+        });
+    }
+
+    function bass(freq, t, dur) {
+        const o = ctx.createOscillator();
+        const g = ctx.createGain();
+        o.type = 'sine';
+        o.frequency.setValueAtTime(freq, t);
+        g.gain.setValueAtTime(0.0001, t);
+        g.gain.linearRampToValueAtTime(0.11, t + 0.5);
+        g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+        o.connect(g).connect(musicBus);
+        o.start(t);
+        o.stop(t + dur + 0.1);
+    }
+
+    function pluck(freq, t, vol) {
+        const o = ctx.createOscillator();
+        const f = ctx.createBiquadFilter();
+        const g = ctx.createGain();
+        o.type = 'triangle';
+        o.frequency.setValueAtTime(freq, t);
+        f.type = 'lowpass';
+        f.frequency.setValueAtTime(2400, t);
+        f.frequency.exponentialRampToValueAtTime(700, t + 0.9);
+        g.gain.setValueAtTime(0.0001, t);
+        g.gain.linearRampToValueAtTime(vol, t + 0.02);
+        g.gain.exponentialRampToValueAtTime(0.0001, t + 1.1);
+        o.connect(f).connect(g).connect(musicBus);
+        o.start(t);
+        o.stop(t + 1.2);
+    }
+
+    // One scheduler slot. Chords land on the downbeat; the melody is a coin
+    // flip per off-step, biased by daylight — busy and bright by day, sparse
+    // and dark at night, so the score breathes with the day/night cycle.
+    function scheduleStep(i, t) {
+        const e = env();
+        const ch = PROG[Math.floor(i / STEPS_PER_CHORD) % PROG.length];
+        const beat = i % STEPS_PER_CHORD;
+
+        if (beat === 0) {
+            const dur = STEP * STEPS_PER_CHORD * 0.98;
+            const cutoff = 620 + 900 * e.day - 260 * e.cloud;
+            ch.chord.forEach(iv => pad(midi(ch.root + iv + 12), t, dur, cutoff));
+            bass(midi(ch.root - 12), t, dur);
+        }
+        if (beat % 2 === 0 && Math.random() < 0.14 + 0.26 * e.day) {
+            pluck(midi(MELODY[(Math.random() * MELODY.length) | 0]), t,
+                  0.05 + 0.03 * e.day);
+        }
+    }
+
+    // --- per-frame ---------------------------------------------------------
+    // Called from the main loop every frame (not per sub-step: audio is
+    // wall-clock, so fast-forward must not speed the music up).
+    function update() {
+        if (!ctx || ctx.state !== 'running') return;
+        const now = ctx.currentTime;
+
+        if (musicOn) {
+            // Catch up if the tab was backgrounded (rAF stops, the audio clock
+            // doesn't) rather than dumping a burst of overdue notes at once.
+            if (nextStepAt < now - 1) { nextStepAt = now + 0.05; }
+            while (nextStepAt < now + LOOKAHEAD) {
+                scheduleStep(stepIdx++, nextStepAt);
+                nextStepAt += STEP;
+            }
+        }
+
+        if (!amb) return;
+        const e = env();
+        const quiet = (SC.state && (SC.state.paused || SC.state.gameOver)) ? 0 : 1;
+        // Traffic hum rises with how many trucks are actually rolling, so a
+        // busy network is audibly busy. Saturating, not linear — the 30th truck
+        // shouldn't be 30× the 1st.
+        const rolling = (SC.state && SC.state.trucks)
+            ? SC.state.trucks.reduce((n, t) => n + (t.path ? 1 : 0), 0) : 0;
+        const traffic = 1 - Math.exp(-rolling / 6);
+
+        const set = (p, v) => p.setTargetAtTime(v, now, 0.6);
+        set(amb.wind.gain, quiet * (0.012 + 0.026 * e.cloud + 0.018 * e.wind + 0.02 * e.snow));
+        set(amb.rain.gain, quiet * 0.05 * e.rain);
+        set(amb.hum.gain, quiet * 0.055 * traffic);
+        amb.hum.filter.frequency.setTargetAtTime(95 + 45 * traffic, now, 0.8);
+    }
+
+    function applyMusic() {
+        if (!musicBus) return;
+        musicBus.gain.setTargetAtTime(musicOn ? 0.32 : 0, ctx.currentTime, 0.25);
+    }
+
+    return {
+        // Shared plumbing for sfx.js.
+        ctx: () => ctx || init(),
+        sfxBus: () => sfxBus,
+        // Ambience follows the Sound toggle (see build()).
+        setAmbientMuted(m) {
+            if (ambBus) ambBus.gain.setTargetAtTime(m ? 0 : 1, ctx.currentTime, 0.2);
+        },
+        update,
+        musicEnabled: () => musicOn,
+        toggleMusic() {
+            musicOn = !musicOn;
+            localStorage.setItem('scTycoonMusic', String(musicOn));
+            init();
+            applyMusic();
+            return musicOn;
+        }
+    };
+})();

--- a/supply-chain/js/main.js
+++ b/supply-chain/js/main.js
@@ -76,6 +76,9 @@ SC.init = function() {
             }
         }
         SC.render.frame(dt, SC.state.time);
+        // Ambience/score run on the wall clock, so this stays outside the
+        // fast-forward sub-step loop — 4× speed must not pitch the music up.
+        SC.audio.update();
         SC.ui.update(dt);
         requestAnimationFrame(loop);
     }

--- a/supply-chain/js/main.js
+++ b/supply-chain/js/main.js
@@ -47,6 +47,18 @@ SC.init = function() {
     });
 
     SC.ui.init();
+    // Headless verification hook (see CLAUDE.md): &tutorial=N drops a fresh
+    // world straight onto tutorial step N (1-based, default 1) so the banner
+    // and the focus dim/rings can be screenshotted. Deliberately NOT part of
+    // ?probe=, which builds the starter roads and would satisfy the first
+    // three steps before the shot is taken.
+    if (params.has('tutorial')) {
+        SC.state.gameStarted = true;
+        SC.tutorial.start();
+        const n = parseInt(params.get('tutorial'), 10);
+        if (n > 1) SC.state.tutorialStep = Math.min(n - 1, SC.tutorial.stepCount - 1);
+        SC._ui.updateTutorial();
+    }
     if (restored) SC.emit('toast', { text: 'Game restored from autosave', kind: 'info' });
 
     let last = performance.now();

--- a/supply-chain/js/render-core.js
+++ b/supply-chain/js/render-core.js
@@ -351,6 +351,9 @@ SC.render = (function() {
         R.drawFloaters(dt);
         R.drawGrade();             // time-of-day colour grade over world + sky
         R.drawPrecip(dt);          // rain/snow on top, left ungraded so it stays crisp
+        // After the grade/precip so the dim isn't lifted back out by them, but
+        // under the vignette/arrows so those still frame the shot.
+        R.drawTutorialFocus(now);
         R.drawVignette();          // frame the scene…
         R.drawOffscreenArrows(now); // …but keep edge arrows crisp on top
     }

--- a/supply-chain/js/render-env.js
+++ b/supply-chain/js/render-env.js
@@ -13,6 +13,10 @@
     const WEATHER_ROTATION = ['clear', 'clouds', 'rain', 'clouds', 'clear', 'snow', 'clouds'];
     let weather = { i: 0, type: 'clear', t: 0, dur: 40, intensity: 0, cloud: 0,
                     snow: 0, windAng: 0.6, windMag: 0.5 };
+    // Shared so the audio layer can score the ambience to the visible weather
+    // (see js/audio.js `env()`). Mutated in place, never reassigned — the
+    // reference stays valid for the life of the page.
+    R.weather = weather;
     let forcedWeather = null;               // &weather= for screenshots
     let precip = [];                        // rain/snow particle pool (screen-space)
     let clouds = null;                      // drifting overcast blobs (screen-space)

--- a/supply-chain/js/render-network.js
+++ b/supply-chain/js/render-network.js
@@ -1079,6 +1079,80 @@
         groundRing(g.x, g.y, sp.fw + 8, color, 2.5);
     }
 
+    // Scratch layer for the tutorial dim — see drawTutorialFocus.
+    let dimLayer = null;
+
+    // ── Guided tutorial focus (js/tutorial.js decides the targets) ──────
+    // Dims the whole field, then punches a soft hole around each node the
+    // current step names and rings it — so "tap the bakery, then the wheat
+    // farm" points at two specific buildings instead of leaving the player to
+    // find them. Drawn per frame in the main pass (never into the cached bg
+    // layer, which would bake the dim in permanently).
+    function drawTutorialFocus(now) {
+        const targets = SC.tutorial.focus();
+        if (!targets.length) return;
+        const ctx = R.ctx;
+        const w = R.canvas.width / R.dpr, h = R.canvas.height / R.dpr;
+        const spots = targets.map(n => {
+            const sp = nodeSpec(n);
+            const g = S(n.x, n.y);
+            // Cover the building's full extruded height, not just its footprint
+            // — the hole has to reveal the whole silhouette, not its base.
+            const top = (sp.h || 0) * zoom();
+            return { n, sp, g, top, r: (sp.fw + 46) * clampZoom() + top * 0.5 };
+        });
+
+        // Dim pass. The holes are punched with 'destination-out', which erases
+        // whatever is already in the target canvas — so this MUST happen on a
+        // scratch layer and be blitted over, never straight onto the frame
+        // (doing that erases the buildings the holes are meant to reveal, and
+        // save/restore does NOT isolate compositing).
+        if (!dimLayer) dimLayer = document.createElement('canvas');
+        if (dimLayer.width !== R.canvas.width || dimLayer.height !== R.canvas.height) {
+            dimLayer.width = R.canvas.width;
+            dimLayer.height = R.canvas.height;
+        }
+        const dctx = dimLayer.getContext('2d');
+        dctx.setTransform(R.dpr, 0, 0, R.dpr, 0, 0);
+        dctx.clearRect(0, 0, w, h);
+        dctx.fillStyle = 'rgba(6, 12, 24, 0.5)';
+        dctx.fillRect(0, 0, w, h);
+        dctx.globalCompositeOperation = 'destination-out';
+        for (const s of spots) {
+            const grd = dctx.createRadialGradient(s.g.x, s.g.y, s.r * 0.3, s.g.x, s.g.y, s.r);
+            grd.addColorStop(0, 'rgba(0,0,0,1)');
+            grd.addColorStop(1, 'rgba(0,0,0,0)');
+            dctx.fillStyle = grd;
+            dctx.beginPath();
+            dctx.arc(s.g.x, s.g.y, s.r, 0, Math.PI * 2);
+            dctx.fill();
+        }
+        dctx.globalCompositeOperation = 'source-over';
+        ctx.save();
+        ctx.setTransform(1, 0, 0, 1, 0, 0);   // blit in device pixels
+        ctx.drawImage(dimLayer, 0, 0);
+        ctx.restore();
+
+        // Pulsing ground ring + a bobbing arrow, so the target still reads on a
+        // busy map where the dim alone is subtle.
+        const pulse = 1 + Math.sin(now * 4) * 0.09;
+        for (const s of spots) {
+            groundRing(s.g.x, s.g.y, s.sp.fw + 10, '#38bdf8', 2.5, pulse);
+            const bob = Math.sin(now * 4) * 4 * clampZoom();
+            const tipY = s.g.y - s.top - 26 * clampZoom() + bob;
+            const a = 9 * clampZoom();
+            ctx.beginPath();
+            ctx.moveTo(s.g.x, tipY + a);              // point down at the node
+            ctx.lineTo(s.g.x - a * 0.8, tipY - a * 0.5);
+            ctx.lineTo(s.g.x + a * 0.8, tipY - a * 0.5);
+            ctx.closePath();
+            ctx.fillStyle = '#38bdf8';
+            ctx.globalAlpha = 0.9;
+            ctx.fill();
+            ctx.globalAlpha = 1;
+        }
+    }
+
     function drawGhostRoad() {
         const sel = SC.state.selectedNode;
         const hover = SC.input.getHover && SC.input.getHover();
@@ -1241,5 +1315,5 @@
 
     Object.assign(R, { drawRoads, drawRouteFlow, nodeSpec, drawShadow, drawSupplierSite, drawJunction,
         drawNodeBody, drawYardParking, drawYardSite, emojiPlateAt, drawOrderBubbles,
-        drawHighlight, drawInspectHighlight, drawGhostRoad, drawPlacementGhost, drawOffscreenArrows });
+        drawHighlight, drawInspectHighlight, drawTutorialFocus, drawGhostRoad, drawPlacementGhost, drawOffscreenArrows });
 })();

--- a/supply-chain/js/save.js
+++ b/supply-chain/js/save.js
@@ -43,6 +43,7 @@ SC.save = (function() {
             worldW: st.worldW, worldH: st.worldH, expansions: st.expansions,
             congestionEnabled: st.congestionEnabled,
             autoAcceptContracts: st.autoAcceptContracts,
+            tutorialStep: st.tutorialStep,
             money: st.money, earnedTotal: st.earnedTotal,
             interestPaid: st.interestPaid,
             delivered: st.delivered, missed: st.missed,
@@ -124,6 +125,9 @@ SC.save = (function() {
         st.congestionEnabled = data.congestionEnabled !== undefined
             ? data.congestionEnabled : SC.DIFFICULTIES[st.difficulty].congestion;
         st.autoAcceptContracts = !!data.autoAcceptContracts;
+        // Saves from before the tutorial shipped have no step — those players
+        // are mid-run and shouldn't be dropped into step 1, so default to -1.
+        st.tutorialStep = (typeof data.tutorialStep === 'number') ? data.tutorialStep : -1;
         st.upgrades = Object.assign(st.upgrades, data.upgrades);
         if (data.research) {
             st.research.completed = Object.assign({}, data.research.completed);

--- a/supply-chain/js/sfx.js
+++ b/supply-chain/js/sfx.js
@@ -1,36 +1,61 @@
-// Tiny WebAudio synth for UI feedback. Follows the cargo-lander audio
-// pattern: lazy init on first user gesture (autoplay policy) and a mute
-// flag persisted in localStorage.
+// Tiny WebAudio synth for UI feedback. The AudioContext and the mix buses live
+// in `audio.js` (loaded just before this) so one-shots, the ambient bed and the
+// generative score share one context — this module only synthesises the blips
+// and routes them into the sfx bus.
+//
+// `muted` here is the **Sound** toggle: one-shots *and* the world ambience.
+// Music has its own toggle (`SC.audio.toggleMusic`).
 window.SC = window.SC || {};
 
 SC.sfx = (function() {
-    let ctx = null;
     let muted = localStorage.getItem('scTycoonMuted') === 'true';
+    const lastAt = {};   // name → ctx time, for rate-limited sounds
 
-    function init() {
-        if (ctx) {
-            if (ctx.state === 'suspended') ctx.resume();
-            return;
-        }
-        try {
-            ctx = new (window.AudioContext || window.webkitAudioContext)();
-        } catch (e) { /* no audio support — stay silent */ }
+    function bus() {
+        const ctx = SC.audio.ctx();
+        if (!ctx) return null;
+        return { ctx, dest: SC.audio.sfxBus() || ctx.destination };
     }
-    ['pointerdown', 'keydown'].forEach(ev =>
-        document.addEventListener(ev, init, { once: true }));
 
-    function tone(freq, dur, type, vol, delay) {
-        if (!ctx || muted) return;
-        const t0 = ctx.currentTime + (delay || 0);
-        const osc = ctx.createOscillator();
-        const gain = ctx.createGain();
+    function tone(freq, dur, type, vol, delay, endFreq) {
+        if (muted) return;
+        const b = bus();
+        if (!b) return;
+        const t0 = b.ctx.currentTime + (delay || 0);
+        const osc = b.ctx.createOscillator();
+        const gain = b.ctx.createGain();
         osc.type = type || 'sine';
         osc.frequency.setValueAtTime(freq, t0);
+        if (endFreq) osc.frequency.exponentialRampToValueAtTime(endFreq, t0 + dur);
         gain.gain.setValueAtTime(vol || 0.15, t0);
         gain.gain.exponentialRampToValueAtTime(0.001, t0 + dur);
-        osc.connect(gain).connect(ctx.destination);
+        osc.connect(gain).connect(b.dest);
         osc.start(t0);
         osc.stop(t0 + dur);
+    }
+
+    // Short filtered-noise burst — used for the things that shouldn't be a
+    // clean pitch (engine puff, tyre roll).
+    function noise(dur, filterType, freq, vol, delay) {
+        if (muted) return;
+        const b = bus();
+        if (!b) return;
+        const t0 = b.ctx.currentTime + (delay || 0);
+        const n = Math.max(1, Math.floor(b.ctx.sampleRate * dur));
+        const buf = b.ctx.createBuffer(1, n, b.ctx.sampleRate);
+        const d = buf.getChannelData(0);
+        for (let i = 0; i < n; i++) d[i] = Math.random() * 2 - 1;
+        const src = b.ctx.createBufferSource();
+        src.buffer = buf;
+        const f = b.ctx.createBiquadFilter();
+        f.type = filterType;
+        f.frequency.setValueAtTime(freq, t0);
+        const g = b.ctx.createGain();
+        g.gain.setValueAtTime(vol, t0);
+        g.gain.exponentialRampToValueAtTime(0.001, t0 + dur);
+        src.connect(f).connect(g).connect(b.dest);
+        src.start(t0);
+        src.stop(t0 + dur);
     }
 
     const sounds = {
@@ -41,14 +66,39 @@ SC.sfx = (function() {
         error:    () => tone(140, 0.2, 'sawtooth', 0.1),
         craft:    () => tone(520, 0.08, 'triangle', 0.07),
         unlock:   () => { tone(523, 0.1, 'sine', 0.1); tone(659, 0.1, 'sine', 0.1, 0.09); tone(784, 0.16, 'sine', 0.1, 0.18); },
-        expire:   () => { tone(300, 0.12, 'triangle', 0.09); tone(210, 0.2, 'triangle', 0.09, 0.1); }
+        expire:   () => { tone(300, 0.12, 'triangle', 0.09); tone(210, 0.2, 'triangle', 0.09, 0.1); },
+        // A truck pulling away: an airy diesel puff under a short rising note.
+        // Deliberately quiet — dispatch fires this often on a busy map.
+        depart:   () => { noise(0.22, 'bandpass', 240, 0.05); tone(120, 0.18, 'triangle', 0.035, 0, 165); },
+        // Research finished: a brighter, longer version of `unlock`.
+        science:  () => { tone(659, 0.1, 'sine', 0.09); tone(880, 0.1, 'sine', 0.09, 0.1);
+                          tone(1109, 0.1, 'sine', 0.09, 0.2); tone(1319, 0.3, 'sine', 0.1, 0.3); },
+        // Debt/default warning: a slow two-pulse low alarm, distinct from `error`.
+        warn:     () => { tone(196, 0.22, 'square', 0.07); tone(185, 0.3, 'square', 0.07, 0.26); }
     };
 
+    // Some sounds ride on events that can fire several times in one tick
+    // (dispatch assigning a batch of jobs). Collapse those into one blip.
+    const THROTTLE = { depart: 0.35, craft: 0.12 };
+
     return {
-        play(name) { if (sounds[name]) sounds[name](); },
+        play(name) {
+            const fn = sounds[name];
+            if (!fn || muted) return;
+            const gap = THROTTLE[name];
+            if (gap) {
+                const ctx = SC.audio.ctx();
+                if (!ctx) return;
+                const now = ctx.currentTime;
+                if (lastAt[name] && now - lastAt[name] < gap) return;
+                lastAt[name] = now;
+            }
+            fn();
+        },
         toggleMute() {
             muted = !muted;
             localStorage.setItem('scTycoonMuted', String(muted));
+            SC.audio.setAmbientMuted(muted); // Sound covers the world ambience too
             return muted;
         },
         isMuted: () => muted

--- a/supply-chain/js/state.js
+++ b/supply-chain/js/state.js
@@ -61,6 +61,9 @@ SC.newState = function(difficulty) {
         mode: 'build',      // 'build' (default, tap-to-build) | 'upgrade' | 'inspect'
         placeMode: null,    // { kind: 'supplier'|'factory'|'yard', good } — manual placement (input.js)
         gameStarted: false,
+        // Guided first-order tutorial (tutorial.js): 0..N-1 = on that step,
+        // -1 = finished or skipped. Persisted so a reload resumes mid-sequence.
+        tutorialStep: -1,
 
         deliveredByProduct: {},  // see stats.js — { goodKey: count }
         moneyHistory: [],        // recent SC.state.money samples, see stats.js tick

--- a/supply-chain/js/tutorial.js
+++ b/supply-chain/js/tutorial.js
@@ -1,0 +1,110 @@
+// Guided first-order tutorial (PLAN.md Phase 1 item 5).
+//
+// The help overlay explains the rules but leaves a new player staring at an
+// empty map wondering what to tap first. This walks them through the one
+// sequence that makes the game click — wire the bakery to its two suppliers,
+// link it to HQ, watch a truck fill the first order — by naming the exact next
+// tap and pointing at the nodes it means.
+//
+// Pure logic: it decides *what* the current step is and *which nodes* it points
+// at, and never touches the DOM or canvas. ui.js renders the banner and
+// render-network.js draws the focus rings/arrows, both by reading `current()`
+// and `focus()`. Progress is derived from the same events the rest of the game
+// already emits, so a step can't get stuck out of sync with the world — if the
+// player builds the road the step is asking for before reading the step, the
+// check still passes the moment it re-evaluates.
+window.SC = window.SC || {};
+
+SC.tutorial = (function () {
+    // Node lookups are re-run per check rather than captured at start: the
+    // starter cluster is fixed, but a supplier can be upgraded/replaced and a
+    // restored save has entirely different node objects than the ones a
+    // captured reference would hold.
+    const hq = () => SC.state.nodes.find(n => n.kind === 'city' && n.isHQ);
+    const bakery = () => SC.state.nodes.find(n => n.kind === 'factory' && n.active && n.recipe === 'bread');
+    const supplier = mat => {
+        const f = bakery();
+        if (!f) return null;
+        // Nearest active supplier of that good — on a fresh map there's exactly
+        // one, but after milestone unlocks add more, point at the closest.
+        return SC.state.nodes
+            .filter(n => n.kind === 'supplier' && n.active && n.mat === mat)
+            .sort((a, b) => Math.hypot(a.x - f.x, a.y - f.y) - Math.hypot(b.x - f.x, b.y - f.y))[0] || null;
+    };
+
+    const linked = (a, b) => !!(a && b && a.edges.indexOf(b) !== -1);
+    const routed = (a, b) => !!(a && b && SC.roads.findPath(a, b));
+
+    // Each step names the tap it wants, the nodes to point at, and the
+    // condition that retires it. `done()` states the goal rather than the
+    // action, so any route to it counts — `refresh()` re-checks on the events
+    // that can change the answer (roads built/demolished, orders filled), never
+    // per frame, since the HQ check runs a Dijkstra.
+    const STEPS = [
+        {
+            id: 'wheat',
+            text: '🌾 Your bakery needs wheat. Tap the <b>bakery</b>, then the <b>wheat farm</b>, to build a road between them.',
+            targets: () => [bakery(), supplier('wheat')],
+            done: () => linked(bakery(), supplier('wheat'))
+        },
+        {
+            id: 'water',
+            text: '💧 Bread needs water too. Now road the <b>bakery</b> to the <b>water pump</b>.',
+            targets: () => [bakery(), supplier('water')],
+            done: () => linked(bakery(), supplier('water'))
+        },
+        {
+            id: 'hq',
+            text: '⭐ Link the <b>bakery</b> to <b>HQ</b> so your trucks have somewhere to deliver the bread.',
+            targets: () => [bakery(), hq()],
+            done: () => routed(bakery(), hq())
+        },
+        {
+            id: 'deliver',
+            text: '🚚 That\'s a supply chain! Trucks dispatch themselves — sit back and watch your first order get filled.',
+            targets: () => [],
+            done: () => SC.state.delivered > 0
+        }
+    ];
+
+    // Advance past every satisfied step, not just one: a single road can
+    // complete two steps at once (linking the bakery to HQ can also be the
+    // step that first routes them), and a restored save can land mid-sequence.
+    function refresh() {
+        if (!active()) return;
+        let moved = false;
+        while (SC.state.tutorialStep < STEPS.length && STEPS[SC.state.tutorialStep].done()) {
+            SC.state.tutorialStep++;
+            moved = true;
+        }
+        if (!moved) return;
+        if (SC.state.tutorialStep >= STEPS.length) finish();
+        else SC.emit('tutorialStep', STEPS[SC.state.tutorialStep]);
+    }
+
+    function finish() {
+        SC.state.tutorialStep = -1;   // -1 = retired, distinct from "at step 0"
+        SC.emit('tutorialDone');
+    }
+
+    const active = () => SC.state.gameStarted && SC.state.tutorialStep >= 0 &&
+                         SC.state.tutorialStep < STEPS.length;
+
+    return {
+        // Fresh runs only — a restored save keeps whatever step it saved, and a
+        // player who has already finished (or skipped) stays finished.
+        start() {
+            SC.state.tutorialStep = 0;
+            refresh();  // skip any step the starter cluster already satisfies
+            if (active()) SC.emit('tutorialStep', STEPS[SC.state.tutorialStep]);
+        },
+        skip: finish,
+        refresh,
+        active,
+        current: () => (active() ? STEPS[SC.state.tutorialStep] : null),
+        // Nodes the current step points at, minus any that don't exist yet.
+        focus: () => (active() ? STEPS[SC.state.tutorialStep].targets().filter(Boolean) : []),
+        stepCount: STEPS.length,
+        stepIndex: () => SC.state.tutorialStep
+    };
+})();

--- a/supply-chain/js/ui-bind.js
+++ b/supply-chain/js/ui-bind.js
@@ -5,7 +5,7 @@
 // lived inside the ui.js closure.
 (function () {
     const U = SC._ui;
-    const { $, fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, setHidePills, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, openStatsOverlay, closeStatsOverlay, openAchievementDetail, closeAchievementDetail, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, focusOrder, yardLabel, openYardOverlay, closeYardOverlay } = U;
+    const { $, fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, setHidePills, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, openStatsOverlay, closeStatsOverlay, openAchievementDetail, closeAchievementDetail, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, focusOrder, yardLabel, openYardOverlay, closeYardOverlay, updateTutorial } = U;
     const getDevMode = U.getDevMode;
     const getHidePills = U.getHidePills;
 
@@ -324,6 +324,10 @@
             const fresh = !SC.state.gameStarted; // help opened mid-game shouldn't re-hint
             SC.state.gameStarted = true;
             SC.state.paused = false; // in case help was opened via the menu
+            // Fresh runs get the guided first-order walkthrough; a restored
+            // save resumes whatever step it persisted, so don't restart it.
+            if (fresh) SC.tutorial.start();
+            updateTutorial();
             // One-time riverside-grace hint at the very start of a run.
             const graceLeft = SC.map.riverGraceRemaining();
             if (fresh && graceLeft > 0) {
@@ -331,8 +335,24 @@
             }
         });
 
+        $('tutorial-skip').addEventListener('click', () => {
+            SC.sfx.play('click');
+            SC.tutorial.skip();
+            updateTutorial();
+        });
+
         // Game event feedback
         SC.on('toast', d => toast(d.text, d.kind));
+        // The tutorial's steps are goals, not actions — re-check them whenever
+        // something could have satisfied one. Cheaper and more robust than
+        // polling: a step can also be completed by a road built for other
+        // reasons, or by demolishing one (which can un-route the HQ step).
+        ['roadBuilt', 'roadDemolished', 'orderComplete'].forEach(ev =>
+            SC.on(ev, () => { SC.tutorial.refresh(); updateTutorial(); }));
+        SC.on('tutorialDone', () => {
+            updateTutorial();
+            toast('🎓 Tutorial complete — the map grows as you deliver. Good luck!', 'good');
+        });
         SC.on('orderComplete', o => {
             SC.sfx.play('cash');
             toast(o.contract ? `📜 Contract fulfilled! +${fmt(o.payout)}` : `Order filled: +${fmt(o.payout)}`, 'good');

--- a/supply-chain/js/ui-bind.js
+++ b/supply-chain/js/ui-bind.js
@@ -102,6 +102,11 @@
             SC.sfx.toggleMute();
             updateMenuInfo();
         });
+        $('menu-music').addEventListener('click', () => {
+            SC.audio.toggleMusic();
+            SC.sfx.play('click');
+            updateMenuInfo();
+        });
         $('menu-pills').addEventListener('click', () => {
             setHidePills(!getHidePills());
             SC.sfx.play('click');
@@ -337,6 +342,9 @@
         SC.on('crossingChoice', openCrossingChoice);
         SC.on('contractFailed', d => { SC.sfx.play('expire'); toast(`📜 Contract failed — penalty ${fmt(d.penalty)}`, 'error'); });
         SC.on('crafted', () => SC.sfx.play('craft'));
+        // Dispatch can assign a whole batch in one tick; sfx.js throttles this
+        // one so a busy map gets a single puff, not a machine-gun of them.
+        SC.on('truckDispatched', () => SC.sfx.play('depart'));
         SC.on('salvage', () => toast(`Late delivery salvaged for ${fmt(SC.CONFIG.SALVAGE_PAY)}`, 'info'));
         SC.on('unlock', n => {
             SC.sfx.play('unlock');
@@ -348,7 +356,7 @@
             toast(`📍 ${what}${across ? ' — across the river 🌉' : ''}!`, 'good');
         });
         SC.on('researchComplete', id => {
-            SC.sfx.play('unlock');
+            SC.sfx.play('science');
             toast(`🔬 Research complete: ${SC.RESEARCH[id].name}!`, 'good');
         });
         SC.on('achievementUnlocked', id => {
@@ -360,7 +368,7 @@
             });
         });
         SC.on('debtWarning', d => {
-            SC.sfx.play('error');
+            SC.sfx.play('warn');
             toast(`🏦 Debt past your credit limit — recover within ${Math.round(d.grace)}s or the bank forecloses!`, 'error');
         });
         SC.on('debtRecovered', () => toast('Debt back within the credit limit — default averted', 'good'));

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -872,6 +872,10 @@ SC.ui = (function() {
         updateOrders();
         updateShop();
         updateHUD();
+        // A save restored mid-tutorial resumes on its persisted step, so the
+        // banner has to be reinstated at boot, not only on the Start button.
+        SC.tutorial.refresh();
+        updateTutorial();
         const params = new URLSearchParams(location.search);
         // ?new=1 (menu "New game" / post-foreclosure restart) always routes
         // through the new-game screen so the difficulty can be picked.
@@ -911,9 +915,25 @@ SC.ui = (function() {
     // decide whether the factory production pills should auto-hide at low
     // zoom — the only cross-module read of a ☰-menu toggle from the render
     // layer, since drawing (not just event wiring) needs to react to it live.
+    // ── Guided tutorial banner (js/tutorial.js decides the steps) ─────
+    function updateTutorial() {
+        const step = SC.tutorial.current();
+        const el = $('tutorial-banner');
+        el.classList.toggle('hidden', !step);
+        if (!step) return;
+        // Only touch the DOM when the step actually changes — this runs on
+        // every event refresh, and rewriting innerHTML would restart the
+        // banner's entrance animation each time.
+        if (el.dataset.step === step.id) return;
+        el.dataset.step = step.id;
+        $('tutorial-progress').textContent =
+            `Step ${SC.tutorial.stepIndex() + 1} of ${SC.tutorial.stepCount}`;
+        $('tutorial-text').innerHTML = step.text;
+    }
+
     SC._ui = {
         $, getDevMode: () => devMode, getHidePills: () => hidePills,
-        fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, setHidePills, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, openStatsOverlay, closeStatsOverlay, openAchievementDetail, closeAchievementDetail, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, focusOrder, yardLabel, openYardOverlay, closeYardOverlay,
+        fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, setHidePills, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, openStatsOverlay, closeStatsOverlay, openAchievementDetail, closeAchievementDetail, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, focusOrder, yardLabel, openYardOverlay, closeYardOverlay, updateTutorial,
     };
 
     return { init, update, toast, openStatsOverlay };

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -794,6 +794,7 @@ SC.ui = (function() {
             ? `Autosaves every ${SC.CONFIG.AUTOSAVE_INTERVAL}s · last saved ${fmtDuration((Date.now() - at) / 1000)} ago`
             : `Autosaves every ${SC.CONFIG.AUTOSAVE_INTERVAL}s · not saved yet this session`;
         $('menu-sound').textContent = SC.sfx.isMuted() ? '🔇 Sound: off' : '🔊 Sound: on';
+        $('menu-music').textContent = SC.audio.musicEnabled() ? '🎵 Music: on' : '🎵 Music: off';
         $('menu-fullscreen').textContent = document.fullscreenElement ? '⛶ Exit full screen' : '⛶ Full screen';
         $('menu-dev').textContent = devMode ? '🛠 Dev tools: on' : '🛠 Dev tools: off';
         $('menu-pills').textContent = hidePills ? '🏷 Factory labels: auto-hide' : '🏷 Factory labels: always on';

--- a/supply-chain/js/vehicles.js
+++ b/supply-chain/js/vehicles.js
@@ -147,6 +147,7 @@ SC.vehicles = (function() {
             bestTruck.jobs = bundle;
             bestTruck.phase = 'toPickup';
             setPath(bestTruck, bestRoute.path);
+            SC.emit('truckDispatched', bestTruck);
             idle = idle.filter(t => t !== bestTruck);
         }
 

--- a/supply-chain/style.css
+++ b/supply-chain/style.css
@@ -1067,3 +1067,65 @@ html, body {
 
     .research-tree-card { width: 1380px; max-width: 96vw; max-height: 90vh; }
 }
+
+/* ── Guided first-order tutorial (js/tutorial.js) ──────────────────────
+   A banner centred at the top, clear of the HUD (top-left) and the Orders
+   panel (top-right). The map dims and pulses rings on the nodes the current
+   step names — that drawing lives in render-network.js, not here. */
+#tutorial-banner {
+    position: fixed;
+    top: 0.75rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 160;
+    width: min(30rem, calc(100vw - 2rem));
+    background: var(--card-bg);
+    border: 1px solid rgba(56, 189, 248, 0.45);
+    border-radius: 12px;
+    padding: 0.6rem 0.8rem 0.55rem;
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+    text-align: center;
+    animation: tut-in 0.25s ease-out;
+}
+#tutorial-banner.hidden { display: none; }
+
+@keyframes tut-in {
+    from { opacity: 0; transform: translate(-50%, -0.5rem); }
+    to   { opacity: 1; transform: translate(-50%, 0); }
+}
+
+.tut-step {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+    color: var(--accent-color);
+    font-weight: 700;
+    margin-bottom: 0.2rem;
+}
+.tut-text { font-size: 0.85rem; line-height: 1.45; }
+.tut-text b { color: var(--accent-color); }
+.tut-skip {
+    margin-top: 0.45rem;
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 0.7rem;
+    text-decoration: underline;
+    cursor: pointer;
+    padding: 0.15rem 0.3rem;
+}
+.tut-skip:hover { color: var(--text-primary); }
+
+/* The HUD and Orders panel bracket the top edge; on a phone the banner would
+   collide with both, so drop it below them and let it span the width. */
+@media (max-width: 768px) {
+    #tutorial-banner {
+        top: auto;
+        bottom: 5.2rem;
+        width: calc(100vw - 1.2rem);
+        padding: 0.5rem 0.7rem 0.45rem;
+    }
+    .tut-text { font-size: 0.8rem; }
+}

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,12 +17,12 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.54.0';</script>
+    <script>window.SC_VERSION = '1.55.0';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'audio', 'sfx', 'rng', 'map', 'camera',
                     'roads', 'factories', 'economy', 'vehicles', 'stats',
-                    'inspect', 'research', 'placement'];
+                    'inspect', 'research', 'placement', 'tutorial'];
         for (var i = 0; i < mods.length; i++)
             document.write('<script src="js/' + mods[i] + '.js?v=' + SC_VERSION + '"><\/script>');
     })();
@@ -2252,6 +2252,107 @@
         assert('truck path has 3 nodes now', truck.path.length === 3 && truck.path[1] === res.node);
         assert('truck progress mapped correctly', approx(truck.progress, 0.8));
         assert('truck pathIdx is still 0', truck.pathIdx === 0);
+    })();
+
+    // ── Tutorial: step progression, skipping, persistence ────────────
+    (function() {
+        const { S1, S2, F, C } = fixture();   // wheat + water + bakery + HQ
+        SC.state.gameStarted = true;
+        SC.tutorial.start();
+
+        assert('tutorial starts on the wheat step', SC.tutorial.current().id === 'wheat');
+        assert('tutorial points at the bakery and the wheat farm',
+            SC.tutorial.focus().length === 2 &&
+            SC.tutorial.focus().includes(F) && SC.tutorial.focus().includes(S1));
+
+        // Roading an unrelated pair must not advance the step.
+        SC.state.money = 99999;
+        SC.roads.build(S2, C);
+        SC.tutorial.refresh();
+        assert('an unrelated road does not advance the tutorial',
+            SC.tutorial.current().id === 'wheat');
+
+        SC.roads.build(F, S1);
+        SC.tutorial.refresh();
+        assert('roading bakery→wheat advances to the water step',
+            SC.tutorial.current().id === 'water');
+        assert('water step points at the bakery and the water pump',
+            SC.tutorial.focus().includes(F) && SC.tutorial.focus().includes(S2));
+
+        // Bakery→water also routes the bakery to HQ (via the S2→C road built
+        // above), so this must clear BOTH remaining build steps at once.
+        SC.roads.build(F, S2);
+        SC.tutorial.refresh();
+        assert('one road can satisfy two steps at once',
+            SC.tutorial.current().id === 'deliver');
+
+        // The final step waits on an actual delivery.
+        assert('deliver step highlights nothing', SC.tutorial.focus().length === 0);
+        SC.state.delivered = 1;
+        SC.tutorial.refresh();
+        assert('a delivery finishes the tutorial', SC.tutorial.current() === null);
+        assert('finished tutorial is inactive', !SC.tutorial.active());
+        assert('finished tutorial stores step -1', SC.state.tutorialStep === -1);
+    })();
+
+    // ── Tutorial: demolishing back a road re-opens the step it satisfied ──
+    (function() {
+        const { S1, F } = fixture();
+        SC.state.gameStarted = true;
+        SC.state.money = 99999;
+        SC.tutorial.start();
+        const res = SC.roads.build(F, S1);
+        SC.tutorial.refresh();
+        assert('wheat step cleared by the road', SC.tutorial.current().id === 'water');
+        // Steps are goals, not a one-way ratchet — but they only ever advance,
+        // so demolishing does NOT send the player backwards.
+        SC.roads.demolish(res.edge);
+        SC.tutorial.refresh();
+        assert('demolishing does not rewind the tutorial',
+            SC.tutorial.current().id === 'water');
+    })();
+
+    // ── Tutorial: skip is permanent, and never auto-starts mid-run ────
+    (function() {
+        fixture();
+        SC.state.gameStarted = true;
+        SC.tutorial.start();
+        assert('tutorial active after start', SC.tutorial.active());
+        SC.tutorial.skip();
+        assert('skip retires the tutorial', !SC.tutorial.active() && SC.tutorial.current() === null);
+        SC.tutorial.refresh();
+        assert('refresh does not revive a skipped tutorial', !SC.tutorial.active());
+
+        // A world that has not started must never show a step.
+        fixture();
+        SC.state.gameStarted = false;
+        assert('tutorial inactive before the game starts', !SC.tutorial.active());
+    })();
+
+    // ── Tutorial: save round-trip resumes mid-sequence ───────────────
+    (function() {
+        const { S1, F } = fixture();
+        SC.state.gameStarted = true;
+        SC.state.money = 99999;
+        SC.tutorial.start();
+        SC.roads.build(F, S1);
+        SC.tutorial.refresh();
+        const step = SC.state.tutorialStep;
+        SC.save.store();
+        SC.newState();
+        assert('save round-trip loads', SC.save.load());
+        assert('tutorial step survives a save round-trip', SC.state.tutorialStep === step);
+
+        // A save written before the tutorial existed must not drop the player
+        // into step 1 mid-run.
+        const raw = JSON.parse(localStorage.getItem(SC.save.KEY) || '{}');
+        delete raw.tutorialStep;
+        localStorage.setItem(SC.save.KEY, JSON.stringify(raw));
+        SC.newState();
+        SC.save.load();
+        assert('a pre-tutorial save restores as finished, not step 1',
+            SC.state.tutorialStep === -1);
+        SC.save.clear();
     })();
 
     document.getElementById('summary').textContent = `${passed} passed / ${failed} failed`;

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,10 +17,10 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.53.2';</script>
+    <script>window.SC_VERSION = '1.54.0';</script>
     <script>
     (function () {
-        var mods = ['config', 'state', 'save', 'sfx', 'rng', 'map', 'camera',
+        var mods = ['config', 'state', 'save', 'audio', 'sfx', 'rng', 'map', 'camera',
                     'roads', 'factories', 'economy', 'vehicles', 'stats',
                     'inspect', 'research', 'placement'];
         for (var i = 0; i < mods.length; i++)


### PR DESCRIPTION
Adds the sound pass the roadmap has been carrying since v1: an ambient bed
and a generative score, with Music toggling independently of Sound.

New `js/audio.js` owns the shared AudioContext and the music/sfx/ambience
buses; `sfx.js` now asks it for a bus instead of opening a second context.
Everything is synthesised at runtime — no audio assets, so the folder stays
self-contained and the sound can react to game state:

- Ambience: three looping filtered-noise beds (wind / rain / traffic hum)
  whose gains are ramped each frame rather than rebuilt. Wind tracks cloud
  cover and wind strength, rain tracks the rain spell, and the hum saturates
  with the number of trucks actually rolling, so a busy network is audibly
  busy. Ducks to silence while paused or after game over.
- Music: a four-chord loop (Am7-Fmaj7-Cmaj7-G7) with pad, bass root and a
  sparse melody from a fixed A-minor-pentatonic scale — consonant over all
  four chords, so notes are picked at random without clashing. Daylight
  opens the pad filter and thickens the melody; night sparsens it.
- Scheduling runs on the wall clock, so `SC.audio.update()` sits outside
  main.js's fast-forward sub-step loop: 4x speed must not pitch the music up.

`render-env.js` now shares its weather object on `SC._render.weather` so the
audio layer can score to the visible weather.

New one-shots wired to events: `depart` (throttled — dispatch assigns whole
batches per tick), `science` on researchComplete, `warn` on debtWarning.
vehicles.js emits `truckDispatched` for the first of these.

Verification: `audio-check.html` fakes the first user gesture and asserts the
graph is wired and scheduling. It can't live in tests.html (needs a gesture,
plus --autoplay-policy=no-user-gesture-required), and it earns its keep: it
caught `amb.*.gain` being a GainNode rather than an AudioParam, which threw
from update() every frame once the context was running and froze the game
loop — invisible to the ?probe= smoke, since no gesture fires there.

857 logic tests pass / 0 failed; audio-check 14/14.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017z2pjxV5vH25kK5ofHjYPD