### PR TITLE
supply-chain: auto-hide supplier stock bars when zoomed out

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
                 </svg></span>
         </a>
 
-        <a href="supply-chain/index.html?v=1.55.0" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.55.1" class="card card-metal" id="card-supply-chain">
             <div class="beta-badge">BETA</div>
             <div>
                 <div class="card-icon">🏭</div>

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.55.0';</script>
+    <script>window.SC_VERSION = '1.55.1';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>

--- a/supply-chain/js/render-network.js
+++ b/supply-chain/js/render-network.js
@@ -859,15 +859,31 @@
         if (n.kind === 'supplier') {
             const cap = SC.supplierCap(n);
             const frac = Math.max(0, Math.min(1, (n.stock || 0) / cap));
-            const bw = 34, bx = tc.x - bw / 2, by = tc.y - iconSize - 9;
-            // dark backing plate so the bar doesn't float as a bare dash
-            R.ctx.fillStyle = 'rgba(12, 18, 30, 0.75)';
-            roundRectPath(bx - 3, by - 3, bw + 6, 10, 5); R.ctx.fill();
-            R.ctx.fillStyle = 'rgba(255, 255, 255, 0.16)';
-            roundRectPath(bx, by, bw, 4, 2); R.ctx.fill();
-            R.ctx.fillStyle = frac < 0.25 ? '#f87171' : sp.base;
-            roundRectPath(bx, by, bw * frac, 4, 2); R.ctx.fill();
-            if (n.level > 0) labelAt('▲'.repeat(n.level), tc.x, by - 13, '#facc15', 10);
+            // Low-stock warning colour: red when critically low (<15%),
+            // amber when getting low (<50%), otherwise not "low" at all.
+            const warn = frac < 0.15 ? '#f87171' : frac < 0.5 ? '#facc15' : null;
+            if (pillsVisible()) {
+                const bw = 34, bx = tc.x - bw / 2, by = tc.y - iconSize - 9;
+                // dark backing plate so the bar doesn't float as a bare dash
+                R.ctx.fillStyle = 'rgba(12, 18, 30, 0.75)';
+                roundRectPath(bx - 3, by - 3, bw + 6, 10, 5); R.ctx.fill();
+                R.ctx.fillStyle = 'rgba(255, 255, 255, 0.16)';
+                roundRectPath(bx, by, bw, 4, 2); R.ctx.fill();
+                R.ctx.fillStyle = warn || sp.base;
+                roundRectPath(bx, by, bw * frac, 4, 2); R.ctx.fill();
+                if (n.level > 0) labelAt('▲'.repeat(n.level), tc.x, by - 13, '#facc15', 10);
+            } else if (warn) {
+                // Zoomed out the full stock bars turn to visual noise, so they
+                // auto-hide with the factory pills. A supplier running low is
+                // still worth flagging, so drop the bar to a small warning dot
+                // (red <15%, amber <50%) — enough to catch the eye without the
+                // clutter of a bar over every supplier.
+                const by = tc.y - iconSize - 6;
+                R.ctx.fillStyle = 'rgba(12, 18, 30, 0.75)';
+                R.ctx.beginPath(); R.ctx.arc(tc.x, by, 4.5, 0, Math.PI * 2); R.ctx.fill();
+                R.ctx.fillStyle = warn;
+                R.ctx.beginPath(); R.ctx.arc(tc.x, by, 2.8, 0, Math.PI * 2); R.ctx.fill();
+            }
         } else if (n.kind === 'factory' && forSale) {
             labelAt(`$${SC.CONFIG.FACTORY_SITE_PRICE}`, tc.x, tc.y - iconSize - 6, '#94a3b8', 11);
         } else if (n.kind === 'yard') {

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.55.0';</script>
+    <script>window.SC_VERSION = '1.55.1';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'audio', 'sfx', 'rng', 'map', 'camera',


### PR DESCRIPTION
When zoomed out (same threshold as the factory production pills), the
per-supplier stock bars became visual noise across the map. They now
auto-hide with the pills, and a supplier running low is flagged instead
by a small warning dot above it: red below 15% stock, amber below 50%.
The full bar (now using the same red/amber low thresholds) still shows
when zoomed in.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016AByiwYNqaf4VCJCtegaRk