### PR TITLE
Research tree readable on mobile + six new supply chains (v1.63.0)

### DIFF
--- a/index.html
+++ b/index.html
@@ -908,7 +908,7 @@
     </header>
 
     <main class="grid">
-        <a href="supply-chain/index.html?v=1.62.1" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.63.0" class="card card-metal" id="card-supply-chain">
             <div class="card-bg-hover"></div>
             <div>
                 <div class="card-icon">

--- a/index.html
+++ b/index.html
@@ -908,7 +908,7 @@
     </header>
 
     <main class="grid">
-        <a href="supply-chain/index.html?v=1.61.0" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.62.0" class="card card-metal" id="card-supply-chain">
             <div class="card-bg-hover"></div>
             <div>
                 <div class="card-icon">

--- a/supply-chain/CLAUDE.md
+++ b/supply-chain/CLAUDE.md
@@ -139,6 +139,16 @@ Any headless Chromium works (on sandboxed Linux add `--no-sandbox`); below,
   **[DEBUG.md](DEBUG.md) lists every flag** for putting the game into a
   specific state (debt, night, a ferry, the research tree, …) — check it
   before hand-rolling a setup, and add a row when you add a flag.
+- **Research tree zoom/readability**: `<chromium> --headless=new --disable-gpu
+  --window-size=900,1100 --virtual-time-budget=15000 --dump-dom
+  http://localhost:8199/supply-chain/research-zoom-check.html`, grep for
+  `id="summary"` — "N passed / **0 failed**". It drives the real game in a
+  500px-wide iframe (which dodges the headless viewport floor below) and
+  asserts the phone-facing behaviour `tests.html` can't reach: the tree opens
+  at a legible 1:1, pinch/± zoom is anchored, drag still pans, and a tap still
+  starts a tech. Worth running after any change to `fitResearchTree` /
+  `updateResearchTree` in `ui.js` or the tree's pointer handlers in
+  `ui-bind.js`.
 - **Mobile layout**: same screenshot with `--window-size=390,844`. Caveat
   found while building the research-tree overlay: this Chromium build
   enforces a **hard ~500px minimum layout viewport** in headless mode —

--- a/supply-chain/PLAN.md
+++ b/supply-chain/PLAN.md
@@ -39,6 +39,18 @@ in Phase 4 — not in README.md, which now just points here. See
 
 ## Shipped
 
+- v1.63.0: **six new goods, no new raw materials** — 🛞tyres (rubber+coal)
+  and 🧣textiles (wool+water) as intermediates, feeding 🚲bicycles
+  (tyre+steel), 🧥jackets (cloth+rubber), 🔋batteries (copper+coal) and
+  🛵e-scooters (tyre+battery, the first recipe whose input is itself an
+  orderable product). Orderable goods go 4 → 8. Deliberately built from the
+  existing eight raws, so coal is now wanted by the smelter, the tyre plant
+  and the battery plant at once, water by the bakery and the textile mill:
+  running several chains means planting *more of the same suppliers*, and
+  the milestone pool interleaves those extra sites with the new factories.
+  The start screen's Production Recipes graph is now laid out from
+  `SC.GOODS` instead of a hand-written position table that silently dropped
+  anything missing from it.
 - v1.62.1: **research tree readable on mobile** — the overlay used to shrink
   the whole tree to fit a phone's width, bottoming out at 0.62 and putting the
   description text at ~7px, with no way to zoom in (the page is

--- a/supply-chain/PLAN.md
+++ b/supply-chain/PLAN.md
@@ -39,6 +39,17 @@ in Phase 4 — not in README.md, which now just points here. See
 
 ## Shipped
 
+- v1.62.0: **research tree readable on mobile** — the overlay used to shrink
+  the whole tree to fit a phone's width, bottoming out at 0.62 and putting the
+  description text at ~7px, with no way to zoom in (the page is
+  `user-scalable=no`, since the map canvas owns pinch). It now opens at 1:1
+  with phone-sized cards and larger type, and carries its own zoom: pinch
+  inside the tree, ± / ⤢ buttons in the header, ctrl-wheel on desktop, all
+  anchored so the point under the gesture stays put. Zooming out reaches a
+  whole-tree overview however wide the tree grows. Rows are also pitched off
+  the measured card heights per row instead of one worst-case constant, so the
+  tree is considerably shorter and the edges leave from real card bottoms.
+  Covered by `research-zoom-check.html` (see CLAUDE.md → Verification).
 - v1.61.0: **Traffic & Bottleneck Heatmap + Dijkstra Pathfinding Caching** —
   added a dedicated Heatmap mode button (`🔥`) that visualizes road usage and
   truck throughput with dynamic color gradients (Green → Yellow → Red glow),

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -14,19 +14,22 @@ that ambient animation as its background — it now lives independently at
 
 - **Goods & recipes** (emoji-first, colors are accents): suppliers
   (hexagons) provide raw goods; each factory (square) is dedicated to one
-  recipe. 🌾wheat+💧water→🍞bread (bakery), 🧶wool+🛞rubber→👟sneakers
-  (sneaker factory), the two-tier chain 🪨ore+⚫coal→🔩steel (smelter),
-  🔩steel+💾chips→🚗cars (car factory), and the three-tier chain
-  🟠copper+🛞rubber→🧵wire (wire mill), 🧵wire+💾chips→🔌circuit board
-  (circuit factory), 🔌circuit+🔩steel→🤖robots (robot factory). Steel,
-  chips and rubber are each shared by two recipes, so one supplier's
-  placement (and the roads to it) can matter for more than one product.
-  Steel/wire/circuit are intermediates — cities only order `orderable`
-  goods; the planner recursively schedules factory-to-factory runs for
-  chains of any depth (nothing in `economy.js`/`factories.js` is
-  hardcoded to 2 tiers). The goods tree lives in `js/config.js`
-  (`SC.GOODS`) — adding a good/recipe is one entry there, plus a pool
-  entry in `js/map.js` if it should be unlockable.
+  recipe, which always takes exactly two inputs. Chains run one to three
+  tiers deep — 🌾wheat+💧water→🍞bread is the shallow end,
+  🟠copper+🧪rubber→🧵wire→(+💾chips)→🔌circuit→(+🔩steel)→🤖robots the
+  deep one. **Every raw material feeds more than one recipe** (rubber and
+  coal feed three or more), so a supplier's placement and the roads to it
+  matter for several products at once, and running two chains side by side
+  means owning two coal pits rather than discovering a new kind of site.
+  Intermediates like steel/wire/circuit/tyres aren't ordered by cities —
+  only `orderable` goods are — and a good can be both, as batteries are
+  (a product in their own right and the e-scooter's input). The planner
+  recursively schedules factory-to-factory runs for chains of any depth
+  (nothing in `economy.js`/`factories.js` is hardcoded to 2 tiers). The
+  authoritative tree is `SC.GOODS` in `js/config.js` — the start screen's
+  Production Recipes graph is laid out from it, so it never drifts —
+  and adding a good/recipe is one entry there, plus a pool entry in
+  `js/map.js` if it should be unlockable.
 - **Orders**: HQ (⭐) is the only order-placing location at the start.
   New customer DCs (🏢) unlock on their own independent timer (~50-70s for
   the first, ~90-140s between further ones — `CUSTOMER_SPAWN_FIRST` /

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.62.1';</script>
+    <script>window.SC_VERSION = '1.63.0';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>
@@ -387,8 +387,12 @@
                water, the smelter 🔩 turns ore and coal into steel for the car
                factory 🚗. Some chains run deeper and share ingredients: the
                robot factory 🤖 needs a circuit board 🔌 (itself made from wire
-               🧵 and electronics 💾) plus the same steel your cars use. Your
-               trucks do the hauling — but only where roads exist.</p>
+               🧵 and electronics 💾) plus the same steel your cars use. Every
+               raw material feeds more than one recipe — that coal pit is
+               wanted by the smelter, the tyre plant 🛞 and the battery plant
+               🔋 at once — so running several chains means planting more of
+               the suppliers you already have, not just new ones. Your trucks
+               do the hauling — but only where roads exist.</p>
             <ul>
                 <li><b>Guided walkthrough:</b> new runs start with a 4-step guided walkthrough to help link your first bakery, suppliers, and HQ.</li>
                 <li><b>Build roads:</b> tap a node, then tap another. Crossing the river pops up a choice: a pricier bridge (fast) or a cheaper ferry (slower boat crossing).</li>

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.61.0';</script>
+    <script>window.SC_VERSION = '1.62.0';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>
@@ -244,7 +244,15 @@
         <div class="research-tree-card">
             <div class="research-tree-header">
                 <h1>🔬 Research Tree</h1>
-                <button class="icon-btn" id="research-tree-close" title="Close">✕</button>
+                <!-- Zoom controls: the page itself is user-scalable=no (the map
+                     canvas owns pinch), so the tree carries its own zoom —
+                     pinch inside it, or these buttons. -->
+                <div class="research-tree-tools">
+                    <button class="icon-btn rt-zoom-btn" id="research-zoom-out" title="Zoom out" aria-label="Zoom out">−</button>
+                    <button class="icon-btn rt-zoom-btn" id="research-zoom-in" title="Zoom in" aria-label="Zoom in">+</button>
+                    <button class="icon-btn rt-zoom-btn" id="research-zoom-fit" title="Fit whole tree" aria-label="Fit whole tree">⤢</button>
+                    <button class="icon-btn" id="research-tree-close" title="Close">✕</button>
+                </div>
             </div>
             <div id="research-tree-wrap" class="research-tree-wrap">
                 <svg id="research-tree-edges"></svg>

--- a/supply-chain/js/config.js
+++ b/supply-chain/js/config.js
@@ -439,7 +439,19 @@ SC.GOODS = {
     bread:   { emoji: '🍞', name: 'Bread',    color: '#f59e0b', inputs: ['wheat', 'water'], orderable: true, value: 150, building: 'Bakery' },
     shoes:   { emoji: '👟', name: 'Sneakers', color: '#34d399', inputs: ['wool', 'rubber'], orderable: true, value: 230, building: 'Sneaker factory' },
     car:     { emoji: '🚗', name: 'Cars',     color: '#b07cd8', inputs: ['steel', 'chips'], orderable: true, value: 480, building: 'Car factory' },
-    robot:   { emoji: '🤖', name: 'Robots',   color: '#94a3b8', inputs: ['circuit', 'steel'], orderable: true, value: 900, building: 'Robot factory' }
+    robot:   { emoji: '🤖', name: 'Robots',   color: '#94a3b8', inputs: ['circuit', 'steel'], orderable: true, value: 900, building: 'Robot factory' },
+    // Second-wave chains. Deliberately no new raw material: every one of
+    // these draws on a supplier an earlier chain already wanted (coal was
+    // the smelter's alone, water the bakery's, wool the sneakers'), so the
+    // way to run two of them at once is a second coal pit and a second
+    // water well — more of the sites you already know, competing for the
+    // same roads. Batteries are both a product and the scooter's input.
+    tyre:    { emoji: '🛞', name: 'Tyres',      color: '#475569', inputs: ['rubber', 'coal'], building: 'Tyre plant' },
+    cloth:   { emoji: '🧣', name: 'Textiles',   color: '#f472b6', inputs: ['wool', 'water'], building: 'Textile mill' },
+    battery: { emoji: '🔋', name: 'Batteries',  color: '#4ade80', inputs: ['copper', 'coal'], orderable: true, value: 260, building: 'Battery plant' },
+    jacket:  { emoji: '🧥', name: 'Jackets',    color: '#fb923c', inputs: ['cloth', 'rubber'], orderable: true, value: 400, building: 'Outerwear factory' },
+    bicycle: { emoji: '🚲', name: 'Bicycles',   color: '#22d3ee', inputs: ['tyre', 'steel'], orderable: true, value: 450, building: 'Bicycle works' },
+    scooter: { emoji: '🛵', name: 'E-scooters', color: '#a3e635', inputs: ['tyre', 'battery'], orderable: true, value: 620, building: 'Scooter plant' }
 };
 
 SC.colorOf = function(item) { return SC.GOODS[item].color; };

--- a/supply-chain/js/map.js
+++ b/supply-chain/js/map.js
@@ -345,7 +345,29 @@ SC.map = (function() {
             ['supplier', { mat: 'copper' }],
             ['factory', { forSale: true, recipe: 'wire' }],
             ['factory', { forSale: true, recipe: 'circuit' }],
-            ['factory', { forSale: true, recipe: 'robot' }]
+            ['factory', { forSale: true, recipe: 'robot' }],
+            // Second wave (SC.GOODS): tyres, textiles, batteries and what
+            // they feed. No new raw material — each of these factories bids
+            // for coal/water/wool/rubber/copper against a chain already
+            // running, which is what the extra suppliers interleaved here
+            // are for. Late in the pool on purpose: by the time they unlock
+            // the early chains are established enough for the competition
+            // to be a decision rather than a stall.
+            ['supplier', { mat: 'coal' }],
+            ['factory', { forSale: true, recipe: 'tyre' }],
+            ['supplier', { mat: 'rubber' }],
+            ['factory', { forSale: true, recipe: 'bicycle' }],
+            ['city', {}],
+            ['supplier', { mat: 'copper' }],
+            ['factory', { forSale: true, recipe: 'battery' }],
+            ['supplier', { mat: 'wool' }],
+            ['supplier', { mat: 'water' }],
+            ['factory', { forSale: true, recipe: 'cloth' }],
+            ['factory', { forSale: true, recipe: 'jacket' }],
+            ['city', {}],
+            ['supplier', { mat: 'coal' }],
+            ['supplier', { mat: 'ore' }],
+            ['factory', { forSale: true, recipe: 'scooter' }]
         ];
         for (const [kind, opts] of pool) {
             const spot = randomLandSpotNear(md, SC.nodeMaxSpread());

--- a/supply-chain/js/render-network.js
+++ b/supply-chain/js/render-network.js
@@ -249,8 +249,8 @@
 
     // Hoisted out of nodeSpec (called ~2×/node/frame) so these lookup sets
     // aren't reallocated on every call.
-    const FACTORY_LOW = new Set(['bread', 'shoes', 'steel', 'wire']);
-    const FACTORY_TALL = new Set(['circuit', 'car']);
+    const FACTORY_LOW = new Set(['bread', 'shoes', 'steel', 'wire', 'tyre', 'cloth']);
+    const FACTORY_TALL = new Set(['circuit', 'car', 'battery', 'scooter']);
     function nodeSpec(n) {
         if (n.kind === 'supplier') {
             const base = SC.colorOf(n.mat);

--- a/supply-chain/js/ui-bind.js
+++ b/supply-chain/js/ui-bind.js
@@ -5,7 +5,7 @@
 // lived inside the ui.js closure.
 (function () {
     const U = SC._ui;
-    const { $, fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, setHidePills, getUiScale, setUiScale, openOptionsModal, closeOptionsModal, updateOptionsModal, openToastHistoryModal, closeToastHistoryModal, clearToastHistory, renderToastHistory, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, setResearchTreeHold, openStatsOverlay, closeStatsOverlay, openAchievementDetail, closeAchievementDetail, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, armNewGame, isNewGameArmed, focusOrder, yardLabel, openYardOverlay, closeYardOverlay, updateTutorial } = U;
+    const { $, fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, setHidePills, getUiScale, setUiScale, openOptionsModal, closeOptionsModal, updateOptionsModal, openToastHistoryModal, closeToastHistoryModal, clearToastHistory, renderToastHistory, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, setResearchTreeHold, zoomResearchTreeBy, setResearchTreeZoom, fitResearchTreeToScreen, researchTreeScale, openStatsOverlay, closeStatsOverlay, openAchievementDetail, closeAchievementDetail, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, armNewGame, isNewGameArmed, focusOrder, yardLabel, openYardOverlay, closeYardOverlay, updateTutorial } = U;
     const getDevMode = U.getDevMode;
     const getHidePills = U.getHidePills;
 
@@ -381,16 +381,56 @@
             if (e.target === $('research-overlay')) closeResearchTree(); // tap outside the card
         });
 
-        // Drag to pan for Research Tree view
+        on('research-zoom-in', 'click', () => { SC.sfx.play('click'); zoomResearchTreeBy(1.25); });
+        on('research-zoom-out', 'click', () => { SC.sfx.play('click'); zoomResearchTreeBy(1 / 1.25); });
+        on('research-zoom-fit', 'click', () => { SC.sfx.play('click'); fitResearchTreeToScreen(); });
+
+        // Drag to pan (one pointer) / pinch to zoom (two) for Research Tree view.
+        // The page is `user-scalable=no` — the map canvas runs its own pinch —
+        // so the tree has to provide the gesture itself, and `touch-action:none`
+        // on the wrap means the browser hands us both pointers untouched.
         const wrap = $('research-tree-wrap');
+        const rtPointers = new Map();   // pointerId -> {x, y}
         let isPointerDown = false;
         let isDragging = false;
         let startX = 0, startY = 0;
         let startScrollLeft = 0, startScrollTop = 0;
         let activePointerId = null;
+        let pinch = null;               // {dist, scale, ax, ay} at the last move
+
+        function rtPinchState() {
+            const [a, b] = [...rtPointers.values()];
+            const r = wrap.getBoundingClientRect();
+            return {
+                dist: Math.max(1, Math.hypot(a.x - b.x, a.y - b.y)),
+                ax: (a.x + b.x) / 2 - r.left,
+                ay: (a.y + b.y) / 2 - r.top
+            };
+        }
+
+        function beginPinch() {
+            // A pinch is never a tap: drop the single-pointer drag, and leave
+            // isDragging set so the click that follows is ignored (the node
+            // click handler below bails on it).
+            if (activePointerId !== null) {
+                try { wrap.releasePointerCapture(activePointerId); } catch (_) {}
+                activePointerId = null;
+            }
+            isPointerDown = false;
+            isDragging = true;
+            wrap.classList.add('is-dragging');
+            const s = rtPinchState();
+            pinch = { dist: s.dist, scale: researchTreeScale(), ax: s.ax, ay: s.ay };
+        }
 
         wrap.addEventListener('pointerdown', e => {
             if (e.button !== 0 && e.pointerType === 'mouse') return;
+            rtPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+            if (rtPointers.size >= 2) {
+                setResearchTreeHold(true);
+                beginPinch();
+                return;
+            }
             isPointerDown = true;
             isDragging = false;
             startX = e.clientX;
@@ -409,6 +449,18 @@
         });
 
         wrap.addEventListener('pointermove', e => {
+            if (rtPointers.has(e.pointerId)) rtPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+            if (pinch && rtPointers.size >= 2) {
+                const now = rtPinchState();
+                // Zoom about the midpoint, then let the midpoint's own travel
+                // pan the tree — the same feel as the map's two-finger gesture.
+                setResearchTreeZoom(pinch.scale * (now.dist / pinch.dist), now.ax, now.ay);
+                wrap.scrollLeft -= now.ax - pinch.ax;
+                wrap.scrollTop -= now.ay - pinch.ay;
+                pinch.ax = now.ax;
+                pinch.ay = now.ay;
+                return;
+            }
             if (!isPointerDown || e.pointerId !== activePointerId) return;
             const dx = e.clientX - startX;
             const dy = e.clientY - startY;
@@ -424,7 +476,20 @@
         });
 
         function endDrag(e) {
-            if (!isPointerDown || (e && e.pointerId !== activePointerId)) return;
+            if (e) rtPointers.delete(e.pointerId);
+            // Lifting one finger of a pinch: stop zooming, but don't re-arm the
+            // drag from the finger still down — that would jump the tree.
+            if (pinch && rtPointers.size < 2) pinch = null;
+            if (!isPointerDown || (e && e.pointerId !== activePointerId)) {
+                // The pinch path leaves isPointerDown false, so release its
+                // drag flag / hold once the last finger is up.
+                if (!isPointerDown && !rtPointers.size && isDragging) {
+                    wrap.classList.remove('is-dragging');
+                    setTimeout(() => { isDragging = false; }, 50);
+                    setTimeout(() => setResearchTreeHold(false), 60);
+                }
+                return;
+            }
             isPointerDown = false;
             if (activePointerId !== null) {
                 try { wrap.releasePointerCapture(activePointerId); } catch (_) {}
@@ -449,6 +514,15 @@
         // Mouse only: with no capture until the threshold, a press that leaves
         // the panel before moving would otherwise stay "armed".
         wrap.addEventListener('pointerleave', e => { if (!isDragging) endDrag(e); });
+
+        // Trackpad pinch and ctrl/⌘+wheel zoom; a plain wheel keeps scrolling
+        // the wrap natively.
+        wrap.addEventListener('wheel', e => {
+            if (!e.ctrlKey && !e.metaKey) return;
+            e.preventDefault();
+            const r = wrap.getBoundingClientRect();
+            zoomResearchTreeBy(Math.exp(-e.deltaY * 0.01), e.clientX - r.left, e.clientY - r.top);
+        }, { passive: false });
 
         $('research-tree-nodes').addEventListener('click', e => {
             if (isDragging) return;

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -315,7 +315,7 @@ SC.ui = (function() {
             }
         }
         return `<div class="rt-node research-row ${done ? 'done' : ''} ${queued ? 'queued' : ''} ${locked || labMissing ? 'locked' : ''}"
-                     style="left:${pos.x}px;top:${pos.y}px;width:${pos.w}px">
+                     data-rt-id="${id}" style="left:${pos.x}px;top:${pos.y}px;width:${pos.w}px">
             <div class="research-top"><span class="research-name">${t.emoji} ${t.name}</span></div>
             <div class="research-desc">${t.desc}</div>
             ${btn}
@@ -390,65 +390,120 @@ SC.ui = (function() {
         return out;
     }
 
-    // Row pitch has to clear the tallest card, and card height is driven by
-    // the description text — 205 keeps the wordiest techs from overlapping
-    // the row below at the default font size.
-    const RT_COL_W = 178, RT_ROW_H = 205, RT_NODE_W = 164, RT_NODE_H = 150, RT_PAD = 20;
+    // Card geometry. Row pitch has to clear the tallest card, and card height
+    // is driven by the description text. Phones get their own, roomier set:
+    // the tree is never auto-shrunk below 100% there (see autoScale below),
+    // so the cards carry the bigger touch-legible type the `max-width: 768px`
+    // block in style.css puts on `.rt-node`, and the pitch has to match.
+    // rowH/nodeH here are only the opening estimate: updateResearchTree
+    // measures the rendered cards and re-pitches the rows off the tallest one.
+    const RT_PAD = 20;
+    const RT_ROW_GAP = 34;   // air between a row's tallest card and the next row
+    const RT_METRICS_DESKTOP = { colW: 178, rowH: 205, nodeW: 164, nodeH: 150 };
+    const RT_METRICS_PHONE = { colW: 260, rowH: 220, nodeW: 236, nodeH: 165 };
+    const RT_PHONE_MAX_W = 768;  // keep in sync with the mobile block in style.css
     const RT_ROOT_GAP = 0.35;   // extra columns between adjacent root subtrees
-    const RT_MIN_SCALE = 0.62;  // below this the tree scrolls instead of shrinking further
     // The tree is laid out at a fixed px size tuned for a phone-ish width, so on
     // a desktop card (up to 1380px) it used to sit small in a sea of empty card.
     // Above RT_GROW_MIN_W it now also scales *up* to fill the space — capped so
     // the nodes stay a sane reading size, and never past the visible height.
     const RT_MAX_SCALE = 1.45;
     const RT_GROW_MIN_W = 900;  // viewport width where growing kicks in (desktop)
+    // How far the player may zoom either side of that with pinch / the ± buttons.
+    const RT_ZOOM_MIN = 0.4, RT_ZOOM_MAX = 2.5;
+
+    function rtMetrics() {
+        return window.innerWidth <= RT_PHONE_MAX_W ? RT_METRICS_PHONE : RT_METRICS_DESKTOP;
+    }
+
+    // Unscaled size of the laid-out tree, the scale on screen, and the
+    // player's own zoom (0 = "no opinion", follow the auto fit).
+    let rtTreeW = 0, rtTreeH = 0, rtScale = 1, rtUserScale = 0;
 
     function researchTreeOpen() { return !$('research-overlay').classList.contains('hidden'); }
 
-    function fitResearchTree() {
+    // What the tree picks for itself when the player hasn't zoomed.
+    function autoResearchTreeScale(containerWidth) {
+        // Never auto-shrink below 100%. Fitting the whole tree into a phone
+        // width used to land at 0.62, putting the description text at ~7px —
+        // that is what made the overlay unreadable on mobile. Narrower than
+        // the tree, the wrap scrolls and drag/pinch takes over instead.
+        if (containerWidth < rtTreeW || window.innerWidth < RT_GROW_MIN_W) return 1;
+        // Room to spare on desktop: grow into it, bounded by the width, by
+        // what's still visible below the card header, and by RT_MAX_SCALE.
         const wrap = $('research-tree-wrap');
-        if (!wrap) return;
+        const availH = Math.max(240, window.innerHeight * 0.9 - wrap.getBoundingClientRect().top);
+        return Math.max(1, Math.min(containerWidth / rtTreeW, availH / rtTreeH, RT_MAX_SCALE));
+    }
+
+    function applyResearchTreeScale(scale) {
+        const wrap = $('research-tree-wrap');
         const nodesEl = $('research-tree-nodes');
         const svg = $('research-tree-edges');
-
-        // Reset scaling first to read unscaled sizes
-        nodesEl.style.transform = '';
-        nodesEl.style.transformOrigin = '';
-        svg.style.transform = '';
-        svg.style.transformOrigin = '';
-        wrap.style.height = '';
-
-        const containerWidth = wrap.clientWidth;
-        const treeWidth = parseFloat(nodesEl.style.width) || 0;
-        const treeHeight = parseFloat(nodesEl.style.height) || 0;
-
-        if (!treeWidth || !treeHeight || containerWidth <= 0) return;
-
-        let scale = 1;
-        // On desktop the tree is never shrunk: at 1280px wide it used to hit the
-        // 0.62 floor and render tiny even though the card had to scroll anyway.
-        // Full size + drag-to-pan reads far better there. Phones keep the floor.
-        const minScale = window.innerWidth >= RT_GROW_MIN_W ? 1 : RT_MIN_SCALE;
-
-        if (containerWidth < treeWidth) {
-            // Shrink to fit, but not past the point where the node text is
-            // unreadable — the wrap scrolls (overflow:auto) from there on.
-            scale = Math.max(minScale, containerWidth / treeWidth);
-        } else if (window.innerWidth >= RT_GROW_MIN_W) {
-            // Room to spare on desktop: grow into it, bounded by the width, by
-            // what's still visible below the card header, and by RT_MAX_SCALE.
-            const availH = Math.max(240, window.innerHeight * 0.9 - wrap.getBoundingClientRect().top);
-            scale = Math.min(containerWidth / treeWidth, availH / treeHeight, RT_MAX_SCALE);
-            scale = Math.max(1, scale);
-        }
-
-        if (scale === 1) return;
-        nodesEl.style.transform = `scale(${scale})`;
+        rtScale = scale;
+        nodesEl.style.transform = scale === 1 ? '' : `scale(${scale})`;
         nodesEl.style.transformOrigin = 'top left';
-        svg.style.transform = `scale(${scale})`;
+        svg.style.transform = scale === 1 ? '' : `scale(${scale})`;
         svg.style.transformOrigin = 'top left';
-        wrap.style.height = (treeHeight * scale) + 'px';
+        // Every node is absolutely positioned, so this box only ever drives the
+        // wrap's scroll extent — sizing it to the *scaled* tree is what lets a
+        // zoomed-in tree pan all the way out to its right/bottom edge.
+        nodesEl.style.width = (rtTreeW * scale) + 'px';
+        nodesEl.style.height = (rtTreeH * scale) + 'px';
+        wrap.style.height = (rtTreeH * scale) + 'px';
     }
+
+    function fitResearchTree() {
+        const wrap = $('research-tree-wrap');
+        if (!wrap || !rtTreeW || !rtTreeH) return;
+        const containerWidth = wrap.clientWidth;
+        if (containerWidth <= 0) return;
+        applyResearchTreeScale(rtUserScale || autoResearchTreeScale(containerWidth));
+    }
+
+    // Zooming out has to reach the whole-tree overview however wide the tree
+    // grows — on a phone that is well under RT_ZOOM_MIN — but a tree that
+    // already fits shouldn't be shrinkable into nothing.
+    function rtMinZoom() {
+        const wrap = $('research-tree-wrap');
+        if (!wrap || !rtTreeW || !wrap.clientWidth) return RT_ZOOM_MIN;
+        return Math.min(RT_ZOOM_MIN, wrap.clientWidth / rtTreeW);
+    }
+
+    // Zoom about a point given in wrap-viewport coordinates (defaults to the
+    // middle of what's on screen), keeping whatever sits under it put.
+    function setResearchTreeZoom(scale, ax, ay) {
+        const wrap = $('research-tree-wrap');
+        if (!wrap || !rtTreeW) return;
+        const next = Math.max(rtMinZoom(), Math.min(RT_ZOOM_MAX, scale));
+        const prev = rtScale || 1;
+        if (Math.abs(next - prev) < 0.001) return;
+        if (ax === undefined) ax = wrap.clientWidth / 2;
+        if (ay === undefined) ay = wrap.clientHeight / 2;
+        const tx = (wrap.scrollLeft + ax) / prev;   // tree coords under the anchor
+        const ty = (wrap.scrollTop + ay) / prev;
+        rtUserScale = next;
+        applyResearchTreeScale(next);
+        wrap.scrollLeft = tx * next - ax;
+        wrap.scrollTop = ty * next - ay;
+    }
+
+    function zoomResearchTreeBy(factor, ax, ay) {
+        setResearchTreeZoom((rtScale || 1) * factor, ax, ay);
+    }
+
+    // The one place the tree is allowed under 100%: an overview the player
+    // asked for explicitly and can pinch straight back out of.
+    function fitResearchTreeToScreen() {
+        const wrap = $('research-tree-wrap');
+        if (!wrap || !rtTreeW || !rtTreeH) return;
+        const avail = Math.max(240, window.innerHeight * 0.9 - wrap.getBoundingClientRect().top);
+        setResearchTreeZoom(Math.min(wrap.clientWidth / rtTreeW, avail / rtTreeH), 0, 0);
+        wrap.scrollLeft = 0;
+        wrap.scrollTop = 0;
+    }
+
+    function researchTreeScale() { return rtScale; }
 
     // The tree is rebuilt from updateShop(), which the game loop calls every
     // 0.4s — and rebuilding means replacing #research-tree-nodes' innerHTML.
@@ -458,7 +513,7 @@ SC.ui = (function() {
     // guards: never rebuild while a pointer is held down inside the tree
     // (flush on release instead), and skip the write entirely when the markup
     // is byte-identical to what is already on screen.
-    let rtHold = false, rtDirty = false, rtLastNodes = '', rtLastEdges = '';
+    let rtHold = false, rtDirty = false, rtLastNodes = '', rtLastEdges = '', rtNodeH = {}, rtLastTops = '';
     function setResearchTreeHold(v) {
         rtHold = !!v;
         if (!rtHold && rtDirty) { rtDirty = false; updateResearchTree(); }
@@ -476,27 +531,60 @@ SC.ui = (function() {
             maxRow = Math.max(maxRow, layout[id].row);
         }
 
-        const width = RT_PAD * 2 + (maxCol + 1) * RT_COL_W;
-        const height = RT_PAD * 2 + (maxRow + 1) * RT_ROW_H;
+        const m = rtMetrics();
+        const width = RT_PAD * 2 + (maxCol + 1) * m.colW;
+        let height = RT_PAD * 2 + (maxRow + 1) * m.rowH;
 
         for (const id in layout) {
             positions[id] = {
-                x: RT_PAD + layout[id].col * RT_COL_W + (RT_COL_W - RT_NODE_W) / 2,
-                y: RT_PAD + layout[id].row * RT_ROW_H,
-                w: RT_NODE_W
+                x: RT_PAD + layout[id].col * m.colW + (m.colW - m.nodeW) / 2,
+                y: RT_PAD + layout[id].row * m.rowH,
+                w: m.nodeW
             };
         }
 
         const ids = SC.RESEARCH_ORDER.filter(id => positions[id]);
         const nodesEl = $('research-tree-nodes');
-        nodesEl.style.width = width + 'px';
-        nodesEl.style.height = height + 'px';
         const nodesHTML = ids.map(id => researchNodeHTML(id, positions[id])).join('');
         const changed = nodesHTML !== rtLastNodes;
         if (changed) {
             rtLastNodes = nodesHTML;
             nodesEl.innerHTML = nodesHTML;
+            // Cards grow with their description text, so m.nodeH is only an
+            // opening estimate — measure the real ones (one reflow, and only
+            // when the markup actually changed).
+            rtNodeH = {};
+            for (const el of nodesEl.children) {
+                if (el.dataset.rtId) rtNodeH[el.dataset.rtId] = el.offsetHeight;
+            }
         }
+
+        // Second pass: with real card heights in hand, stack each row directly
+        // under the tallest card of the row above it — a fixed pitch has to
+        // clear the wordiest tech in the whole tree, which left every other row
+        // swimming in dead space. Positions are pure JS; only `top` hits the DOM.
+        const rowH = [];
+        for (const id in positions) {
+            const r = layout[id].row;
+            rowH[r] = Math.max(rowH[r] || 0, rtNodeH[id] || m.nodeH);
+        }
+        const rowTop = [];
+        let y = RT_PAD;
+        for (let r = 0; r <= maxRow; r++) {
+            rowTop[r] = y;
+            y += (rowH[r] || m.nodeH) + RT_ROW_GAP;
+        }
+        height = y - RT_ROW_GAP + RT_PAD;
+        for (const id in positions) positions[id].y = rowTop[layout[id].row];
+        const tops = rowTop.join();
+        if (changed || tops !== rtLastTops) {
+            rtLastTops = tops;
+            for (const el of nodesEl.children) {
+                if (el.dataset.rtId) el.style.top = positions[el.dataset.rtId].y + 'px';
+            }
+        }
+        rtTreeW = width;
+        rtTreeH = height;
 
         const svg = $('research-tree-edges');
         svg.setAttribute('width', width);
@@ -507,7 +595,7 @@ SC.ui = (function() {
             for (const req of SC.RESEARCH[id].requires) {
                 const from = positions[req];
                 if (!from) continue;
-                const x1 = from.x + from.w / 2, y1 = from.y + RT_NODE_H;
+                const x1 = from.x + from.w / 2, y1 = from.y + (rtNodeH[req] || m.nodeH);
                 const x2 = to.x + to.w / 2, y2 = to.y;
                 const midY = (y1 + y2) / 2;
                 edges += `<path d="M${x1},${y1} C${x1},${midY} ${x2},${midY} ${x2},${y2}"
@@ -527,6 +615,9 @@ SC.ui = (function() {
     function openResearchTree() {
         $('research-overlay').classList.remove('hidden');
         setResearchTreeHold(false);
+        rtUserScale = 0;   // each opening starts from the auto fit again
+        const wrap = $('research-tree-wrap');
+        if (wrap) { wrap.scrollLeft = 0; wrap.scrollTop = 0; }
         updateResearchTree();
         fitResearchTree(); // the wrap only has real dimensions once shown
     }
@@ -1256,7 +1347,7 @@ SC.ui = (function() {
     SC._ui = {
         $, getDevMode: () => devMode, getHidePills: () => hidePills, getUiScale, setUiScale,
         openOptionsModal, closeOptionsModal, updateOptionsModal, openToastHistoryModal, closeToastHistoryModal, clearToastHistory, renderToastHistory, getToastHistory: () => toastHistory,
-        fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, setHidePills, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, setResearchTreeHold, openStatsOverlay, closeStatsOverlay, openAchievementDetail, closeAchievementDetail, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, armNewGame, isNewGameArmed, focusOrder, yardLabel, openYardOverlay, closeYardOverlay, updateTutorial, inspectTooltipHTML
+        fmt, fmtDuration, toast, setMode, setSpeed, setDevMode, setHidePills, openMenu, closeMenu, menuOpen, openResearchTree, closeResearchTree, setResearchTreeHold, zoomResearchTreeBy, setResearchTreeZoom, fitResearchTreeToScreen, researchTreeScale, openStatsOverlay, closeStatsOverlay, openAchievementDetail, closeAchievementDetail, chooseCrossing, closeCrossingChoice, openCrossingChoice, updateContractOffer, updateDevPanel, updateMenuInfo, updateOrders, updateShop, updateStatsOverlay, toggleFullscreen, resetNewGameArm, armNewGame, isNewGameArmed, focusOrder, yardLabel, openYardOverlay, closeYardOverlay, updateTutorial, inspectTooltipHTML
     };
 
     return { init, update, toast, openStatsOverlay, openOptionsModal, openToastHistoryModal };

--- a/supply-chain/js/ui.js
+++ b/supply-chain/js/ui.js
@@ -630,32 +630,29 @@ SC.ui = (function() {
         const container = $('recipe-graph');
         if (!container) return;
 
-        const nodePositions = {
-            // Column 0: Raw Materials
-            wheat:   { x: 15,  y: 15,  w: 130 },
-            water:   { x: 15,  y: 65,  w: 130 },
-            wool:    { x: 15,  y: 115, w: 130 },
-            rubber:  { x: 15,  y: 165, w: 130 },
-            copper:  { x: 15,  y: 215, w: 130 },
-            ore:     { x: 15,  y: 265, w: 130 },
-            coal:    { x: 15,  y: 315, w: 130 },
-            chips:   { x: 15,  y: 365, w: 130 },
-
-            // Column 1: Tier 1 Crafting
-            bread:   { x: 200, y: 40,  w: 130 },
-            shoes:   { x: 200, y: 140, w: 130 },
-            wire:    { x: 200, y: 190, w: 130 },
-            steel:   { x: 200, y: 290, w: 130 },
-
-            // Column 2: Tier 2 Crafting
-            circuit: { x: 385, y: 215, w: 130 },
-            car:     { x: 385, y: 340, w: 130 },
-
-            // Column 3: Tier 3 Crafting
-            robot:   { x: 570, y: 275, w: 130 }
-        };
-
-        const NODE_H = 32;
+        // Laid out from SC.GOODS rather than a hand-written table: column is
+        // the good's chain depth, row is its order within that column. The
+        // old fixed table silently dropped any good missing from it, so every
+        // recipe added to config.js had to be mirrored here or vanish from
+        // this graph. Rows are centred per column so the tree reads top-down.
+        const NODE_W = 130, NODE_H = 32, COL_W = 185, ROW_H = 42, PAD = 15;
+        const cols = [];
+        for (const id of Object.keys(SC.GOODS)) {
+            const d = SC.depthOf(id);
+            (cols[d] = cols[d] || []).push(id);
+        }
+        const tallest = Math.max(...cols.map(c => c.length));
+        const nodePositions = {};
+        cols.forEach((ids, d) => {
+            const top = PAD + (tallest - ids.length) * ROW_H / 2;
+            ids.forEach((id, i) => {
+                nodePositions[id] = { x: PAD + d * COL_W, y: top + i * ROW_H, w: NODE_W };
+            });
+        });
+        const graphW = PAD * 2 + (cols.length - 1) * COL_W + NODE_W;
+        const graphH = PAD * 2 + (tallest - 1) * ROW_H + NODE_H;
+        container.style.width = graphW + 'px';
+        container.style.height = graphH + 'px';
         const nodesEl = $('recipe-graph-nodes');
         const svg = $('recipe-graph-edges');
         if (!nodesEl || !svg) return;
@@ -671,8 +668,8 @@ SC.ui = (function() {
         }
         nodesEl.innerHTML = nodesHTML;
 
-        svg.setAttribute('width', 715);
-        svg.setAttribute('height', 415);
+        svg.setAttribute('width', graphW);
+        svg.setAttribute('height', graphH);
         let edges = '';
         for (const [id, pos] of Object.entries(nodePositions)) {
             const g = SC.GOODS[id];

--- a/supply-chain/research-zoom-check.html
+++ b/supply-chain/research-zoom-check.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Supply Chain Tycoon — research tree zoom check</title>
+<style>
+  body { background:#111827; color:#e5e7eb; font:14px/1.6 ui-monospace,Menlo,monospace; padding:24px; }
+  h1 { font-size:16px; color:#93c5fd; }
+  .pass { color:#6ee7b7; } .fail { color:#fca5a5; } .info { color:#94a3b8; }
+  #summary { margin-top:14px; font-weight:700; }
+  #summary.pass { color:#6ee7b7; } #summary.fail { color:#fca5a5; }
+  /* Phone-width frame: the research overlay's mobile rules (and the mobile
+     node metrics in ui.js) key off the *game's* viewport, which is this
+     iframe's width — not the outer window. That is what lets a check run at
+     a real 500px layout viewport despite headless Chromium's ~500px floor. */
+  iframe { width:500px; height:900px; border:1px solid #334155; margin-top:16px; }
+</style>
+</head>
+<body>
+<h1>Research tree zoom check</h1>
+<p class="info">
+  The research overlay's readability on a phone rests on DOM behaviour
+  <code>tests.html</code> can't hold (it loads logic modules only): the tree
+  opening at a legible 1:1 instead of a fit-to-width shrink, pinch/button zoom
+  about an anchor, drag-to-pan, and taps still landing on a tech afterwards.
+  This page drives the real game in an iframe and asserts all of it. See
+  CLAUDE.md → Verification.
+</p>
+<div id="summary">running…</div>
+<pre id="log"></pre>
+<iframe id="f" src="index.html?probe=2&amp;techtree=1"></iframe>
+<script>
+const out = [];
+let pass = 0, fail = 0;
+function ok(name, cond, extra) {
+    (cond ? pass++ : fail++);
+    out.push((cond ? '✓ ' : '✗ ') + name + (extra !== undefined ? ' — ' + extra : ''));
+}
+function scaleOf(el) {
+    const t = getComputedStyle(el).transform;
+    return t === 'none' ? 1 : +t.match(/matrix\(([-\d.]+)/)[1];
+}
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+function finish() {
+    document.getElementById('log').textContent = out.join('\n');
+    const s = document.getElementById('summary');
+    s.textContent = pass + ' passed / ' + fail + ' failed';
+    s.className = fail ? 'fail' : 'pass';
+}
+
+setTimeout(() => {
+    const w = document.getElementById('f').contentWindow;
+    const d = w.document;
+    const nodes = d.getElementById('research-tree-nodes');
+    const wrap = d.getElementById('research-tree-wrap');
+    const U = w.SC._ui;
+
+    ok('tree overlay is open', !d.getElementById('research-overlay').classList.contains('hidden'));
+    ok('opens at 100% (no unreadable auto-shrink)', Math.abs(scaleOf(nodes) - 1) < 0.001, scaleOf(nodes));
+
+    const nodeW = nodes.getBoundingClientRect().width;
+    d.getElementById('research-zoom-in').click();
+    const s1 = scaleOf(nodes);
+    ok('zoom-in scales the tree up', s1 > 1.2 && s1 < 1.3, s1);
+    ok('scroll extent grows with the zoom', nodes.getBoundingClientRect().width > nodeW * 1.2);
+
+    d.getElementById('research-zoom-out').click();
+    ok('zoom-out returns to 100%', Math.abs(scaleOf(nodes) - 1) < 0.001, scaleOf(nodes));
+
+    d.getElementById('research-zoom-fit').click();
+    const sf = scaleOf(nodes);
+    ok('fit shrinks the whole tree in', sf < 1 && sf > 0.05, sf);
+    ok('fit width fits the wrap', nodes.getBoundingClientRect().width <= wrap.clientWidth + 2);
+    ok('fit scrolls back to the origin', wrap.scrollLeft === 0 && wrap.scrollTop === 0);
+
+    // Anchored zoom: the tree point under the anchor must stay under it.
+    U.setResearchTreeZoom(1, 0, 0);
+    wrap.scrollLeft = 300; wrap.scrollTop = 100;
+    const before = (wrap.scrollLeft + 120) / U.researchTreeScale();
+    U.zoomResearchTreeBy(1.5, 120, 60);
+    const after = (wrap.scrollLeft + 120) / U.researchTreeScale();
+    ok('zoom keeps the anchored point put', Math.abs(before - after) < 1.5, before + ' vs ' + after);
+
+    U.setResearchTreeZoom(99);
+    ok('zoom clamps at the top', U.researchTreeScale() <= 2.5);
+    // The bottom clamp is adaptive: never past what it takes to see the whole
+    // tree, so a wide tree on a phone can still reach its overview.
+    U.setResearchTreeZoom(0.01);
+    const floor = U.researchTreeScale();
+    U.setResearchTreeZoom(1, 0, 0);
+    U.fitResearchTreeToScreen();
+    ok('zoom clamps at the whole-tree overview', Math.abs(floor - U.researchTreeScale()) < 0.02,
+        floor + ' vs fit ' + U.researchTreeScale());
+
+    // Reopening forgets the player's zoom.
+    U.closeResearchTree();
+    U.openResearchTree();
+    ok('reopening resets to the auto fit', Math.abs(scaleOf(nodes) - 1) < 0.001, scaleOf(nodes));
+
+    // The whole point: node text has to be legible at the opening scale.
+    const desc = d.querySelector('.rt-node .research-desc');
+    const px = parseFloat(getComputedStyle(desc).fontSize) * scaleOf(nodes);
+    ok('description text is >= 12px on screen', px >= 12, px.toFixed(1) + 'px');
+
+    // Row pitch comes from the measured cards — nothing may overlap.
+    const cards = [...d.querySelectorAll('.rt-node')].map(el => ({
+        top: parseFloat(el.style.top), bottom: parseFloat(el.style.top) + el.offsetHeight,
+        left: parseFloat(el.style.left), right: parseFloat(el.style.left) + el.offsetWidth
+    }));
+    let overlap = 0;
+    for (let i = 0; i < cards.length; i++) for (let j = i + 1; j < cards.length; j++) {
+        const a = cards[i], b = cards[j];
+        if (a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom) overlap++;
+    }
+    ok('no two cards overlap', overlap === 0, overlap + ' overlapping pairs');
+
+    gestures(w, d, wrap, nodes, U).then(finish, e => { ok('gestures ran', false, e); finish(); });
+}, 2500);
+
+async function gestures(w, d, wrap, nodes, U) {
+    function pev(type, id, x, y, target) {
+        target.dispatchEvent(new w.PointerEvent(type, {
+            pointerId: id, clientX: x, clientY: y, bubbles: true, cancelable: true,
+            pointerType: 'touch', isPrimary: id === 1, button: 0,
+            buttons: type === 'pointerup' ? 0 : 1
+        }));
+    }
+    const scaleOf2 = el => {
+        const t = getComputedStyle(el).transform;
+        return t === 'none' ? 1 : +t.match(/matrix\(([-\d.]+)/)[1];
+    };
+
+    U.setResearchTreeZoom(1, 0, 0);
+    const r = wrap.getBoundingClientRect();
+    const cy = r.top + 200;
+
+    // Two fingers 100px apart, spread to 200px → 2× zoom.
+    pev('pointerdown', 1, r.left + 150, cy, wrap);
+    pev('pointerdown', 2, r.left + 250, cy, wrap);
+    pev('pointermove', 1, r.left + 100, cy, wrap);
+    pev('pointermove', 2, r.left + 300, cy, wrap);
+    ok('pinch out zooms in', Math.abs(scaleOf2(nodes) - 2) < 0.05, scaleOf2(nodes));
+
+    // …and back together → back to 1×.
+    pev('pointermove', 1, r.left + 150, cy, wrap);
+    pev('pointermove', 2, r.left + 250, cy, wrap);
+    ok('pinch in zooms back out', Math.abs(scaleOf2(nodes) - 1) < 0.05, scaleOf2(nodes));
+
+    pev('pointerup', 1, r.left + 150, cy, wrap);
+    pev('pointerup', 2, r.left + 250, cy, wrap);
+    await sleep(150);
+    ok('the pinch releases the drag state', !wrap.classList.contains('is-dragging'));
+
+    // A one-finger drag still pans, and doesn't zoom.
+    U.setResearchTreeZoom(1, 0, 0);
+    wrap.scrollLeft = 0;
+    pev('pointerdown', 3, r.left + 200, cy, wrap);
+    pev('pointermove', 3, r.left + 120, cy, wrap);
+    ok('one-finger drag pans', wrap.scrollLeft === 80, wrap.scrollLeft);
+    ok('one-finger drag does not zoom', Math.abs(scaleOf2(nodes) - 1) < 0.001);
+    pev('pointerup', 3, r.left + 120, cy, wrap);
+    await sleep(150);
+
+    // A tap on a tech still starts it after all that pointer traffic — the
+    // press-hold guard around the 0.4s rebuild is easy to break from here.
+    w.SC.state.money = 100000;
+    U.updateShop();
+    await sleep(50);
+    const btn = d.querySelector('[data-research]:not([disabled])');
+    ok('an affordable tech has a live button', !!btn);
+    if (btn) {
+        const id = btn.dataset.research;
+        pev('pointerdown', 4, r.left + 40, cy, btn);
+        pev('pointerup', 4, r.left + 40, cy, btn);
+        btn.dispatchEvent(new w.MouseEvent('click', { bubbles: true, cancelable: true }));
+        ok('tapping a tech still starts it', w.SC.research.isActive(id) || w.SC.research.isQueued(id), id);
+    }
+}
+</script>
+</body>
+</html>

--- a/supply-chain/style.css
+++ b/supply-chain/style.css
@@ -702,6 +702,18 @@ html, body {
     margin-bottom: 0.8rem;
 }
 .research-tree-header h1 { font-size: 1.1rem; }
+.research-tree-tools {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+.rt-zoom-btn {
+    width: 36px;
+    height: 36px;
+    font-size: 1.05rem;
+    line-height: 1;
+    flex: none;
+}
 .research-tree-wrap {
     position: relative;
     /* Scrollable & Draggable: players can pan/drag the full-size tree */
@@ -1284,7 +1296,37 @@ html, body {
     /* Float toasts above the bottom control cluster (shop / speed / mode)
        instead of on top of it. */
     #toast { bottom: 6rem; }
-    .research-tree-card { padding: 0.8rem; }
+    /* ── Research tree on a phone ──────────────────────────────────
+       The tree is no longer squeezed to fit the width (it would land near
+       60% and put this text at ~7px); it renders at 100% and pans, so the
+       type goes up to a size that's actually readable at arm's length and
+       the buttons get a proper tap target. Node box metrics move with it —
+       RT_METRICS_PHONE in js/ui.js, keep the two in step. */
+    #research-overlay { padding: 0.4rem; }
+    .research-tree-card {
+        padding: 0.7rem 0.6rem;
+        max-width: 99vw;
+        max-height: 94vh;
+        border-radius: 14px;
+    }
+    /* Title gives way first — four zoom/close buttons plus the readout is
+       most of a narrow header, and the tree behind it says what it is. */
+    .research-tree-header h1 {
+        font-size: 0.95rem;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .research-tree-tools { gap: 0.25rem; flex: none; }
+    .rt-zoom-btn { width: 34px; height: 34px; }
+    .rt-node { padding: 0.7rem 0.75rem; font-size: 0.95rem; }
+    .rt-node .research-desc {
+        font-size: 0.85rem;
+        line-height: 1.35;
+        margin-bottom: 0.5rem;
+    }
+    .rt-node .research-btn { font-size: 0.88rem; padding: 0.55rem 0.4rem; }
     .stats-card { padding: 0.8rem; }
     .stats-ach-grid { grid-template-columns: repeat(2, 1fr); }
 }

--- a/supply-chain/style.css
+++ b/supply-chain/style.css
@@ -1200,6 +1200,8 @@ html, body {
     border: 1px solid rgba(255, 255, 255, 0.05);
 }
 .recipe-graph-container {
+    /* Sized in JS from SC.GOODS (drawRecipeGraph) — the graph grows a column
+       when a deeper chain is added, so these are only a pre-render fallback. */
     position: relative;
     width: 715px;
     height: 415px;

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.61.0';</script>
+    <script>window.SC_VERSION = '1.62.0';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'audio', 'sfx', 'rng', 'map', 'camera',

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.62.1';</script>
+    <script>window.SC_VERSION = '1.63.0';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'audio', 'sfx', 'rng', 'map', 'camera',
@@ -594,6 +594,56 @@
         const n1 = SC.map.unlockNext();
         assert('unlockNext (no filter) activates a site', n1 && n1.active);
         assert('starter products craftable', SC.economy.craftableProducts().includes('bread'));
+        // World-gen skips a pool entry whose spot search comes up empty, so a
+        // pool that outgrows the map loses chains silently. Every recipe in
+        // SC.GOODS must actually reach the map across a spread of seeds.
+        assert('every recipe has a factory somewhere in the pool', (function() {
+            const missing = new Set(Object.keys(SC.GOODS).filter(k => !SC.GOODS[k].raw));
+            for (const seed of ['pool-1', 'pool-2', 'pool-3', 'pool-4', 'pool-5']) {
+                SC.newState(); SC.map._resetSeq(); SC.map.generateWorld(seed);
+                for (const n of SC.state.nodes) if (n.kind === 'factory') missing.delete(n.recipe);
+                for (const k of Object.keys(SC.GOODS)) {
+                    if (!SC.GOODS[k].raw && !SC.state.nodes.some(n => n.recipe === k)) return false;
+                }
+            }
+            return missing.size === 0;
+        })());
+        assert('every raw material has a supplier somewhere in the pool', (function() {
+            SC.newState(); SC.map._resetSeq(); SC.map.generateWorld('pool-mats');
+            return Object.keys(SC.GOODS).filter(k => SC.GOODS[k].raw)
+                .every(m => SC.state.nodes.some(n => n.kind === 'supplier' && n.mat === m));
+        })());
+    })();
+
+    // ── Second-wave chains plan end to end ──────────
+    (function() {
+        // A bicycle needs a tyre plant (rubber + coal) and a smelter (ore +
+        // coal) — the two share the coal pit, which is the whole point of
+        // these chains. The planner has to schedule both sub-factories.
+        SC.newState(); SC.map._resetSeq();
+        SC.state.river = { spine: [{ x: 2100, y: 0 }, { x: 2100, y: SC.CONFIG.WORLD_H }], halfWidths: [10, 10] };
+        SC.map.makeNode('city', 100, 100, { active: true, isHQ: true });
+        SC.map.makeNode('factory', 150, 100, { active: true, recipe: 'bicycle' });
+        SC.map.makeNode('factory', 300, 100, { active: true, recipe: 'tyre' });
+        SC.map.makeNode('factory', 450, 100, { active: true, recipe: 'steel' });
+        for (const mat of ['rubber', 'coal', 'ore']) {
+            SC.map.makeNode('supplier', 600, 300, { active: true, mat });
+        }
+        assert('bicycles are craftable from a shared coal pit',
+            SC.economy.craftableProducts().includes('bicycle'));
+        const o = SC.economy.spawnOrder();
+        assert('only bicycles are orderable in this world', o && o.product === 'bicycle');
+        assert('the depth-2 premium lands on the payout',
+            o.payout >= SC.GOODS.bicycle.value * (1 + SC.CONFIG.ORDER_DEPTH_VALUE * (SC.depthOf('bicycle') - 1)));
+
+        // Scooters take a product (batteries) as an input — the planner must
+        // treat that factory-to-factory hop like any other.
+        SC.map.makeNode('factory', 700, 100, { active: true, recipe: 'scooter' });
+        SC.map.makeNode('factory', 850, 100, { active: true, recipe: 'battery' });
+        SC.map.makeNode('supplier', 600, 300, { active: true, mat: 'copper' });
+        const craftable = SC.economy.craftableProducts();
+        assert('an orderable good can itself be an input',
+            craftable.includes('battery') && craftable.includes('scooter'));
     })();
 
     // ── Seeded RNG: deterministic stream, independent of global state ──
@@ -735,7 +785,10 @@
         SC.map.generateWorld();
         SC.state.time = 1e6; // past any river-grace window: test the raw pool mechanic
 
-        for (let i = 0; i < 20; i++) {
+        // Drain the pool rather than iterating a fixed count — the pool grows
+        // whenever a chain is added to SC.GOODS, and a short loop would leave
+        // sites locked and fail the "all active" assert below for no reason.
+        for (let i = 0; i < SC.state.nodes.length + 1; i++) {
             const n = SC.map.unlockNext(x => x.kind !== 'city');
             if (!n) break;
             assert('kind-filtered unlockNext never activates a city', n.kind !== 'city');
@@ -1372,16 +1425,37 @@
 
     // ── Goods tree sanity ───────────────────────────
     (function() {
-        assert('chain depths: bread=1, car=2, robot=3',
-            SC.depthOf('bread') === 1 && SC.depthOf('car') === 2 && SC.depthOf('robot') === 3);
+        const goods = Object.keys(SC.GOODS);
+        const raws = goods.filter(k => SC.GOODS[k].raw);
+        const usedBy = m => goods.filter(k => (SC.GOODS[k].inputs || []).includes(m));
+        assert('chain depths: bread=1, car=2, robot=3, scooter=2',
+            SC.depthOf('bread') === 1 && SC.depthOf('car') === 2 &&
+            SC.depthOf('robot') === 3 && SC.depthOf('scooter') === 2);
         assert('every crafted good has a building name',
-            Object.keys(SC.GOODS).every(k => SC.GOODS[k].raw || !!SC.GOODS[k].building));
+            goods.every(k => SC.GOODS[k].raw || !!SC.GOODS[k].building));
         assert('every input exists in the goods table',
-            Object.keys(SC.GOODS).every(k => (SC.GOODS[k].inputs || []).every(m => !!SC.GOODS[m])));
-        assert('rubber, chips and steel are each shared by two recipes', (function() {
-            const usedBy = m => Object.keys(SC.GOODS).filter(k => (SC.GOODS[k].inputs || []).includes(m));
-            return usedBy('rubber').length === 2 && usedBy('chips').length === 2 && usedBy('steel').length === 2;
+            goods.every(k => (SC.GOODS[k].inputs || []).every(m => !!SC.GOODS[m])));
+        assert('every crafted good takes exactly two inputs',
+            goods.every(k => SC.GOODS[k].raw || SC.GOODS[k].inputs.length === 2));
+        assert('every orderable good has a value',
+            goods.every(k => !SC.GOODS[k].orderable || SC.GOODS[k].value > 0));
+        assert('a deeper chain is never worth less than a shallower one', (function() {
+            const sell = goods.filter(k => SC.GOODS[k].orderable)
+                              .sort((a, b) => SC.depthOf(a) - SC.depthOf(b));
+            return sell.every((k, i) => i === 0 ||
+                SC.depthOf(k) === SC.depthOf(sell[i - 1]) ||
+                SC.GOODS[k].value >= SC.GOODS[sell[i - 1]].value);
         })());
+        // The point of the second-wave chains: they buy variety with more of
+        // the SAME sites, so a raw material is contended rather than owned by
+        // one recipe. No new raw may appear without a supplier art entry and
+        // a pool slot, hence the fixed count.
+        assert('no raw material is orphaned', raws.every(m => usedBy(m).length > 0));
+        assert('the goods tree still rests on eight raw materials', raws.length === 8);
+        assert('most raw materials are contended by two or more recipes',
+            raws.filter(m => usedBy(m).length >= 2).length >= 6);
+        assert('rubber and coal each feed three or more recipes',
+            usedBy('rubber').length >= 3 && usedBy('coal').length >= 3);
     })();
 
     // ── Inspect mode: factory/supplier/city info + highlight paths ──


### PR DESCRIPTION
Two changes to Supply Chain Tycoon.

## 1. The research tree is readable on a phone (v1.62.1)

The overlay fit the whole tree into the viewport width, which on a phone bottomed out at the `0.62` scale floor and rendered the description text at ~7px. There was no way to zoom in either: the page is `user-scalable=no`, because the map canvas owns pinch for its own camera.

- **Never auto-shrink below 100%.** Narrower than the tree, the wrap scrolls and the drag-to-pan it already supported takes over. Description text now measures 13.6px on screen.
- **The tree carries its own zoom** — pinch inside it, `−` / `+` / `⤢` buttons in the header, ctrl/⌘-wheel on desktop. All anchored, so whatever sits under the gesture stays under it. Zooming out reaches a whole-tree overview however wide the tree grows; reopening returns to the auto fit.
- **Phone-sized cards and larger type** under the existing 768px breakpoint.
- **Row pitch is measured, not guessed.** Each row now stacks under the tallest card of the row above it, instead of one constant sized for the wordiest tech in the whole tree — the tree is considerably shorter, and edges leave from real card bottoms.

## 2. Six new goods, built from the existing raw materials (v1.63.0)

🛞 tyres (rubber+coal) and 🧣 textiles (wool+water) as intermediates, feeding 🚲 bicycles (tyre+steel), 🧥 jackets (cloth+rubber), 🔋 batteries (copper+coal) and 🛵 e-scooters (tyre+battery). Orderable goods go from 4 to 8.

No new raw material, by design: every one of these bids for a supplier an earlier chain already wanted. Coal now feeds the smelter, the tyre plant and the battery plant; water the bakery and the textile mill; rubber four recipes. Running two chains at once therefore means planting a second coal pit rather than discovering a new kind of site — the milestone pool interleaves those extra suppliers with the new factories, late enough that the early chains are established first.

E-scooters are the first recipe whose input (batteries) is itself an orderable product. The planner already handled factory-to-factory hops at any depth; a test now pins it.

Also replaces the start screen's hand-written recipe-graph position table with a layout derived from `SC.GOODS` — the old table silently dropped any good missing from it, which is exactly what six new goods would have hit.

## Verification

- `tests.html`: **1324 passed / 0 failed**. The goods-tree suite now asserts the design property (raw materials are contended, no new raws, deeper chains never pay less) rather than naming individual recipes, and world-gen is checked across five seeds so a pool that outgrows the map can't drop a chain silently.
- `audio-check.html`: 14 passed / 0 failed.
- New `research-zoom-check.html`: 21 passed / 0 failed — drives the real game in a 500px iframe and covers the pinch gesture, anchored zoom, pan, text size, card overlap, and that a tap still starts a tech.
- Visual smoke at `?probe=40` and a full-pool render: clean.

`origin/master` (through the biome/ground-quality work) is merged in; its tests and changes are intact.

---
_Generated by [Claude Code](https://claude.ai/code/session_011nPc1CoHX5vHDiePqgTa5D)_