### PR TITLE
Road overlap rules: no laying a road over the network, crossings build interchanges

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
                 </svg></span>
         </a>
 
-        <a href="supply-chain/index.html?v=1.56.0" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.57.0" class="card card-metal" id="card-supply-chain">
             <div class="beta-badge">BETA</div>
             <div>
                 <div class="card-icon">🏭</div>

--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
                 </svg></span>
         </a>
 
-        <a href="supply-chain/index.html?v=1.55.0" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.56.0" class="card card-metal" id="card-supply-chain">
             <div class="beta-badge">BETA</div>
             <div>
                 <div class="card-icon">🏭</div>

--- a/supply-chain/CLAUDE.md
+++ b/supply-chain/CLAUDE.md
@@ -88,7 +88,7 @@ then (any headless Chromium works; on sandboxed Linux add `--no-sandbox`):
 - **Logic tests**: `<chromium> --headless=new --disable-gpu
   --virtual-time-budget=15000 --dump-dom
   http://localhost:8199/supply-chain/tests.html`, grep for `id="summary"`
-  — must say "N passed / **0 failed**" (857 tests at last count; N grows,
+  — must say "N passed / **0 failed**" (895 tests at last count; N grows,
   0 failed is the bar).
 - **Audio check**: the WebAudio layer can't live in `tests.html` — it needs a
   real user gesture to open an AudioContext, which headless only permits with
@@ -126,7 +126,16 @@ then (any headless Chromium works; on sandboxed Linux add `--no-sandbox`):
   and sets it as the active yard, for screenshotting the yard marker/
   per-yard truck counts. `&junction=1` places a junction near HQ (same
   ring-search as `&yard=1`) and roads it in, for screenshotting the
-  small roundabout marker (`drawJunction`). `&tutorial=N` drops a fresh
+  small roundabout marker (`drawJunction`). `&interchange=1` completes the
+  crossings research, drops a waypoint either side of the first starter
+  road and connects them, so the **interchange** a legal crossing builds
+  (junction on the crossing point, both roads split through it — see
+  README "Overlap rules") can be screenshotted; pair with `&focus=` to
+  frame it. `&select=hq|factory|<node id>` picks the node a road would
+  start from, so `&hoverAt=` renders the build ghost: with the research it
+  rings each interchange the road would build and folds the fee into the
+  label, without it the ghost goes red with the block reason and a ✕ on
+  whatever is in the way. `&tutorial=N` drops a fresh
   world straight onto guided-tutorial step N (1-based, default 1) for
   screenshotting the banner and the focus dim/rings; pair it with
   `nohelp=1`. Deliberately NOT part of `?probe=`, which builds the starter

--- a/supply-chain/CLAUDE.md
+++ b/supply-chain/CLAUDE.md
@@ -133,9 +133,13 @@ then (any headless Chromium works; on sandboxed Linux add `--no-sandbox`):
   README "Overlap rules") can be screenshotted; pair with `&focus=` to
   frame it. `&select=hq|factory|<node id>` picks the node a road would
   start from, so `&hoverAt=` renders the build ghost: with the research it
-  rings each interchange the road would build and folds the fee into the
-  label, without it the ghost goes red with the block reason and a ✕ on
-  whatever is in the way. `&tutorial=N` drops a fresh
+  rings each interchange the road would build and prices it there, without
+  it the ghost goes red with the block reason, a ✕ + clearance ring (or a
+  red-lit road) on whatever is in the way, and the green legal alternative
+  beside it. Those pointing marks are a second render pass
+  (`R.drawGhostMarks()`, after the entity pass) — verify them at a decent
+  `&focus=` zoom, since at low zoom they hide under the site art they
+  point at. `&tutorial=N` drops a fresh
   world straight onto guided-tutorial step N (1-based, default 1) for
   screenshotting the banner and the focus dim/rings; pair it with
   `nohelp=1`. Deliberately NOT part of `?probe=`, which builds the starter

--- a/supply-chain/PLAN.md
+++ b/supply-chain/PLAN.md
@@ -35,6 +35,15 @@ pan/pinch camera).
 
 ## Shipped
 
+- v1.56.0: **road overlap rules** — a road may no longer be laid over the
+  top of the network: it can't brush past a site it doesn't connect to
+  (`NODE_ROAD_CLEARANCE`), and it can't cross another road until the
+  early **Road Crossings** research, after which each crossing builds a
+  paid **interchange** (a junction node splitting both roads). Late-game
+  maps had degenerated into a cat's cradle of map-long diagonals drawn
+  straight over everything; now the geometry has to be planned, junctions
+  earn their keep, and the crossings research does what its name says.
+  See README "Overlap rules".
 - v1.37.0: **Stats & Achievements screen** (☰ menu) — deliveries per
   product, a money-over-time sparkline, busiest road by trip count, and
   nine milestone badges. Per item 14 below — details there.

--- a/supply-chain/PLAN.md
+++ b/supply-chain/PLAN.md
@@ -35,6 +35,12 @@ pan/pinch camera).
 
 ## Shipped
 
+- v1.57.0: **the overlap rules explain themselves on the map** — the build
+  ghost marks the site it would run over (clearance ring + ✕) or lights the
+  road it can't cross red, and draws the legal alternative in green beside
+  it (the two hops through that site, or the ends of the road in the way);
+  a legal crossing rings and prices each interchange it would build. Help
+  overlay gained a "Roads can't overlap" entry. Per v1.56.0 below.
 - v1.56.0: **road overlap rules** — a road may no longer be laid over the
   top of the network: it can't brush past a site it doesn't connect to
   (`NODE_ROAD_CLEARANCE`), and it can't cross another road until the

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -37,7 +37,9 @@ that ambient animation as its background — it now lives independently at
   the order shows "no route!" until you build one.
 - **Roads**: tap node → tap node. Cost scales with length; crossing the
   river costs 3× (bridge). Tap a road twice to demolish for a 50% refund
-  (refused while a truck is on it).
+  (refused while a truck is on it). Roads can't be laid over the top of
+  each other — see **Overlap rules** below, the thing that makes the
+  network a plan rather than a cat's cradle.
 - **Modes** (bottom-right toggle): **Build** (🔨, default) is the road
   tap-tap flow above. **Upgrade** (⬆️) turns taps into upgrades: tap a
   supplier twice to level its stock cap/regen, or a road twice to pave
@@ -156,6 +158,29 @@ that ambient animation as its background — it now lives independently at
   paves it (`edge.level 1`) — trucks cross it `HIGHWAY_SPEED_MULT`×
   faster, and pathfinding weighs edges by travel time so routes prefer
   paved legs.
+- **Overlap rules** (`SC.roads.checkSegment`, quoted by every
+  `SC.roads.quote`): a road may not be laid over the top of the network.
+  Two rules:
+  1. It may not brush past a site that isn't one of its own endpoints
+     (`NODE_ROAD_CLEARANCE`, the same gap manual placement keeps the
+     other way round) — route *through* that site instead.
+  2. It may not cross another road at all until the cheap, early
+     **Road Crossings** (`intersections`) research. After that a crossing
+     is legal but builds a real **interchange**: `SC.roads.build` drops a
+     junction node on each crossing point, splits both crossed roads
+     through it (`splitEdge`, re-seating any truck mid-edge) and charges
+     `PLACEMENT_INTERSECTION_PRICE` per interchange on top of the
+     length-priced spans. So the two roads genuinely meet, and a long
+     diagonal over a busy area costs real money.
+
+  A blocked prospect comes back from `quote` with `.blocked`
+  (`'node'`/`'crossing'`/`'tight'`/`'water'`) instead of `null`, plus
+  `SC.roads.blockMessage` — `input.js` toasts it and the build ghost goes
+  red with a ✕ on what's in the way (a legal crossing instead rings each
+  interchange the road would build, with the fee folded into the label).
+  The manual **Place intersection** tool is now only a retrofit for saves
+  made before this rule, so its Shop button hides itself unless the map
+  actually still has a crossing (`SC.roads.hasCrossings`).
 - **Congestion** (`SC.state.congestionEnabled`, a difficulty trait fixed
   for the run — on for Normal/Hard, off for Easy/Sandbox; not a normal
   player-facing toggle, see the Dev tools panel further down for A/B
@@ -317,7 +342,7 @@ they signal the UI through the tiny `SC.on`/`SC.emit` pub/sub in state.js.
 | `js/save.js` | Autosave/restore to localStorage (serialize/restore round-trip) |
 | `js/rng.js` | Seeded PRNG (xmur3 hash + mulberry32 stream) used only by map.js's world gen, so `?seed=` reproduces a map |
 | `js/map.js` | World gen: river, node sites, starter cluster (seeded via `js/rng.js`, `generateWorld(seed)`); `unlockNext(filterFn)` for milestone (supplier/factory) and customer-DC (city) unlock tracks |
-| `js/roads.js` | Road build/demolish/quote (incl. ferry-vs-bridge), highway upgrades, congestion (`speedMult`/`congestionMult`), Dijkstra pathfinding weighted by travel time |
+| `js/roads.js` | Road build/demolish/quote (incl. ferry-vs-bridge), the overlap rules + interchange building (`checkSegment`/`blockMessage`/`splitEdge`), highway upgrades, congestion (`speedMult`/`congestionMult`), Dijkstra pathfinding weighted by travel time |
 | `js/factories.js` | Craft tasks (incl. intermediates), raw intake, production ticks, site purchase |
 | `js/economy.js` | Orders (spawn/plan/deliver/expire) with recursive multi-tier sourcing, money, interest + default countdown, upgrades, supplier stock regen/upgrades, promotions, customer-DC spawn timer, contract offers (roll/accept/decline) and miss penalties |
 | `js/vehicles.js` | Trucks (each with a home yard), haul jobs, dispatcher (globally nearest idle truck per job, bundles same-route jobs up to capacity, sends idle trucks home), supplier-stock loading waits, reassignment, movement, `truckCountOnEdge` (feeds congestion) |

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -175,9 +175,25 @@ that ambient animation as its background — it now lives independently at
 
   A blocked prospect comes back from `quote` with `.blocked`
   (`'node'`/`'crossing'`/`'tight'`/`'water'`) instead of `null`, plus
-  `SC.roads.blockMessage` — `input.js` toasts it and the build ghost goes
-  red with a ✕ on what's in the way (a legal crossing instead rings each
-  interchange the road would build, with the fee folded into the label).
+  `SC.roads.blockMessage`, which `input.js` toasts on the refused tap.
+
+  **Seeing the rules** (`drawGhostRoad`/`drawGhostMarks`, `blockedHint`):
+  the dashed build preview answers *why* and *how* before you tap, not
+  just "no". Red ghost + the reason, and on the map itself: the site the
+  road would run over gets its clearance ring and a ✕, or the road it
+  can't cross is lit red down its whole length with a ✕ on the crossing.
+  Beside that, in green, the legal way to do the same thing — the two
+  hops through that site ("road it in two hops" / "continue from here"),
+  or rings on the ends of the road in the way, which are always fair game
+  to connect to. Suggestions are only drawn once re-quoted as buildable,
+  so the ghost never proposes another blocked road. A legal crossing
+  instead rings each interchange it would build and prices it there
+  (`+$150 junction`), with the total in the ghost label. The pointing
+  marks are a **second pass** drawn after the depth-sorted entity pass
+  (`R.drawGhostMarks()` in `render-core.frame`) — down with the roads
+  they'd be painted over by the very site they point at; the dashed road
+  itself stays at road level.
+
   The manual **Place intersection** tool is now only a retrofit for saves
   made before this rule, so its Shop button hides itself unless the map
   actually still has a crossing (`SC.roads.hasCrossings`).

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.55.0';</script>
+    <script>window.SC_VERSION = '1.56.0';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.56.0';</script>
+    <script>window.SC_VERSION = '1.57.0';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>
@@ -338,6 +338,7 @@
                trucks do the hauling — but only where roads exist.</p>
             <ul>
                 <li><b>Build roads:</b> tap a node, then tap another. Crossing the river pops up a choice: a pricier bridge (fast) or a cheaper ferry (slower boat crossing).</li>
+                <li><b>Roads can't overlap:</b> a road can't run over a site it doesn't stop at, and it can't cross another road — plan the network instead of drawing one long diagonal over everything. The dashed preview tells you before you tap: <span style="color:#34d399">green</span> with the price when it's fine, <span style="color:#f87171">red</span> with an ✕ on whatever is in the way when it isn't, and a green suggestion showing the legal way round (hop through that site, or connect to the end of the road you're crossing). After the <b>Road Crossings ➕</b> research you may cross a road after all — each crossing builds an <b>interchange</b> (a junction where the two roads meet, both split through it) for a fee, ringed and priced in the preview.</li>
                 <li><b>Fill orders:</b> connect each ingredient's supplier to the factory, and the factory to the ordering HQ/DC. Dispatch is automatic.</li>
                 <li><b>Earn &amp; grow:</b> payouts fund more roads, trucks, factories and upgrades. New sites appear as you deliver.</li>
                 <li><b>Credit line:</b> you can spend into the red down to −$1,500, but debt bleeds interest every minute (rate set by difficulty — 15%/min on Normal). If interest drags you <i>below</i> the limit, a default countdown starts — recover in time or the bank forecloses and the run ends. Sandbox never forecloses.</li>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -67,6 +67,19 @@ SC.CONFIG = {
     BRIDGE_MULT: 3,            // river crossings cost extra
     ROAD_REFUND: 0.5,          // fraction returned when demolishing
 
+    // Overlap rules (see SC.roads.checkSegment): a road can't be laid over
+    // the top of the network — it may not brush past a site it doesn't
+    // connect (NODE_ROAD_CLEARANCE, the same gap manual placement keeps the
+    // other way round), and it may not cross another road until the
+    // 'intersections' research, after which each crossing builds a real
+    // interchange junction for PLACEMENT_INTERSECTION_PRICE apiece. This is
+    // the minimum room such an interchange needs: how far its junction must
+    // sit from the crossed road's endpoints, from the new road's own
+    // endpoints, and from the next interchange along the same road (a
+    // roundabout is ~14 units across, and a stub edge shorter than that
+    // reads as a blob rather than a junction).
+    ROAD_JUNCTION_MIN_GAP: 40,
+
     // Ferries: a cheaper-but-slower alternative to a bridge, chosen at
     // build time (toggle in the Shop panel) for any road crossing the
     // river. Half the speed of a normal road, but a much smaller premium
@@ -247,7 +260,7 @@ SC.DIFFICULTY_ORDER = ['easy', 'normal', 'hard', 'sandbox'];
 SC.RESEARCH = {
     intersections: {
         name: 'Road Crossings', emoji: '➕', cost: 150, time: 14, requires: [],
-        desc: 'Unlocks intersections — place a junction exactly where two roads cross to connect them.'
+        desc: 'Lets a road cross another one at all — each crossing builds an interchange junction for a fee.'
     },
     junctions: {
         name: 'Road Junctions', emoji: '🔀', cost: 350, time: 35, requires: ['intersections'],

--- a/supply-chain/js/input.js
+++ b/supply-chain/js/input.js
@@ -142,6 +142,16 @@ SC.input = (function() {
         if (node) {
             pendingDemolish = null;
             if (st.selectedNode && st.selectedNode !== node) {
+                // Overlap rules first: a road that runs over a site or
+                // crosses another road illegally never gets as far as the
+                // bridge-vs-ferry question (see SC.roads.checkSegment).
+                const q = SC.roads.quote(st.selectedNode, node);
+                if (q && q.blocked) {
+                    SC.sfx.play('error');
+                    SC.emit('toast', { text: SC.roads.blockMessage(q), kind: 'error' });
+                    pendingBuy = null;
+                    return;
+                }
                 if (!SC.roads.findEdge(st.selectedNode, node) &&
                     SC.map.segmentCrossesRiver(st.selectedNode.x, st.selectedNode.y, node.x, node.y)) {
                     SC.emit('crossingChoice', { a: st.selectedNode, b: node, shiftKey });

--- a/supply-chain/js/main.js
+++ b/supply-chain/js/main.js
@@ -288,6 +288,16 @@ SC.runProbe = function(seconds) {
         const [hx, hy] = p.get('hoverAt').split(',').map(Number);
         SC.input._setDebugHover(hx, hy);
     }
+    // &select=hq|factory|<node id> picks the node a road would start from
+    // (what tapping it does), so the build ghost can be screenshotted
+    // together with &hoverAt: its cost label, the rings where a legal
+    // crossing would build interchanges, or the red ✕ preview of a road the
+    // overlap rules refuse.
+    if (p.has('select')) {
+        const key = p.get('select');
+        SC.state.selectedNode = SC.state.nodes.find(n => String(n.id) === key) ||
+            (key === 'factory' ? SC.factories.all()[0] : SC.state.nodes.find(n => n.isHQ));
+    }
     // Point the camera somewhere specific (&focus=x,y,zoom — zoom optional):
     // screenshots default to the HQ cluster, so this is how a far corner,
     // the whole-map view (&focus with a low zoom), or a specific site gets
@@ -313,7 +323,11 @@ SC.runProbe = function(seconds) {
         for (let a = 0; a < 16 && !res.ok; a++) {
             const angle = (a / 16) * Math.PI * 2;
             const x = hq.x + Math.cos(angle) * 350, y = hq.y + Math.sin(angle) * 350;
-            if (SC.placement.canPlaceAt(x, y)) res = SC.placement.place('yard', null, x, y);
+            // Needs a spot HQ can also reach with a legal road (overlap
+            // rules), since the shot is of the yard *plus* its road.
+            if (SC.placement.canPlaceAt(x, y) &&
+                !SC.roads.checkSegment(hq.x, hq.y, x, y, [hq]).blocked)
+                res = SC.placement.place('yard', null, x, y);
         }
         if (res.ok) {
             SC.roads.build(hq, res.node);
@@ -330,9 +344,41 @@ SC.runProbe = function(seconds) {
         for (let a = 0; a < 16 && !res.ok; a++) {
             const angle = (a / 16) * Math.PI * 2;
             const x = hq.x + Math.cos(angle) * 250, y = hq.y + Math.sin(angle) * 250;
-            if (SC.placement.canPlaceAt(x, y)) res = SC.placement.place('junction', null, x, y);
+            if (SC.placement.canPlaceAt(x, y) &&
+                !SC.roads.checkSegment(hq.x, hq.y, x, y, [hq]).blocked)
+                res = SC.placement.place('junction', null, x, y);
         }
         if (res.ok) SC.roads.build(hq, res.node);
+    }
+    // Force an interchange (&interchange=1): with 'intersections' researched
+    // a road laid across another one builds a junction at the crossing and
+    // splits both roads (see SC.roads.build). Drops two waypoints either
+    // side of an existing road and connects them, so the result can be
+    // screenshotted without hunting for a legal crossing by hand.
+    if (p.has('interchange')) {
+        SC.state.money = Math.max(SC.state.money, 50000);
+        SC.state.research.completed.intersections = true;
+        SC.state.research.completed.junctions = true;
+        // Waypoints either side of the first starter road, at whatever pair
+        // of offsets clears the rest of the cluster (the starter layout is
+        // seed-dependent, so both sides get their own search).
+        const edge = SC.state.edges[0];
+        const dists = [160, 200, 240, 300, 380];
+        let done = false;
+        for (let i = 0; edge && !done && i < dists.length; i++) {
+            for (let j = 0; !done && j < dists.length; j++) {
+                const ux = (edge.b.x - edge.a.x) / edge.len, uy = (edge.b.y - edge.a.y) / edge.len;
+                const mx = (edge.a.x + edge.b.x) / 2, my = (edge.a.y + edge.b.y) / 2;
+                const p1 = { x: mx - uy * dists[i], y: my + ux * dists[i] };
+                const p2 = { x: mx + uy * dists[j], y: my - ux * dists[j] };
+                if (!SC.placement.canPlaceAt(p1.x, p1.y) || !SC.placement.canPlaceAt(p2.x, p2.y)) continue;
+                const chk = SC.roads.checkSegment(p1.x, p1.y, p2.x, p2.y, []);
+                if (chk.blocked || !chk.crossings.length) continue;
+                const n1 = SC.placement.place('junction', null, p1.x, p1.y);
+                const n2 = SC.placement.place('junction', null, p2.x, p2.y);
+                done = n1.ok && n2.ok && SC.roads.build(n1.node, n2.node).ok;
+            }
+        }
     }
     // Force some interesting Stats-screen data (&stats=1): a few
     // achievements, a delivery breakdown, and a money-history sparkline,

--- a/supply-chain/js/placement.js
+++ b/supply-chain/js/placement.js
@@ -35,74 +35,14 @@ SC.placement = (function() {
         return SC.state.nodes.every(n => Math.hypot(n.x - x, n.y - y) >= C.PLACEMENT_MIN_DIST);
     }
 
+    // Retrofit tool: a junction dropped onto two roads that already cross
+    // without meeting. Since the overlap rules landed (SC.roads.checkSegment)
+    // a new road builds its own interchanges, so the only crossings left to
+    // retrofit are the ones in a save from before that — hence the Shop
+    // button hides itself when the map has none (SC.roads.hasCrossings).
     function canPlaceIntersectionAt(x, y) {
         if (SC.map.isInRiver(x, y)) return null;
         return SC.roads.findClosestCrossing(x, y, 40);
-    }
-
-    function splitEdge(edge, node, t_intersect) {
-        const a = edge.a;
-        const b = edge.b;
-
-        // Remove edge from SC.state.edges
-        const idx = SC.state.edges.indexOf(edge);
-        if (idx !== -1) SC.state.edges.splice(idx, 1);
-
-        // Remove connections
-        a.edges.splice(a.edges.indexOf(b), 1);
-        b.edges.splice(b.edges.indexOf(a), 1);
-
-        // Create two new edges: a-node and node-b
-        const len1 = Math.hypot(node.x - a.x, node.y - a.y);
-        const len2 = Math.hypot(b.x - node.x, b.y - node.y);
-
-        // Determine bridge/ferry status
-        const bridge1 = SC.map.segmentCrossesRiver(a.x, a.y, node.x, node.y);
-        const bridge2 = SC.map.segmentCrossesRiver(node.x, node.y, b.x, b.y);
-
-        // Keep ferry if original was ferry
-        const ferry1 = edge.ferry && bridge1;
-        const ferry2 = edge.ferry && bridge2;
-
-        // Calculate new cost proportional to length
-        const mult1 = ferry1 ? SC.CONFIG.FERRY_COST_MULT : (bridge1 ? SC.CONFIG.BRIDGE_MULT : 1);
-        const cost1 = Math.round(len1 * SC.CONFIG.ROAD_COST_PER_UNIT * mult1);
-        const mult2 = ferry2 ? SC.CONFIG.FERRY_COST_MULT : (bridge2 ? SC.CONFIG.BRIDGE_MULT : 1);
-        const cost2 = Math.round(len2 * SC.CONFIG.ROAD_COST_PER_UNIT * mult2);
-
-        const edge1 = { a, b: node, len: len1, bridge: bridge1, ferry: ferry1, cost: cost1, level: edge.level };
-        const edge2 = { a: node, b, len: len2, bridge: bridge2, ferry: ferry2, cost: cost2, level: edge.level };
-
-        SC.state.edges.push(edge1);
-        SC.state.edges.push(edge2);
-        a.edges.push(node);
-        node.edges.push(a);
-        b.edges.push(node);
-        node.edges.push(b);
-
-        // Update in-flight truck paths
-        for (const t of SC.state.trucks) {
-            if (!t.path) continue;
-            for (let k = 0; k < t.path.length - 1; k++) {
-                const na = t.path[k], nb = t.path[k + 1];
-                if ((na === a && nb === b) || (na === b && nb === a)) {
-                    t.path.splice(k + 1, 0, node);
-                    if (k < t.pathIdx) {
-                        t.pathIdx++;
-                    } else if (k === t.pathIdx) {
-                        const fromNode = na;
-                        const f_intersect = (fromNode === a) ? t_intersect : (1 - t_intersect);
-                        if (t.progress < f_intersect) {
-                            t.progress = t.progress / f_intersect;
-                        } else {
-                            t.pathIdx++;
-                            t.progress = (t.progress - f_intersect) / (1 - f_intersect);
-                        }
-                    }
-                    k++; // skip the newly inserted node
-                }
-            }
-        }
     }
 
     // kind: 'supplier' (good = raw material key), 'factory' (good = recipe
@@ -121,8 +61,8 @@ SC.placement = (function() {
             SC.state.money -= cost;
             node = SC.map.makeNode('junction', crossing.x, crossing.y, { active: true });
 
-            splitEdge(crossing.e1, node, crossing.t);
-            splitEdge(crossing.e2, node, crossing.u);
+            SC.roads.splitEdge(crossing.e1, node, crossing.t);
+            SC.roads.splitEdge(crossing.e2, node, crossing.u);
         } else {
             if (!canPlaceAt(x, y)) return { ok: false, reason: 'invalid' };
             if (!SC.canAfford(cost)) return { ok: false, reason: 'money', cost };

--- a/supply-chain/js/render-core.js
+++ b/supply-chain/js/render-core.js
@@ -347,6 +347,11 @@ SC.render = (function() {
 
         R.drawFireflies();
         R.drawBursts(dt);          // delivery coin/spark bursts
+        // The build ghost's pointing marks (✕, clearance/interchange rings,
+        // labels) ride above the buildings — drawn down with the roads they'd
+        // be painted over by the very site they point at. The dashed road
+        // itself stays down there, where a road belongs.
+        R.drawGhostMarks();
         R.drawOrderBubbles();
         R.drawFloaters(dt);
         R.drawGrade();             // time-of-day colour grade over world + sky

--- a/supply-chain/js/render-network.js
+++ b/supply-chain/js/render-network.js
@@ -1153,16 +1153,28 @@
         }
     }
 
+    const RED = '#f87171', GREEN = '#34d399';
+
     // Short-form of SC.roads.blockMessage, for the floating ghost label
     // (input.js toasts the full sentence when the tap is actually refused).
     const GHOST_BLOCK_LABEL = {
         node: 'runs over a site',
-        crossing: 'roads can’t cross — research ➕',
+        crossing: 'roads can’t cross — research it',
         tight: 'no room for a junction',
         water: 'crossing over the river'
     };
 
+    // The ghost draws in two passes. Its road-level marks (the dashed road
+    // itself, the red road in the way, the green alternative legs) go down
+    // with the roads, under the buildings, because that's where a road
+    // lives. Everything that *points* at something — ✕, clearance and
+    // interchange rings, labels — is stashed here and drawn by
+    // drawGhostMarks() after the depth-sorted entity pass, or the very site
+    // it's pointing at would paint over it.
+    let ghostFrame = null;
+
     function drawGhostRoad() {
+        ghostFrame = null;
         const sel = SC.state.selectedNode;
         const hover = SC.input.getHover && SC.input.getHover();
         if (!sel || !hover) return;
@@ -1191,7 +1203,7 @@
         if (!q) return;
 
         const ok = SC.canAfford(q.cost) && !q.blocked;
-        const color = ok ? '#34d399' : '#f87171';
+        const color = ok ? GREEN : RED;
         const a = S(sel.x, sel.y), b = S(end.x, end.y);
         R.ctx.beginPath();
         R.ctx.moveTo(a.x, a.y);
@@ -1204,41 +1216,127 @@
         R.ctx.setLineDash([]);
         R.ctx.lineCap = 'butt';
 
-        if (q.blocked) {
-            // Mark what's in the way: the site the road would run over, or
-            // the crossing it can't make.
-            const spot = q.blocked === 'node' ? q.node : q.at;
-            if (spot) {
-                const p = S(spot.x, spot.y);
-                const r = 9 * clampZoom();
-                R.ctx.strokeStyle = rgba('#f87171', 0.95);
-                R.ctx.lineWidth = 2.5;
-                R.ctx.beginPath();
-                R.ctx.moveTo(p.x - r, p.y - r * 0.6);
-                R.ctx.lineTo(p.x + r, p.y + r * 0.6);
-                R.ctx.moveTo(p.x + r, p.y - r * 0.6);
-                R.ctx.lineTo(p.x - r, p.y + r * 0.6);
-                R.ctx.stroke();
+        // Road-level half of the hint (the rest is drawn in drawGhostMarks).
+        const hint = q.blocked ? blockedHint(sel, target, end, q) : null;
+        if (hint && hint.edge) strokeEdge(hint.edge, Math.max(3, 5 * zoom()), rgba(RED, 0.85), [9, 7]);
+        if (hint && hint.legs) for (const leg of hint.legs) ghostLeg(leg, GREEN);
+
+        ghostFrame = { sel, end, q, color, hint };
+    }
+
+    // Second pass, above the buildings: everything that points at a thing.
+    function drawGhostMarks() {
+        if (!ghostFrame) return;
+        const { sel, end, q, color, hint } = ghostFrame;
+        if (hint) {
+            if (hint.ring) {
+                const g = S(hint.ring.x, hint.ring.y);
+                groundRing(g.x, g.y, SC.CONFIG.NODE_ROAD_CLEARANCE / 2, rgba(RED, 0.8), 2);
+            }
+            if (hint.cross) ghostCross(hint.cross.x, hint.cross.y, RED);
+            for (const alt of hint.alts || []) {
+                const g = S(alt.x, alt.y);
+                groundRing(g.x, g.y, 22, rgba(GREEN, 0.9), 2.5);
+            }
+            if (hint.tip) {
+                const g = S(hint.tip.x, hint.tip.y);
+                labelAt(hint.tip.text, g.x, g.y - 40 * clampZoom(), GREEN, 11);
             }
         } else {
-            for (const c of q.crossings || []) {
-                const p = S(c.x, c.y);
-                R.ctx.beginPath();
-                R.ctx.ellipse(p.x, p.y, 9 * clampZoom(), 5 * clampZoom(), 0, 0, Math.PI * 2);
-                R.ctx.strokeStyle = rgba('#34d399', 0.95);
-                R.ctx.lineWidth = 2;
-                R.ctx.setLineDash([4, 3]);
-                R.ctx.stroke();
-                R.ctx.setLineDash([]);
-            }
+            drawInterchangeMarks(q);
         }
 
-        const mx = (sel.x + end.x) / 2, my = (sel.y + end.y) / 2;
-        const mp = S(mx, my);
+        // A crossing block reads best right above the ✕ it's about; anything
+        // else sits on the ghost itself (where the ✕ is on the site, and the
+        // site already carries its own "do it this way" tip).
+        const onCross = hint && hint.edge && hint.cross;
+        const lp = onCross ? S(hint.cross.x, hint.cross.y)
+                           : S((sel.x + end.x) / 2, (sel.y + end.y) / 2);
         const n = (q.crossings || []).length;
         const label = q.blocked ? GHOST_BLOCK_LABEL[q.blocked]
-            : `$${q.cost}${q.ferry ? ' (ferry)' : q.bridge ? ' (bridge)' : ''}${n ? ` — ${n} 🔀` : ''}`;
-        labelAt(label, mp.x, mp.y - 14, color);
+            : `$${q.cost}${q.ferry ? ' (ferry)' : q.bridge ? ' (bridge)' : ''}${n ? ` — ${n} junction${n > 1 ? 's' : ''}` : ''}`;
+        labelAt(label, lp.x, lp.y - (onCross ? 30 : 14), color);
+    }
+
+    function ghostCross(wx, wy, color) {
+        const p = S(wx, wy);
+        const r = 9 * clampZoom();
+        R.ctx.strokeStyle = rgba(color, 0.95);
+        R.ctx.lineWidth = 2.5;
+        R.ctx.beginPath();
+        R.ctx.moveTo(p.x - r, p.y - r * 0.6);
+        R.ctx.lineTo(p.x + r, p.y + r * 0.6);
+        R.ctx.moveTo(p.x + r, p.y - r * 0.6);
+        R.ctx.lineTo(p.x - r, p.y + r * 0.6);
+        R.ctx.stroke();
+    }
+
+    function ghostLeg(leg, color) {
+        const a = S(leg.ax, leg.ay), b = S(leg.bx, leg.by);
+        R.ctx.beginPath();
+        R.ctx.moveTo(a.x, a.y);
+        R.ctx.lineTo(b.x, b.y);
+        R.ctx.strokeStyle = rgba(color, 0.75);
+        R.ctx.lineWidth = Math.max(2.5, 3.5 * zoom());
+        R.ctx.lineCap = 'round';
+        R.ctx.setLineDash([7, 6]);
+        R.ctx.stroke();
+        R.ctx.setLineDash([]);
+        R.ctx.lineCap = 'butt';
+    }
+
+    // Why the ghost is red, said on the map rather than only in words: the
+    // site the road would run over (inside its clearance ring) or the road it
+    // can't cross (lit red down its whole length) gets an ✕ — and next to it,
+    // in green, the legal way to do the same thing: hop *through* that site,
+    // or connect to an end of the road that's in the way. Nothing is offered
+    // as a suggestion unless that road would actually be buildable. Returns
+    // the marks; the caller draws them across the two passes.
+    function blockedHint(sel, target, end, q) {
+        if (q.blocked === 'node' && q.node) {
+            const n = q.node;
+            const hint = { ring: n, cross: n };
+            const have1 = !!SC.roads.findEdge(sel, n);
+            const leg1 = have1 ? null : SC.roads.checkSegment(sel.x, sel.y, n.x, n.y, [sel, n]);
+            const leg2 = SC.roads.checkSegment(n.x, n.y, end.x, end.y,
+                                               target ? [n, target] : [n]);
+            if ((have1 || !leg1.blocked) && !leg2.blocked) {
+                hint.legs = [{ ax: n.x, ay: n.y, bx: end.x, by: end.y }];
+                if (!have1) hint.legs.unshift({ ax: sel.x, ay: sel.y, bx: n.x, by: n.y });
+                hint.tip = { x: n.x, y: n.y,
+                             text: have1 ? 'continue from here' : 'road it in two hops' };
+            }
+            return hint;
+        }
+        if (!q.at) return null;
+        const hint = { edge: q.at.edge, cross: q.at, alts: [] };
+        // The ends of the road in the way are always legal to connect to —
+        // ring whichever of them this road could actually reach.
+        if (q.blocked === 'crossing') {
+            for (const node of [q.at.edge.a, q.at.edge.b]) {
+                if (node === sel || SC.roads.findEdge(sel, node)) continue;
+                const alt = SC.roads.quote(sel, node);
+                if (alt && !alt.blocked) hint.alts.push(node);
+            }
+        }
+        return hint;
+    }
+
+    // A legal crossing: ring each interchange the road would build, and price
+    // it there, so the fee in the cost label has a visible source.
+    function drawInterchangeMarks(q) {
+        for (const c of q.crossings || []) {
+            const p = S(c.x, c.y);
+            R.ctx.beginPath();
+            R.ctx.ellipse(p.x, p.y, 9 * clampZoom(), 5 * clampZoom(), 0, 0, Math.PI * 2);
+            R.ctx.strokeStyle = rgba(GREEN, 0.95);
+            R.ctx.lineWidth = 2;
+            R.ctx.setLineDash([4, 3]);
+            R.ctx.stroke();
+            R.ctx.setLineDash([]);
+            labelAt(`+$${SC.CONFIG.PLACEMENT_INTERSECTION_PRICE} junction`,
+                    p.x, p.y + 16 * clampZoom(), GREEN, 10);
+        }
     }
 
     function drawPlacementGhost() {
@@ -1364,5 +1462,5 @@
 
     Object.assign(R, { drawRoads, drawRouteFlow, nodeSpec, drawShadow, drawSupplierSite, drawJunction,
         drawNodeBody, drawYardParking, drawYardSite, emojiPlateAt, drawOrderBubbles,
-        drawHighlight, drawInspectHighlight, drawTutorialFocus, drawGhostRoad, drawPlacementGhost, drawOffscreenArrows });
+        drawHighlight, drawInspectHighlight, drawTutorialFocus, drawGhostRoad, drawGhostMarks, drawPlacementGhost, drawOffscreenArrows });
 })();

--- a/supply-chain/js/render-network.js
+++ b/supply-chain/js/render-network.js
@@ -1153,6 +1153,15 @@
         }
     }
 
+    // Short-form of SC.roads.blockMessage, for the floating ghost label
+    // (input.js toasts the full sentence when the tap is actually refused).
+    const GHOST_BLOCK_LABEL = {
+        node: 'runs over a site',
+        crossing: 'roads can’t cross — research ➕',
+        tight: 'no room for a junction',
+        water: 'crossing over the river'
+    };
+
     function drawGhostRoad() {
         const sel = SC.state.selectedNode;
         const hover = SC.input.getHover && SC.input.getHover();
@@ -1165,20 +1174,29 @@
         const end = target ? { x: target.x, y: target.y } : hover;
         // Shows the bridge cost when crossing the river — the actual
         // bridge-vs-ferry choice happens in a modal once the road is tapped.
+        // Also previews the overlap rules (SC.roads.checkSegment): the ghost
+        // goes red with the reason when a road would run over a site or cross
+        // one illegally, and rings the interchange junctions a legal crossing
+        // would build (their fee is already in `cost`).
         const q = target ? SC.roads.quote(sel, target) : (() => {
             const len = Math.hypot(sel.x - end.x, sel.y - end.y);
             const bridge = SC.map.segmentCrossesRiver(sel.x, sel.y, end.x, end.y);
             const mult = bridge ? SC.CONFIG.BRIDGE_MULT : 1;
-            return { len, bridge, ferry: false, cost: Math.round(len * SC.CONFIG.ROAD_COST_PER_UNIT * mult) };
+            const chk = SC.roads.checkSegment(sel.x, sel.y, end.x, end.y, [sel]);
+            const fee = chk.crossings.length * SC.CONFIG.PLACEMENT_INTERSECTION_PRICE;
+            return { len, bridge, ferry: false, crossings: chk.crossings, fee,
+                     cost: Math.round(len * SC.CONFIG.ROAD_COST_PER_UNIT * mult) + fee,
+                     blocked: chk.blocked, node: chk.node, at: chk.at };
         })();
         if (!q) return;
 
-        const affordable = SC.canAfford(q.cost);
+        const ok = SC.canAfford(q.cost) && !q.blocked;
+        const color = ok ? '#34d399' : '#f87171';
         const a = S(sel.x, sel.y), b = S(end.x, end.y);
         R.ctx.beginPath();
         R.ctx.moveTo(a.x, a.y);
         R.ctx.lineTo(b.x, b.y);
-        R.ctx.strokeStyle = affordable ? 'rgba(52, 211, 153, 0.7)' : 'rgba(248, 113, 113, 0.7)';
+        R.ctx.strokeStyle = rgba(color, 0.7);
         R.ctx.lineWidth = Math.max(3, 4 * zoom());
         R.ctx.lineCap = 'round';
         R.ctx.setLineDash([10, 8]);
@@ -1186,10 +1204,41 @@
         R.ctx.setLineDash([]);
         R.ctx.lineCap = 'butt';
 
+        if (q.blocked) {
+            // Mark what's in the way: the site the road would run over, or
+            // the crossing it can't make.
+            const spot = q.blocked === 'node' ? q.node : q.at;
+            if (spot) {
+                const p = S(spot.x, spot.y);
+                const r = 9 * clampZoom();
+                R.ctx.strokeStyle = rgba('#f87171', 0.95);
+                R.ctx.lineWidth = 2.5;
+                R.ctx.beginPath();
+                R.ctx.moveTo(p.x - r, p.y - r * 0.6);
+                R.ctx.lineTo(p.x + r, p.y + r * 0.6);
+                R.ctx.moveTo(p.x + r, p.y - r * 0.6);
+                R.ctx.lineTo(p.x - r, p.y + r * 0.6);
+                R.ctx.stroke();
+            }
+        } else {
+            for (const c of q.crossings || []) {
+                const p = S(c.x, c.y);
+                R.ctx.beginPath();
+                R.ctx.ellipse(p.x, p.y, 9 * clampZoom(), 5 * clampZoom(), 0, 0, Math.PI * 2);
+                R.ctx.strokeStyle = rgba('#34d399', 0.95);
+                R.ctx.lineWidth = 2;
+                R.ctx.setLineDash([4, 3]);
+                R.ctx.stroke();
+                R.ctx.setLineDash([]);
+            }
+        }
+
         const mx = (sel.x + end.x) / 2, my = (sel.y + end.y) / 2;
-        const crossingLabel = q.ferry ? ' (ferry)' : q.bridge ? ' (bridge)' : '';
         const mp = S(mx, my);
-        labelAt(`$${q.cost}${crossingLabel}`, mp.x, mp.y - 14, affordable ? '#34d399' : '#f87171');
+        const n = (q.crossings || []).length;
+        const label = q.blocked ? GHOST_BLOCK_LABEL[q.blocked]
+            : `$${q.cost}${q.ferry ? ' (ferry)' : q.bridge ? ' (bridge)' : ''}${n ? ` — ${n} 🔀` : ''}`;
+        labelAt(label, mp.x, mp.y - 14, color);
     }
 
     function drawPlacementGhost() {

--- a/supply-chain/js/roads.js
+++ b/supply-chain/js/roads.js
@@ -8,34 +8,217 @@ SC.roads = (function() {
             (e.a === a && e.b === b) || (e.a === b && e.b === a)) || null;
     }
 
-    // Quote for a prospective road; null when not buildable. `opts.ferry`
-    // requests a ferry instead of a bridge for a river crossing — cheaper
-    // than BRIDGE_MULT, at the cost of FERRY_SPEED_MULT (see speedMult).
+    // ── Overlap rules ───────────────────────────────────────────────────
+    // A road may not be laid over the top of the network — that's what
+    // turned mature maps into a cat's cradle of map-long diagonals drawn
+    // straight over everything. Two rules, both quoted here and surfaced by
+    // the build ghost (render-network) and a toast (input):
+    //   1. It may not brush past a site that isn't one of its own endpoints
+    //      (NODE_ROAD_CLEARANCE) — route *through* that site instead, which
+    //      is what makes a network of hops rather than one long bypass.
+    //   2. It may not cross another road at all until the (cheap, early)
+    //      'intersections' research; afterwards a crossing is legal but
+    //      builds a real interchange — a junction node splitting both roads,
+    //      priced per crossing at PLACEMENT_INTERSECTION_PRICE, the same as
+    //      retrofitting one by hand — so the two roads genuinely meet
+    //      instead of overlapping.
+    // A blocked prospect comes back from quote() with `.blocked` set (and a
+    // matching blockMessage) instead of null, so the UI can say why.
+
+    // Every existing edge the segment a→b crosses, ordered along it.
+    // Edges sharing one of `ignore`'s nodes are connected to the new road,
+    // not crossed by it.
+    function edgeCrossings(ax, ay, bx, by, ignore) {
+        const p = { x: ax, y: ay }, q = { x: bx, y: by };
+        const out = [];
+        for (const e of SC.state.edges) {
+            if (ignore.indexOf(e.a) !== -1 || ignore.indexOf(e.b) !== -1) continue;
+            const pt = getLineIntersection(p, q, e.a, e.b);
+            if (pt) out.push({ edge: e, x: pt.x, y: pt.y, t: pt.t, u: pt.u });
+        }
+        return out.sort((m, n) => m.t - n.t);
+    }
+
+    // Geometry verdict for a prospective road, independent of who owns its
+    // ends — the build ghost runs it against a bare pointer position, so it
+    // takes raw coordinates plus the nodes the segment is allowed to touch.
+    // Returns { blocked: reason|null, crossings, node?, at? }.
+    function checkSegment(ax, ay, bx, by, ignore) {
+        const C = SC.CONFIG;
+        ignore = ignore || [];
+        for (const n of SC.state.nodes) {
+            if (!n.active || ignore.indexOf(n) !== -1) continue;
+            if (pointSegDist(n.x, n.y, ax, ay, bx, by) < C.NODE_ROAD_CLEARANCE)
+                return { blocked: 'node', node: n, crossings: [] };
+        }
+        const crossings = edgeCrossings(ax, ay, bx, by, ignore);
+        // The plain rule comes first, so a player without the research hears
+        // "roads can't cross" rather than a lecture on interchange geometry.
+        if (crossings.length && !(SC.research && SC.research.isDone('intersections')))
+            return { blocked: 'crossing', at: crossings[0], crossings };
+        // An interchange needs room. On top of a node (or of the next
+        // interchange along) it would leave a stub edge shorter than the
+        // roundabout drawn over it; midstream it would be a roundabout
+        // floating on the river.
+        for (let i = 0; i < crossings.length; i++) {
+            const c = crossings[i];
+            if (SC.map.isInRiver(c.x, c.y)) return { blocked: 'water', at: c, crossings };
+            const tight = [c.edge.a, c.edge.b, { x: ax, y: ay }, { x: bx, y: by }]
+                .some(p => Math.hypot(c.x - p.x, c.y - p.y) < C.ROAD_JUNCTION_MIN_GAP) ||
+                (i > 0 && Math.hypot(c.x - crossings[i - 1].x, c.y - crossings[i - 1].y) < C.ROAD_JUNCTION_MIN_GAP);
+            if (tight) return { blocked: 'tight', at: c, crossings };
+        }
+        return { blocked: null, crossings };
+    }
+
+    function nodeLabel(n) {
+        if (!n) return 'a site';
+        if (n.isHQ) return 'HQ';
+        if (n.kind === 'supplier') return `the ${SC.nameOf(n.mat).toLowerCase()} supplier`;
+        if (n.kind === 'factory') return `the ${(SC.GOODS[n.recipe].building || 'factory').toLowerCase()}`;
+        if (n.kind === 'junction') return 'a junction';
+        if (n.kind === 'yard') return 'a truck yard';
+        return 'a customer DC';
+    }
+
+    // Why a quote (or a checkSegment verdict) is blocked, in words. Pure
+    // string — input.js toasts it, render-network labels the ghost with it.
+    function blockMessage(q) {
+        switch (q && q.blocked) {
+            case 'node': return `That road would run over ${nodeLabel(q.node)} — connect through it instead`;
+            case 'crossing': return 'Roads can’t cross — route through a node, or research Road Crossings ➕';
+            case 'tight': return 'No room for an interchange where those roads cross';
+            case 'water': return 'Roads can’t cross midstream — that interchange would sit in the river';
+            default: return '';
+        }
+    }
+
+    // The spans a prospective road is actually built from: one per stretch
+    // between its endpoints and its interchanges. Each is priced on its own,
+    // since one span may cross the river while another doesn't.
+    function spanQuotes(a, b, crossings, wantFerry) {
+        const pts = [a].concat(crossings, [b]);
+        const out = [];
+        for (let i = 0; i < pts.length - 1; i++) {
+            const p = pts[i], q = pts[i + 1];
+            const len = Math.hypot(q.x - p.x, q.y - p.y);
+            const bridge = SC.map.segmentCrossesRiver(p.x, p.y, q.x, q.y);
+            const ferry = wantFerry && bridge;
+            const mult = ferry ? SC.CONFIG.FERRY_COST_MULT : (bridge ? SC.CONFIG.BRIDGE_MULT : 1);
+            out.push({ len, bridge, ferry, cost: Math.round(len * SC.CONFIG.ROAD_COST_PER_UNIT * mult) });
+        }
+        return out;
+    }
+
+    // Quote for a prospective road; null when the pair is meaningless (same
+    // node, inactive, already roaded), otherwise a quote — with `.blocked`
+    // set when the overlap rules above forbid it. `opts.ferry` requests a
+    // ferry instead of a bridge for a river crossing — cheaper than
+    // BRIDGE_MULT, at the cost of FERRY_SPEED_MULT (see speedMult).
     // Meaningless (and ignored) for a segment that doesn't cross the river.
+    // `cost` covers every span plus `fee`, the interchange junctions.
     function quote(a, b, opts) {
         if (!a || !b || a === b) return null;
         if (!a.active || !b.active) return null;
         if (findEdge(a, b)) return null;
         const len = Math.hypot(a.x - b.x, a.y - b.y);
         const bridge = SC.map.segmentCrossesRiver(a.x, a.y, b.x, b.y);
-        const ferry = !!(opts && opts.ferry) && bridge;
-        const mult = ferry ? SC.CONFIG.FERRY_COST_MULT : (bridge ? SC.CONFIG.BRIDGE_MULT : 1);
-        const cost = Math.round(len * SC.CONFIG.ROAD_COST_PER_UNIT * mult);
-        return { len, bridge, ferry, cost };
+        const wantFerry = !!(opts && opts.ferry);
+        const chk = checkSegment(a.x, a.y, b.x, b.y, [a, b]);
+        const spans = spanQuotes(a, b, chk.crossings, wantFerry);
+        const fee = chk.crossings.length * SC.CONFIG.PLACEMENT_INTERSECTION_PRICE;
+        const cost = spans.reduce((sum, s) => sum + s.cost, 0) + fee;
+        const q = { len, bridge, ferry: wantFerry && bridge, cost, fee,
+                    crossings: chk.crossings, spans };
+        if (chk.blocked) {
+            q.blocked = chk.blocked;
+            q.node = chk.node || null;
+            q.at = chk.at || null;
+        }
+        return q;
     }
 
     function build(a, b, opts) {
         const q = quote(a, b, opts);
         if (!q) return { ok: false, reason: 'invalid' };
+        if (q.blocked) return { ok: false, reason: q.blocked, message: blockMessage(q), quote: q };
         if (!SC.canAfford(q.cost)) return { ok: false, reason: 'money', cost: q.cost };
         SC.state.money -= q.cost;
-        const edge = { a, b, len: q.len, bridge: q.bridge, ferry: q.ferry, cost: q.cost, level: 0 };
-        SC.state.edges.push(edge);
-        a.edges.push(b);
-        b.edges.push(a);
+        // Interchanges first: each crossed road is split by its own junction
+        // node, which the new road then hops through.
+        const chain = [a];
+        for (const c of q.crossings) {
+            const j = SC.map.makeNode('junction', c.x, c.y, { active: true });
+            splitEdge(c.edge, j, c.u);
+            chain.push(j);
+            SC.emit('sitePlaced', { node: j, cost: SC.CONFIG.PLACEMENT_INTERSECTION_PRICE });
+        }
+        chain.push(b);
+        const edges = [];
+        for (let i = 0; i < chain.length - 1; i++) {
+            const s = q.spans[i];
+            const edge = { a: chain[i], b: chain[i + 1], len: s.len, bridge: s.bridge,
+                           ferry: s.ferry, cost: s.cost, level: 0 };
+            SC.state.edges.push(edge);
+            chain[i].edges.push(chain[i + 1]);
+            chain[i + 1].edges.push(chain[i]);
+            edges.push(edge);
+        }
         SC.economy && SC.economy.onNetworkChanged();
-        SC.emit('roadBuilt', edge);
-        return { ok: true, edge };
+        for (const edge of edges) SC.emit('roadBuilt', edge);
+        return { ok: true, edge: edges[0], edges, junctions: chain.slice(1, -1) };
+    }
+
+    // Replace `edge` with two edges meeting at `node`, which sits at
+    // fraction `t` along it (edge.a → edge.b). Shared by the interchanges
+    // built above and the manual retrofit tool (SC.placement 'intersection'),
+    // including re-seating any truck currently driving the old edge.
+    function splitEdge(edge, node, t) {
+        const a = edge.a, b = edge.b;
+        const idx = SC.state.edges.indexOf(edge);
+        if (idx !== -1) SC.state.edges.splice(idx, 1);
+        a.edges.splice(a.edges.indexOf(b), 1);
+        b.edges.splice(b.edges.indexOf(a), 1);
+
+        // Each half re-derives its own bridge/ferry state and length-priced
+        // cost (a split can leave one half over water and the other dry),
+        // and inherits the original's highway level.
+        const halves = [[a, node], [node, b]].map(([p, q]) => {
+            const len = Math.hypot(q.x - p.x, q.y - p.y);
+            const bridge = SC.map.segmentCrossesRiver(p.x, p.y, q.x, q.y);
+            const ferry = !!edge.ferry && bridge;
+            const mult = ferry ? SC.CONFIG.FERRY_COST_MULT : (bridge ? SC.CONFIG.BRIDGE_MULT : 1);
+            return { a: p, b: q, len, bridge, ferry,
+                     cost: Math.round(len * SC.CONFIG.ROAD_COST_PER_UNIT * mult), level: edge.level };
+        });
+        for (const half of halves) {
+            SC.state.edges.push(half);
+            half.a.edges.push(half.b);
+            half.b.edges.push(half.a);
+        }
+
+        // Re-seat in-flight trucks: insert the node into their path and
+        // rescale the progress of whichever leg they're driving right now.
+        for (const truck of SC.state.trucks) {
+            if (!truck.path) continue;
+            for (let k = 0; k < truck.path.length - 1; k++) {
+                const na = truck.path[k], nb = truck.path[k + 1];
+                if (!((na === a && nb === b) || (na === b && nb === a))) continue;
+                truck.path.splice(k + 1, 0, node);
+                if (k < truck.pathIdx) {
+                    truck.pathIdx++;
+                } else if (k === truck.pathIdx) {
+                    const f = (na === a) ? t : (1 - t);
+                    if (truck.progress < f) {
+                        truck.progress = truck.progress / f;
+                    } else {
+                        truck.pathIdx++;
+                        truck.progress = (truck.progress - f) / (1 - f);
+                    }
+                }
+                k++; // skip the node just inserted
+            }
+        }
     }
 
     function demolish(edge) {
@@ -223,7 +406,38 @@ SC.roads = (function() {
         return best;
     }
 
+    // Is there any unconnected crossing left on the map? New roads can't
+    // make one any more (they build an interchange instead, see build), so
+    // this is only ever true for a save from before that rule — which is
+    // exactly when the manual retrofit tool is worth offering (see
+    // SC.ui.updateIntersectionBtn).
+    function hasCrossings() {
+        const edges = SC.state.edges;
+        for (let i = 0; i < edges.length; i++) {
+            for (let j = i + 1; j < edges.length; j++) {
+                const e1 = edges[i], e2 = edges[j];
+                if (e1.a === e2.a || e1.a === e2.b || e1.b === e2.a || e1.b === e2.b) continue;
+                if (getLineIntersection(e1.a, e1.b, e2.a, e2.b)) return true;
+            }
+        }
+        return false;
+    }
+
+    // Test/dev hook: an edge that ignores the overlap rules, i.e. the kind of
+    // crossing a pre-1.56 save can still contain. Not reachable in play.
+    function _addRawEdge(a, b) {
+        const len = Math.hypot(a.x - b.x, a.y - b.y);
+        const bridge = SC.map.segmentCrossesRiver(a.x, a.y, b.x, b.y);
+        const edge = { a, b, len, bridge, ferry: false, level: 0,
+                       cost: Math.round(len * SC.CONFIG.ROAD_COST_PER_UNIT * (bridge ? SC.CONFIG.BRIDGE_MULT : 1)) };
+        SC.state.edges.push(edge);
+        a.edges.push(b);
+        b.edges.push(a);
+        return edge;
+    }
+
     return { findEdge, quote, build, demolish, findPath, pathDist,
              speedMult, congestionMult, upgradeQuote, upgrade, getLineIntersection, findClosestCrossing,
-             pointSegDist, pointRoadDist };
+             checkSegment, blockMessage, splitEdge, hasCrossings,
+             pointSegDist, pointRoadDist, _addRawEdge };
 })();

--- a/supply-chain/js/tutorial.js
+++ b/supply-chain/js/tutorial.js
@@ -32,7 +32,6 @@ SC.tutorial = (function () {
             .sort((a, b) => Math.hypot(a.x - f.x, a.y - f.y) - Math.hypot(b.x - f.x, b.y - f.y))[0] || null;
     };
 
-    const linked = (a, b) => !!(a && b && a.edges.indexOf(b) !== -1);
     const routed = (a, b) => !!(a && b && SC.roads.findPath(a, b));
 
     // Each step names the tap it wants, the nodes to point at, and the
@@ -45,13 +44,17 @@ SC.tutorial = (function () {
             id: 'wheat',
             text: '🌾 Your bakery needs wheat. Tap the <b>bakery</b>, then the <b>wheat farm</b>, to build a road between them.',
             targets: () => [bakery(), supplier('wheat')],
-            done: () => linked(bakery(), supplier('wheat'))
+            // Goal, not action: on the rare starter layout where a third site
+            // sits on the straight line between them, the overlap rules
+            // (SC.roads.checkSegment) refuse the direct road and the player
+            // has to hop through that site — which still counts.
+            done: () => routed(bakery(), supplier('wheat'))
         },
         {
             id: 'water',
             text: '💧 Bread needs water too. Now road the <b>bakery</b> to the <b>water pump</b>.',
             targets: () => [bakery(), supplier('water')],
-            done: () => linked(bakery(), supplier('water'))
+            done: () => routed(bakery(), supplier('water'))
         },
         {
             id: 'hq',

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -186,11 +186,18 @@ SC.ui = (function() {
         $('yard-overlay').classList.add('hidden');
     }
 
+    // ── Intersections: the retrofit tool for roads that already cross
+    // without meeting. New roads build their own interchanges now (see
+    // SC.roads.build), so a crossing to retrofit only exists in a save from
+    // before that rule — the button hides itself when the map has none, and
+    // an active place-mode keeps it visible so it can be cancelled. ──
     function updateIntersectionBtn() {
         const st = SC.state;
         const btn = $('btn-intersection');
         if (!btn) return;
-        btn.classList.toggle('hidden', !SC.placement.isUnlocked('intersection'));
+        const useful = SC.roads.hasCrossings() ||
+            (st.placeMode && st.placeMode.kind === 'intersection');
+        btn.classList.toggle('hidden', !SC.placement.isUnlocked('intersection') || !useful);
         if (btn.classList.contains('hidden')) return;
         const price = SC.CONFIG.PLACEMENT_INTERSECTION_PRICE;
         const active = st.placeMode && st.placeMode.kind === 'intersection';
@@ -578,6 +585,13 @@ SC.ui = (function() {
         const bridgeQuote = SC.roads.quote(d.a, d.b);
         const ferryQuote = SC.roads.quote(d.a, d.b, { ferry: true });
         if (!bridgeQuote || !ferryQuote) { pendingCrossing = null; return; }
+        // Belt-and-braces: input.js already refuses a road the overlap rules
+        // block, so the choice never reaches here for one.
+        if (bridgeQuote.blocked) {
+            toast(SC.roads.blockMessage(bridgeQuote), 'error');
+            pendingCrossing = null;
+            return;
+        }
         $('crossing-bridge-cost').textContent = fmt(bridgeQuote.cost);
         $('crossing-ferry-cost').textContent = fmt(ferryQuote.cost);
         crossingOpenedAt = performance.now();
@@ -600,6 +614,9 @@ SC.ui = (function() {
         } else if (res.reason === 'money') {
             SC.sfx.play('error');
             toast(`Credit limit reached — road costs $${res.cost} (limit −$${SC.CONFIG.CREDIT_LIMIT})`, 'error');
+        } else if (res.message) {
+            SC.sfx.play('error');
+            toast(res.message, 'error');
         }
         pendingCrossing = null;
         $('crossing-overlay').classList.add('hidden');

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.56.0';</script>
+    <script>window.SC_VERSION = '1.57.0';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'audio', 'sfx', 'rng', 'map', 'camera',

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.55.0';</script>
+    <script>window.SC_VERSION = '1.56.0';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'audio', 'sfx', 'rng', 'map', 'camera',
@@ -95,6 +95,109 @@
         assert('demolish refunds half', SC.roads.demolish(res.edge) &&
             SC.state.money === money1 + Math.round(res.edge.cost * SC.CONFIG.ROAD_REFUND));
         assert('adjacency removed after demolish', !S1.edges.includes(F));
+    })();
+
+    // ── Road overlap rules: no laying a road over the network ───────
+    // Clean state each time (the shared fixture's cluster would get in the
+    // way of the geometry): A─B runs east-west at y=300, C─D north-south at
+    // x=500, crossing it at (500, 300). River far away at x=1100.
+    function crossFixture() {
+        SC.newState();
+        SC.map._resetSeq();
+        SC.state.river = { spine: [{ x: 1100, y: 0 }, { x: 1100, y: SC.CONFIG.WORLD_H }],
+                           halfWidths: [40, 40] };
+        SC.state.money = 100000;
+        return {
+            A: SC.map.makeNode('supplier', 200, 300, { active: true, mat: 'wheat' }),
+            B: SC.map.makeNode('supplier', 800, 300, { active: true, mat: 'water' }),
+            C: SC.map.makeNode('factory',  500, 100, { active: true, recipe: 'bread' }),
+            D: SC.map.makeNode('city',     500, 600, { active: true, isHQ: true })
+        };
+    }
+
+    (function() {
+        const { A, B, C, D } = crossFixture();
+        SC.roads.build(A, B);
+
+        const q = SC.roads.quote(C, D);
+        assert('a road across another is blocked before the research',
+            q && q.blocked === 'crossing' && q.crossings.length === 1);
+        assert('the block comes with a reason to show the player',
+            SC.roads.blockMessage(q).length > 0);
+        const before = SC.state.money;
+        const res = SC.roads.build(C, D);
+        assert('building it is refused, free of charge',
+            !res.ok && res.reason === 'crossing' && SC.state.money === before &&
+            SC.state.edges.length === 1);
+
+        // A road may not brush past a site it doesn't connect to either —
+        // E sits on the far side of D, so C→E would run straight over D.
+        const E = SC.map.makeNode('city', 500, 900, { active: true });
+        const qNode = SC.roads.quote(C, E);
+        assert('a road running over a site is blocked, naming it',
+            qNode && qNode.blocked === 'node' && qNode.node === D);
+        assert('the same road is fine once it stops at that site',
+            SC.roads.quote(C, D).blocked === 'crossing' && !SC.roads.quote(D, E).blocked);
+
+        // Clearance is the same gap manual placement keeps the other way
+        // round: threading past D at exactly NODE_ROAD_CLEARANCE is legal,
+        // a unit closer is not.
+        const gap = SC.CONFIG.NODE_ROAD_CLEARANCE;
+        assert('a road clearing a site by NODE_ROAD_CLEARANCE is allowed',
+            !SC.roads.checkSegment(200, 600 + gap, 800, 600 + gap, []).blocked);
+        assert('a unit closer than that is not',
+            SC.roads.checkSegment(200, 600 + gap - 1, 800, 600 + gap - 1, []).blocked === 'node');
+    })();
+
+    // ── Interchanges: a legal crossing builds (and pays for) a junction ──
+    (function() {
+        const { A, B, C, D } = crossFixture();
+        SC.state.research.completed.intersections = true;
+        SC.roads.build(A, B);
+
+        const q = SC.roads.quote(C, D);
+        const fee = SC.CONFIG.PLACEMENT_INTERSECTION_PRICE;
+        const rate = SC.CONFIG.ROAD_COST_PER_UNIT;
+        assert('a crossing is quoted once the research is done', q && !q.blocked);
+        assert('the quote prices both spans plus the interchange fee',
+            q.cost === Math.round(200 * rate) + Math.round(300 * rate) + fee && q.fee === fee);
+
+        const before = SC.state.money;
+        const res = SC.roads.build(C, D);
+        assert('the crossing road builds and charges the quote',
+            res.ok && SC.state.money === before - q.cost);
+        assert('an interchange junction lands on the crossing',
+            res.junctions.length === 1 && res.junctions[0].kind === 'junction' &&
+            approx(res.junctions[0].x, 500) && approx(res.junctions[0].y, 300));
+        assert('both roads are split at it — 4 spans, 4 arms',
+            SC.state.edges.length === 4 && res.junctions[0].edges.length === 4);
+        assert('the two roads now genuinely connect',
+            SC.roads.findPath(A, C) && SC.roads.findPath(A, C).path.includes(res.junctions[0]));
+        assert('no road is left crossing another', !SC.roads.hasCrossings());
+    })();
+
+    // ── Interchange geometry: needs room, and not in midstream ───────
+    (function() {
+        const { A, B } = crossFixture();
+        SC.state.research.completed.intersections = true;
+        SC.roads.build(A, B);
+        // The build ghost checks bare pointer positions, which (unlike real
+        // sites) can sit right on top of a road: crossing one a few units
+        // from where the road would start leaves no room for a junction.
+        assert('a crossing too close to the road\'s own end is refused',
+            SC.roads.checkSegment(650, 280, 650, 700, []).blocked === 'tight');
+        assert('the same crossing further along is fine',
+            !SC.roads.checkSegment(650, 100, 650, 700, []).blocked);
+
+        // An interchange can't float on the river: E─F spans it, G─H would
+        // cross E─F midstream.
+        const E = SC.map.makeNode('supplier', 900, 800, { active: true, mat: 'ore' });
+        const F = SC.map.makeNode('supplier', 1300, 800, { active: true, mat: 'coal' });
+        const G = SC.map.makeNode('city', 1100, 600, { active: true });
+        const H = SC.map.makeNode('city', 1100, 1000, { active: true });
+        SC.roads.build(E, F);
+        assert('an interchange in the river is refused',
+            SC.roads.quote(G, H).blocked === 'water');
     })();
 
     // ── Pathfinding ─────────────────────────────────
@@ -810,7 +913,10 @@
         const copper = SC.map.makeNode('supplier', 100, 500, { active: true, mat: 'copper' });
         const rubber = SC.map.makeNode('supplier', 100, 700, { active: true, mat: 'rubber' });
         const wireF  = SC.map.makeNode('factory',  300, 600, { active: true, recipe: 'wire' });
-        const chips  = SC.map.makeNode('supplier', 500, 500, { active: true, mat: 'chips' });
+        // Chips sits off to the side rather than between the circuit and
+        // robot factories: a road may not run over a site it doesn't stop
+        // at (SC.roads.checkSegment), and circF→robotF passes right there.
+        const chips  = SC.map.makeNode('supplier', 620, 500, { active: true, mat: 'chips' });
         const circF  = SC.map.makeNode('factory',  500, 600, { active: true, recipe: 'circuit' });
         const robotF = SC.map.makeNode('factory',  500, 350, { active: true, recipe: 'robot' });
         const city   = SC.map.makeNode('city',     700, 400, { active: true, isHQ: true });
@@ -1600,15 +1706,16 @@
 
     // ── Congestion: Dijkstra routes around a jammed edge (flag-gated) ──
     (function() {
-        // Two parallel routes of equal length from A to B: a direct edge,
-        // and a two-hop detour through M — same total distance, so
-        // findPath is indifferent until one gets jammed.
+        // Two routes from A to B: a direct edge, and a two-hop detour
+        // through M that's only ~3% longer (M has to clear the direct road
+        // by NODE_ROAD_CLEARANCE — a road may not brush past a site it
+        // doesn't stop at), so the direct edge wins until it's jammed.
         SC.newState('normal'); // congestion on by default
         SC.map._resetSeq();
         SC.state.river = { spine: [{ x: 5000, y: 0 }, { x: 5000, y: SC.CONFIG.WORLD_H }], halfWidths: [10, 10] };
         const A = SC.map.makeNode('city', 0, 0, { active: true, isHQ: true });
         const B = SC.map.makeNode('city', 400, 0, { active: true });
-        const M = SC.map.makeNode('supplier', 200, -1, { active: true, mat: 'wheat' }); // ~= 400 total, matches direct
+        const M = SC.map.makeNode('supplier', 200, 49, { active: true, mat: 'wheat' }); // ~412 total vs the direct 400
         SC.state.money = 100000;
         const direct = SC.roads.build(A, B).edge;
         SC.roads.build(A, M);
@@ -2190,9 +2297,15 @@
         assert('edge trip count survives a save round-trip', restoredEdge && restoredEdge.trips === 2);
     })();
 
-    // ── Intersections: math, placement, and road splitting ───────────
+    // ── Intersections: math, and the retrofit tool for legacy crossings ──
+    // New roads build their own interchanges now (see the overlap-rule tests
+    // above), so the manual tool only ever meets a crossing from a save made
+    // before that rule — which `_addRawEdge` reproduces here.
     (function() {
-        fixture();
+        SC.newState();
+        SC.map._resetSeq();
+        SC.state.river = { spine: [{ x: 1100, y: 0 }, { x: 1100, y: SC.CONFIG.WORLD_H }],
+                           halfWidths: [40, 40] };
         SC.state.money = 100000;
 
         // 1. Math check
@@ -2219,10 +2332,12 @@
         const nC = SC.map.makeNode('supplier', 100, 300, { active: true, mat: 'water' });
         const nD = SC.map.makeNode('city', 300, 100, { active: true });
 
-        const edge1 = SC.roads.build(nA, nB).edge;
-        const edge2 = SC.roads.build(nC, nD).edge;
+        const edge1 = SC.roads._addRawEdge(nA, nB);
+        const edge2 = SC.roads._addRawEdge(nC, nD);
 
         assert('two roads exist', SC.state.edges.length === 2);
+        assert('and they cross without meeting — the legacy case',
+            SC.roads.hasCrossings());
 
         const crossing = SC.roads.findClosestCrossing(200, 200, 40);
         assert('closest crossing detected', crossing !== null && approx(crossing.x, 200) && approx(crossing.y, 200));
@@ -2252,6 +2367,7 @@
         assert('truck path has 3 nodes now', truck.path.length === 3 && truck.path[1] === res.node);
         assert('truck progress mapped correctly', approx(truck.progress, 0.8));
         assert('truck pathIdx is still 0', truck.pathIdx === 0);
+        assert('the retrofit leaves no crossing behind', !SC.roads.hasCrossings());
     })();
 
     // ── Tutorial: step progression, skipping, persistence ────────────


### PR DESCRIPTION
From the screenshot of a mature map: nothing stopped a road being drawn map-long, straight over every site and road in its way, so geometry never mattered and junctions were decoration.

## The rules (`SC.roads.checkSegment`, quoted by every `SC.roads.quote`)

1. **No running over a site.** A road may not brush past a node that isn't one of its own endpoints (`NODE_ROAD_CLEARANCE` — the same gap manual placement keeps the other way round). Route *through* that site instead, which is what turns one long bypass into a network of hops.
2. **No crossing another road** until the cheap, early **Road Crossings** (`intersections`) research. After that a crossing is legal but builds a real **interchange**: `SC.roads.build` drops a junction node on each crossing point, splits both crossed roads through it, and charges `PLACEMENT_INTERSECTION_PRICE` per interchange on top of the length-priced spans. So the two roads genuinely meet, and a long diagonal over a busy area costs real money.

`intersections` now does what its name says, and junctions earn their keep.

## Seeing the rules (v1.57.0)

Saying "no" isn't teaching, so the dashed build preview answers *why* and *how* before the tap:

- **Blocked by a site** — its clearance ring and a ✕ on it, plus, in green, the two hops through it (`road it in two hops`, or `continue from here` when the first hop already exists).
- **Blocked by a crossing** — the road in the way is lit red down its whole length with a ✕ on the crossing point, and the ends of that road (always legal to connect to) get green rings.
- **A legal crossing** — each interchange the road would build is ringed and priced there (`+$150 junction`), with the count folded into the ghost's cost label.

Suggestions are re-quoted before being drawn, so the ghost never proposes another blocked road. The pointing marks moved into a second render pass after the depth-sorted entity pass (`R.drawGhostMarks()`) — drawn with the roads, they were painted over by the very site they point at. `input.js` still toasts the full sentence (`SC.roads.blockMessage`) on a refused tap, and the help overlay gained a **"Roads can't overlap"** entry.

## Fallout handled

- `splitEdge` moved from `placement.js` into `roads.js` (it's road-graph surgery, now shared by interchanges and the manual tool) — including re-seating trucks driving the split edge.
- The manual **Place intersection** tool is only a retrofit for saves made before this rule, so its Shop button hides unless the map still has a crossing (`roads.hasCrossings`).
- Tutorial steps 1–2 check connectivity rather than a direct edge: on a rare starter layout where a site sits on the straight line, hopping through it still counts.
- Probe flags `&interchange=1` (builds one to screenshot) and `&select=hq|factory|<id>` (pairs with `&hoverAt=` to render the build ghost).
- README / PLAN / CLAUDE.md updated; version bumped to 1.57.0 in all three spots.

## Verification

- Logic tests: **895 passed / 0 failed** (new assertions across three blocks: the block rules, interchange building/pricing/splitting, and the geometry guards).
- Visual smoke: `?probe=` on several seeds; `&interchange=1` shows the junction on the crossing with both roads split; `&select=…&hoverAt=` shows all three ghost states (blocked by site, blocked by crossing, legal crossing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDCUKYwRXxwfXwj2X6XyZ9