### PR TITLE
Ground quality: supplier yield follows the biome under the site

### DIFF
--- a/index.html
+++ b/index.html
@@ -908,7 +908,7 @@
     </header>
 
     <main class="grid">
-        <a href="supply-chain/index.html?v=1.61.1" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.61.2" class="card card-metal" id="card-supply-chain">
             <div class="card-bg-hover"></div>
             <div>
                 <div class="card-icon">

--- a/supply-chain/DEBUG.md
+++ b/supply-chain/DEBUG.md
@@ -68,6 +68,7 @@ Adding a flag? Add the row here too — this table is the whole contract.
 | `&research=id,id` | Instantly complete those techs by id (also tops up money, so the Build section/menu are screenshotable). Ids are the keys of `SC.RESEARCH` in [js/config.js](js/config.js). |
 | `&placemode=factory:shoes` | Arm manual-placement mode. Requires `manualPlacement` researched — pass both together. |
 | `&hoverAt=x,y` | Fake a pointer position (world coords) via `SC.input._setDebugHover`, so the placement/road ghost preview renders without a real pointermove. |
+| `&inspect=<mat>\|hq\|factory\|<node id>` | Switch to inspect mode and open the tooltip on a node via `SC.input._setDebugInspect`, without a real tap — a raw material name (`wheat`, `ore`, …) picks the first active supplier of it. The way to screenshot what a site reports: stock, rate, and its biome/yield row. |
 | `&highway=1` | Complete Asphalt Paving and pave every built road (highway styling). |
 | `&capacity=1` | Max the truck-capacity upgrade, so bundled multi-item hauls (the ×N badge) show up without a long probe. |
 | `&interchange=1` | Complete the Road Crossings research, drop a waypoint either side of the first starter road and connect them, so the **interchange** a legal crossing builds (junction on the crossing point, both roads split through it — see README "Overlap rules") can be screenshotted. Pair with `&focus=` to frame it. |

--- a/supply-chain/PLAN.md
+++ b/supply-chain/PLAN.md
@@ -39,6 +39,16 @@ in Phase 4 — not in README.md, which now just points here. See
 
 ## Shipped
 
+- v1.61.2: **ground quality — biome-driven supplier yield** — a supplier's
+  regen is now multiplied by the biome band under it (`BIOME_BANDS` ×
+  `BIOME_YIELD`, per material) plus a small per-site roll
+  (`SITE_YIELD_VARIANCE`), so crops thrive on green ground and struggle in
+  sand while mines read the same map the other way. The biome field moved
+  out of `render-env` into `state.js`, so the tint you see and the
+  multiplier you get come from one seeded source — the map is now the
+  legend for where to build and which site is worth upgrading. Inspect a
+  supplier for its band, yield % and units/sec. Derived from position +
+  seed, so it needs no save-format change and travels with `?seed=`.
 - v1.61.1: **upgraded suppliers grow on the ground, not just upward** — a
   supplier level now widens its plot (`SITE_FW_PER_LEVEL`) as well as
   raising the model, and each site's art fills the extra ground: furrow

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -176,6 +176,18 @@ that ambient animation as its background — it now lives independently at
   (`SITE_FW_PER_LEVEL`), with the site art filling the extra ground
   (more furrows, more rubber trees, a second barn) — so a maxed farm
   reads as a big estate from across the map without opening its tooltip.
+- **Ground quality**: no two sites are worth the same. A supplier's regen
+  (not its cap) is multiplied by `SC.supplierYield` = the **biome band**
+  under it × a small per-site roll (`SITE_YIELD_VARIANCE`). The bands and
+  their per-material multipliers live in `BIOME_BANDS`/`BIOME_YIELD` —
+  crops want green ground and wilt in sand, mines run the other way, a
+  chip fab doesn't care. Both the ground tint and the multiplier read the
+  same seeded field (`SC.biomeNoise`, logic layer), so **the map is the
+  legend**: green ground really is the good farmland, and you can read a
+  site's worth before building on it. Inspect a supplier to see its band,
+  yield % and units/sec. Nothing is stored on the node — yields are
+  derived from position + seed, so they're stable across saves and travel
+  with a shared `?seed=`.
 - **Highways** (needs Asphalt Paving researched): Upgrade mode on a road
   paves it (`edge.level 1`) — trucks cross it `HIGHWAY_SPEED_MULT`×
   faster, and pathfinding weighs edges by travel time so routes prefer

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.61.1';</script>
+    <script>window.SC_VERSION = '1.61.2';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -170,6 +170,35 @@ SC.CONFIG = {
     SUPPLIER_UPGRADE_BASE: 400,
     SUPPLIER_UPGRADE_GROWTH: 1.6,
 
+    // Biome bands, read off the seeded biome noise (`SC.biomeNoise`).
+    // Ordered high→low; a point belongs to the first band whose `min` it
+    // clears, so the ranges can't drift apart or leave a gap. BOTH the
+    // ground tint (render-env) and supplier yield (below) read this one
+    // table — what the ground looks like is what it pays.
+    BIOME_BANDS: [
+        { key: 'forest', min: 1.2,  label: 'Deep forest', emoji: '🌲', tint: 'rgba(20, 110, 60, 0.45)' },
+        { key: 'green',  min: 0.4,  label: 'Greenland',   emoji: '🌳', tint: 'rgba(34, 139, 34, 0.25)' },
+        { key: 'plains', min: -0.4, label: 'Plains',      emoji: '🏞', tint: null },
+        { key: 'scrub',  min: -1.2, label: 'Arid scrub',  emoji: '🌵', tint: 'rgba(160, 130, 80, 0.22)' },
+        { key: 'desert', min: -Infinity, label: 'Deep desert', emoji: '🏜', tint: 'rgba(210, 160, 70, 0.35)' }
+    ],
+    // Ground quality per raw material: multiplies a supplier's regen (not
+    // its stock cap) by biome. Things that grow want green ground and
+    // struggle in sand; ore/coal/copper run the other way, since rock
+    // shows through where nothing grows. A material with no row here —
+    // or a biome missing from its row — is simply 1×.
+    BIOME_YIELD: {
+        wheat:  { forest: 0.9,  green: 1.25, plains: 1.1,  scrub: 0.85, desert: 0.75 },
+        wool:   { forest: 0.9,  green: 1.25, plains: 1.1,  scrub: 0.85, desert: 0.75 },
+        rubber: { forest: 1.3,  green: 1.15, plains: 0.95, scrub: 0.8,  desert: 0.75 },
+        water:  { forest: 1.15, green: 1.15, plains: 1,    scrub: 0.85, desert: 0.8 },
+        ore:    { forest: 0.85, green: 0.9,  plains: 1,    scrub: 1.2,  desert: 1.25 },
+        coal:   { forest: 0.85, green: 0.9,  plains: 1,    scrub: 1.2,  desert: 1.25 },
+        copper: { forest: 0.85, green: 0.9,  plains: 1,    scrub: 1.2,  desert: 1.25 }
+        // chips: a fab is built, not grown — ground doesn't touch it.
+    },
+    SITE_YIELD_VARIANCE: 0.1,  // ±10% per-site roll on top of the biome factor
+
     FACTORY_SITE_PRICE: 700,
 
     CRAFT_TIME: 4,             // seconds per product at level 0

--- a/supply-chain/js/input.js
+++ b/supply-chain/js/input.js
@@ -343,8 +343,10 @@ SC.input = (function() {
         getPendingDemolish: () => pendingDemolish,
         getPendingUpgrade: () => pendingUpgrade,
         _handleTap: handleTap,
-        // Headless verification hook: force a hover point without a real
-        // pointermove, so placement/road ghost previews can be screenshotted.
-        _setDebugHover: (x, y) => { hover = { x, y }; }
+        // Headless verification hooks: force a hover point / an inspected
+        // node without a real pointer event, so the ghost previews and the
+        // inspect tooltip can be screenshotted.
+        _setDebugHover: (x, y) => { hover = { x, y }; },
+        _setDebugInspect: (node) => { inspectNode = node; }
     };
 })();

--- a/supply-chain/js/main.js
+++ b/supply-chain/js/main.js
@@ -306,6 +306,17 @@ SC.runProbe = function(seconds) {
         SC.state.selectedNode = SC.state.nodes.find(n => String(n.id) === key) ||
             (key === 'factory' ? SC.factories.all()[0] : SC.state.nodes.find(n => n.isHQ));
     }
+    // Open the inspect tooltip on a node (&inspect=wheat|<mat>|hq|factory|
+    // <node id>) without a real tap, so what a site actually reports —
+    // stock, rate, the biome/yield row — can be screenshotted.
+    if (p.has('inspect') && SC.input._setDebugInspect) {
+        const key = p.get('inspect');
+        const node = SC.state.nodes.find(n => String(n.id) === key) ||
+            SC.state.nodes.find(n => n.kind === 'supplier' && n.mat === key && n.active) ||
+            (key === 'factory' ? SC.factories.all()[0] : SC.state.nodes.find(n => n.isHQ));
+        SC.state.mode = 'inspect';
+        SC.input._setDebugInspect(node);
+    }
     // Point the camera somewhere specific (&focus=x,y,zoom — zoom optional):
     // screenshots default to the HQ cluster, so this is how a far corner,
     // the whole-map view (&focus with a low zoom), or a specific site gets

--- a/supply-chain/js/render-env.js
+++ b/supply-chain/js/render-env.js
@@ -488,27 +488,12 @@
         }
     }
 
-    // The seed only changes between runs, but this is sampled once per biome
-    // cell across the whole world — re-walking the seed string every call was
-    // pure waste on the hot bake path, so the offset is memoized per seed.
-    let biomeSeedOff = 0, biomeSeedFor = null;
-    function biomeSeedOffset() {
-        const seedStr = SC.state.seed || '';
-        if (biomeSeedFor === seedStr) return biomeSeedOff;
-        let sOff = 0;
-        for (let i = 0; i < seedStr.length; i++) sOff = (sOff + seedStr.charCodeAt(i) * 0.17) % 100;
-        biomeSeedFor = seedStr;
-        biomeSeedOff = sOff;
-        return sOff;
-    }
-
-    function getBiomeNoise(x, y) {
-        const sOff = biomeSeedOffset();
-        const nx = x / 1200, ny = y / 1200;
-        const v1 = Math.sin(nx + sOff) + Math.sin(ny - sOff);
-        const v2 = Math.sin(nx * 1.5 - ny * 1.1 + sOff * 1.2) + Math.cos(nx * 1.2 + ny * 1.6 - sOff * 0.8);
-        return v1 + v2 * 0.6;
-    }
+    // The biome field itself now lives in state.js (logic layer), because
+    // supplier yield reads the same bands — the ground a site sits on is
+    // what sets its output, so the tint below and that multiplier must come
+    // from one source. Sampling is still memoized per seed there, which
+    // matters on this hot bake path (once per biome cell, whole world).
+    const getBiomeNoise = (x, y) => SC.biomeNoise(x, y);
 
     function inRiver(x, y, margin) {
         const r = SC.state.river;
@@ -688,20 +673,15 @@
     // area, which is what made pinch-zoom stutter on mobile once the map had
     // grown. Blurring one small bitmap once gets the same soft boundaries
     // for a single drawImage per frame.
-    const BIOME_BANDS = [
-        { min: 1.2,   max: Infinity, css: 'rgba(20, 110, 60, 0.45)' },  // deep forest
-        { min: 0.4,   max: 1.2,      css: 'rgba(34, 139, 34, 0.25)' },  // greenland
-        { min: -1.2,  max: -0.4,     css: 'rgba(160, 130, 80, 0.22)' }, // arid scrub
-        { min: -Infinity, max: -1.2, css: 'rgba(210, 160, 70, 0.35)' }  // deep desert
-    ];
-
-    function biomeBand(noise) {
-        for (const b of BIOME_BANDS) if (noise >= b.min && noise < b.max) return b;
-        return null; // base slate gradient shows through
+    // Bands (and their tints) come from SC.CONFIG.BIOME_BANDS, shared with
+    // supplier yield. `tint: null` (the plains band) means no wash — the
+    // base slate gradient shows through, as before.
+    function biomeTint(x, y) {
+        return SC.biomeAt(x, y).tint;
     }
 
     function ensureBiome(W, Wh, step) {
-        const key = Math.round(W) + 'x' + Math.round(Wh) + ':' + step + ':' + biomeSeedOffset();
+        const key = Math.round(W) + 'x' + Math.round(Wh) + ':' + step + ':' + (SC.state.seed || '');
         if (biome && biomeKey === key) return biome;
         const cols = Math.max(1, Math.ceil(W / step)), rows = Math.max(1, Math.ceil(Wh / step));
         // A 1px-per-cell bitmap upscaled by PAD, so one modest blur radius
@@ -713,9 +693,9 @@
         const bctx = cv.getContext('2d');
         for (let j = 0; j < rows; j++) {
             for (let i = 0; i < cols; i++) {
-                const band = biomeBand(getBiomeNoise(i * step + step / 2, j * step + step / 2));
-                if (!band) continue;
-                bctx.fillStyle = band.css;
+                const tint = biomeTint(i * step + step / 2, j * step + step / 2);
+                if (!tint) continue;
+                bctx.fillStyle = tint;
                 bctx.fillRect(i * PAD, j * PAD, PAD, PAD);
             }
         }

--- a/supply-chain/js/state.js
+++ b/supply-chain/js/state.js
@@ -198,15 +198,70 @@ SC.truckPrice = function(yard) {
         Math.pow(SC.CONFIG.TRUCK_PRICE_GROWTH, SC.trucksAtYard(yard)));
 };
 
+// ── Biome field ───────────────────────────────────────────
+// Seeded noise over world position, sampled by the ground tint in
+// render-env AND by supplier yield below. It lives here, in the logic
+// layer, precisely so the two can't disagree: the band you can see under
+// a farm is the band that sets its output. Pure function of (x, y) + the
+// run's seed — no state, so it's stable across saves and shareable via
+// `?seed=`.
+let biomeSeedOff = 0, biomeSeedFor = null;
+function biomeSeedOffset() {
+    const seedStr = SC.state.seed || '';
+    if (biomeSeedFor === seedStr) return biomeSeedOff;
+    let sOff = 0;
+    for (let i = 0; i < seedStr.length; i++) sOff = (sOff + seedStr.charCodeAt(i) * 0.17) % 100;
+    biomeSeedFor = seedStr;
+    biomeSeedOff = sOff;
+    return sOff;
+}
+
+SC.biomeNoise = function(x, y) {
+    const sOff = biomeSeedOffset();
+    const nx = x / 1200, ny = y / 1200;
+    const v1 = Math.sin(nx + sOff) + Math.sin(ny - sOff);
+    const v2 = Math.sin(nx * 1.5 - ny * 1.1 + sOff * 1.2) + Math.cos(nx * 1.2 + ny * 1.6 - sOff * 0.8);
+    return v1 + v2 * 0.6;
+};
+
+// The band covering a world point. Bands are ordered high→low, so the
+// first one the noise clears wins; the last has min -Infinity, so this
+// never returns null.
+SC.biomeAt = function(x, y) {
+    const noise = SC.biomeNoise(x, y);
+    const bands = SC.CONFIG.BIOME_BANDS;
+    for (const b of bands) if (noise >= b.min) return b;
+    return bands[bands.length - 1];
+};
+
 // ── Suppliers: finite, regenerating, upgradable stock ─────
 SC.supplierCap = function(n) {
     return SC.CONFIG.SUPPLIER_STOCK_CAP + SC.CONFIG.SUPPLIER_CAP_PER_LEVEL * (n.level || 0);
 };
 
+// How good this particular patch of ground is for what the site pulls out
+// of it: the biome factor for its material, times a small per-site roll so
+// two farms in the same greenland still aren't interchangeable. Both parts
+// are derived from position/id + seed rather than stored, so old saves get
+// their yields the moment they load and nothing can drift out of sync.
+SC.supplierYield = function(n) {
+    if (!n || n.kind !== 'supplier') return 1;
+    const row = SC.CONFIG.BIOME_YIELD[n.mat];
+    const band = SC.biomeAt(n.x, n.y);
+    const biomeF = (row && row[band.key] !== undefined) ? row[band.key] : 1;
+    const v = SC.CONFIG.SITE_YIELD_VARIANCE || 0;
+    // Deterministic ±v roll, decorrelated from the biome noise so a site
+    // isn't doubly rewarded for sitting in good ground.
+    const h = Math.sin((n.id || 0) * 127.1 + biomeSeedOffset() * 311.7) * 43758.5453;
+    const roll = 1 + ((h - Math.floor(h)) * 2 - 1) * v;
+    return biomeF * roll;
+};
+
 SC.supplierRegen = function(n) {
     return SC.CONFIG.SUPPLIER_REGEN *
         (1 + SC.CONFIG.SUPPLIER_REGEN_PER_LEVEL * (n.level || 0)) *
-        (1 + SC.research.supplierRegenBonus());
+        (1 + SC.research.supplierRegenBonus()) *
+        SC.supplierYield(n);
 };
 
 SC.supplierUpgradePrice = function(n) {

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -846,8 +846,16 @@ SC.ui = (function() {
                     <span>${c.connected ? Math.round(c.dist) + 'u' : 'no route!'}</span>
                 </div>`).join('') : '<div class="itip-row itip-bad">No factory needs this yet</div>';
             const n = info.node;
+            // Yield is what the ground under this site is worth for this
+            // material (biome band × the site's own roll). Colour-coded
+            // rather than explained: good ground is worth upgrading, poor
+            // ground is worth routing around.
+            const y = SC.supplierYield(n), band = SC.biomeAt(n.x, n.y);
+            const yCls = y >= 1.1 ? 'itip-good' : y <= 0.9 ? 'itip-bad' : '';
             return `<div class="itip-title">${SC.emojiOf(info.mat)} ${SC.nameOf(info.mat)} supplier${n.level ? ` <span class="itip-forsale">Lv${n.level + 1}</span>` : ''}</div>
                     <div class="itip-row"><span>Stock</span><span>${Math.floor(n.stock)}/${SC.supplierCap(n)}</span></div>
+                    <div class="itip-row"><span>Rate</span><span>${SC.supplierRegen(n).toFixed(2)}/s</span></div>
+                    <div class="itip-row ${yCls}"><span>${band.emoji} ${band.label}</span><span>${Math.round(y * 100)}% yield</span></div>
                     <div class="itip-sub">Used by</div>${rows}`;
         }
         if (info.kind === 'junction') {

--- a/supply-chain/style.css
+++ b/supply-chain/style.css
@@ -301,6 +301,7 @@ html, body {
     padding: 0.1rem 0;
 }
 .itip-row.itip-bad { color: var(--bad); }
+.itip-row.itip-good { color: var(--good); }
 
 /* ── Panels ──────────────────────────────────────── */
 .panel {

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.61.1';</script>
+    <script>window.SC_VERSION = '1.61.2';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'audio', 'sfx', 'rng', 'map', 'camera',
@@ -1431,7 +1431,9 @@
 
         S1.stock = 2;
         SC.economy.tickSuppliers(4);
-        assert('stock regenerates over time', approx(S1.stock, 2 + SC.CONFIG.SUPPLIER_REGEN * 4, 0.01));
+        // Rate is the config base scaled by this site's ground (SC.supplierYield),
+        // so assert against the formula, not the bare constant.
+        assert('stock regenerates over time', approx(S1.stock, 2 + SC.supplierRegen(S1) * 4, 0.01));
         SC.economy.tickSuppliers(10000);
         assert('regen stops at the cap', S1.stock === SC.supplierCap(S1));
 
@@ -1489,6 +1491,67 @@
         SC.state.research.completed.fertilizer = true;
         assert('fertilizer research boosts supplier regen',
             approx(SC.supplierRegen(S1), r0 * (1 + SC.RESEARCH.fertilizer.supplierRegenBonus), 0.001));
+    })();
+
+    // ── Biome field + per-site yield ──
+    (function() {
+        fixture();
+        SC.state.seed = 'biome-test';
+
+        // The field is a pure function of position + seed: same point, same
+        // answer; and every point lands in some band (last one is -Infinity).
+        assert('biome noise is deterministic for a point',
+            SC.biomeNoise(500, 700) === SC.biomeNoise(500, 700));
+        assert('biome noise varies across the map',
+            SC.biomeNoise(200, 200) !== SC.biomeNoise(3000, 2400));
+        assert('every point falls in a band', [[0, 0], [500, 900], [4000, 3000]]
+            .every(([x, y]) => !!SC.biomeAt(x, y).key));
+        assert('band matches its own threshold', [[0, 0], [500, 900], [1700, 2600]]
+            .every(([x, y]) => SC.biomeNoise(x, y) >= SC.biomeAt(x, y).min));
+
+        // Reseeding moves the field — otherwise every map would share one
+        // layout of good and bad ground.
+        const before = SC.biomeNoise(600, 600);
+        SC.state.seed = 'biome-test-2';
+        assert('a different seed gives a different field', SC.biomeNoise(600, 600) !== before);
+
+        // Yield: biome row × per-site roll, applied to regen only.
+        const bandOf = { forest: null, green: null, plains: null, scrub: null, desert: null };
+        for (let x = 0; x < 6000 && Object.values(bandOf).some(v => v === null); x += 40)
+            for (let y = 0; y < 6000; y += 40) {
+                const k = SC.biomeAt(x, y).key;
+                if (bandOf[k] === null) bandOf[k] = { x, y };
+            }
+        const greenSpot = bandOf.green || bandOf.forest, drySpot = bandOf.desert || bandOf.scrub;
+        const farmGreen = SC.map.makeNode('supplier', greenSpot.x, greenSpot.y, { active: true, mat: 'wheat' });
+        const farmDry   = SC.map.makeNode('supplier', drySpot.x, drySpot.y, { active: true, mat: 'wheat' });
+        const mineDry   = SC.map.makeNode('supplier', drySpot.x, drySpot.y, { active: true, mat: 'ore' });
+        assert('a farm on green ground out-yields one in the sand',
+            SC.supplierYield(farmGreen) > SC.supplierYield(farmDry));
+        assert('a mine reads the same ground the other way',
+            SC.supplierYield(mineDry) > SC.supplierYield(farmDry));
+        assert('yield feeds regen, not the stock cap',
+            approx(SC.supplierRegen(farmGreen) / SC.supplierRegen(farmDry),
+                   SC.supplierYield(farmGreen) / SC.supplierYield(farmDry), 0.001) &&
+            SC.supplierCap(farmGreen) === SC.supplierCap(farmDry));
+        assert('yield is stable for a given site', SC.supplierYield(farmGreen) === SC.supplierYield(farmGreen));
+
+        // The per-site roll stays inside SITE_YIELD_VARIANCE, so ground
+        // quality is never swamped by the tiebreaker on top of it.
+        const v = SC.CONFIG.SITE_YIELD_VARIANCE, row = SC.CONFIG.BIOME_YIELD.wheat;
+        assert('the per-site roll stays within its configured band',
+            [farmGreen, farmDry].every(n => {
+                const f = row[SC.biomeAt(n.x, n.y).key];
+                const r = SC.supplierYield(n) / f;
+                return r >= 1 - v - 1e-9 && r <= 1 + v + 1e-9;
+            }));
+        // A fab is built, not grown — no BIOME_YIELD row, so ground is 1×
+        // apart from its own roll.
+        const fab = SC.map.makeNode('supplier', drySpot.x, drySpot.y, { active: true, mat: 'chips' });
+        assert('a material with no yield row is unaffected by its biome',
+            Math.abs(SC.supplierYield(fab) - 1) <= v + 1e-9);
+        assert('non-suppliers have no yield',
+            SC.supplierYield(SC.state.nodes.find(n => n.kind === 'city')) === 1);
     })();
 
     // ── Road upgrades: research gate, cost, routing and truck speed ──


### PR DESCRIPTION
Every supplier of a material used to be interchangeable — same cap, same regen — so "which one do I upgrade?" had no answer beyond "the nearest one". A supplier's **regen** (not its cap) is now multiplied by the ground it stands on.

## How it works

`SC.supplierYield(n)` = biome band under the site, per material × a small per-site roll.

- `BIOME_BANDS`, `BIOME_YIELD` and `SITE_YIELD_VARIANCE` live in `config.js`. Crops want green ground and wilt in sand (wheat/wool 1.25× greenland → 0.75× deep desert); ore, coal and copper read the same map the other way, since rock shows through where nothing grows; rubber peaks in deep forest at 1.3×. A chip fab is built rather than grown, so it has no row and ignores the ground entirely.
- The **biome field moved out of `render-env.js` into `state.js`**. That's the point of the change rather than a side effect: the tint you see and the multiplier you get now come from one seeded source, so the map is its own legend — green ground really is the good farmland, and you can read a site's worth before you build on it. `render-env` keeps the bake/blur path and reads its tints from the same band table.
- Yield is derived from position + node id + seed and never stored, so existing saves pick theirs up on load, and a shared `?seed=` carries the same ground.
- Supplier tooltip gains **rate (units/sec), band and yield %**, tinted good/bad.
- New `&inspect=<mat>|hq|factory|<id>` probe flag (documented in DEBUG.md) opens a node's tooltip headlessly — that's what makes the new row screenshot-verifiable.

## Verification

- **1029 tests pass / 0 failed** — 12 new, covering field determinism, band coverage (every point lands in a band, and in one whose threshold it clears), reseeding moving the field, the crop/mine inversion on the same ground, yield feeding regen but not cap, the per-site roll staying inside `SITE_YIELD_VARIANCE`, and a no-row material being unaffected.
- One existing assertion changed from the bare `SUPPLIER_REGEN` constant to `SC.supplierRegen(S1)`, since rate is now scaled by the site's ground.
- Terrain screenshots before/after the `render-env` refactor are pixel-identical — the tint, decor and river are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R62W4DvX6itVFg6uHhFtWu)_