### PR TITLE
Fill the map: decor scales with area, locked sites stake a claim

### DIFF
--- a/index.html
+++ b/index.html
@@ -908,7 +908,7 @@
     </header>
 
     <main class="grid">
-        <a href="supply-chain/index.html?v=1.61.2" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.61.3" class="card card-metal" id="card-supply-chain">
             <div class="card-bg-hover"></div>
             <div>
                 <div class="card-icon">

--- a/supply-chain/PLAN.md
+++ b/supply-chain/PLAN.md
@@ -39,6 +39,17 @@ in Phase 4 — not in README.md, which now just points here. See
 
 ## Shipped
 
+- v1.61.3: **the map stops reading as empty** — two causes, both fixed.
+  Decor counts (ground patches, trees/rocks) were flat regardless of world
+  size, so every land purchase diluted the scenery — by the third expansion
+  the world is ~4× the starting area with the same 90 trees in it; they now
+  scale with world area, holding a new game's density at any size. And
+  locked **supplier** sites, which have existed at their final spots since
+  world-gen, are drawn as staked claims (dashed plot + material mark, flat
+  on unworked ground) instead of being invisible until their milestone —
+  no economy change, but the blank half of the map becomes a plan you can
+  read, right down to which ground will yield well. Locked factories/DCs
+  stay hidden.
 - v1.61.2: **ground quality — biome-driven supplier yield** — a supplier's
   regen is now multiplied by the biome band under it (`BIOME_BANDS` ×
   `BIOME_YIELD`, per material) plus a small per-site roll

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -83,6 +83,13 @@ that ambient animation as its background — it now lives independently at
   The cap is per-difficulty (`SC.nodeMaxSpread` → `DIFFICULTIES[].nodeSpread`,
   falling back to `CONFIG.NODE_MAX_SPREAD`): tighter/tidier on Easy (520),
   real sprawl and longer supply lines on Hard (820).
+  Locked **suppliers** are drawn on the map as **staked claims** —
+  a dashed plot with the material's mark, flat on unworked ground
+  (`R.drawProspectSites`). They cost nothing and do nothing until the
+  milestone opens them; they're there so the map reads as a plan rather
+  than a void: what's coming, where, and (with yield following the biome)
+  how good that ground will be for it. Locked factories and DCs stay
+  hidden — revealing those too would give the whole run away.
 - **Field expansion**: the playing field only ever grows when the player buys
   it — the map never re-lays itself out mid-run. The `landSurvey` research
   unlocks the Buy land button; each purchase adds `stepW`/`stepH`

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.61.2';</script>
+    <script>window.SC_VERSION = '1.61.3';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>

--- a/supply-chain/js/render-core.js
+++ b/supply-chain/js/render-core.js
@@ -303,6 +303,7 @@ SC.render = (function() {
         drawWorld(dt);       // mountains ride inside the cached bg layer
         R.drawCloudShadows(dt); // soft shadows sliding over the ground
         R.drawSnowBlanket();    // pale snow settling on the land
+        R.drawProspectSites();  // staked-out locked sites, under everything built
         R.drawRoads();
         R.drawWetRoads();       // rain sheen on the road surface
         R.drawRouteFlow();      // colored pulses along roads with live trucks

--- a/supply-chain/js/render-env.js
+++ b/supply-chain/js/render-env.js
@@ -513,9 +513,18 @@
                     + ':' + terrainKey();
         if (decor && decorKey === key) return decor;
         const rng = makeRng(0x2357);
+        // Decor counts scale with world AREA, not the map. They used to be
+        // flat (18 patches / 90 trees) no matter how far the world had been
+        // expanded, so every land purchase diluted the scenery — by the
+        // third expansion the world is ~4x the starting area with the same
+        // 90 trees in it, which is what made a grown map read as barren.
+        // Scaling off the base world size keeps the density a new game has.
+        const areaScale = (W * Wh) / (SC.CONFIG.WORLD_W * SC.CONFIG.WORLD_H);
+        const patchCount = Math.max(1, Math.round(18 * areaScale));
+        const treeCount = Math.max(1, Math.round(90 * areaScale));
         const patches = [];
         const tints = ['#233650', '#2b3a3a', '#1d2b40', '#2a3446', '#243d3a'];
-        for (let i = 0; i < 18; i++) {
+        for (let i = 0; i < patchCount; i++) {
             const cx = rng() * W, cy = rng() * Wh;
             const rx = 220 + rng() * 320, ry = 140 + rng() * 200;
             const pts = [];
@@ -532,7 +541,9 @@
         }
         const trees = [];
         let tries = 0;
-        while (trees.length < 90 && tries < 1000) {
+        // The retry budget scales with the target too — it exists to bail
+        // out of a map with nowhere left to plant, not to cap the count.
+        while (trees.length < treeCount && tries < treeCount * 12) {
             tries++;
             const x = 70 + rng() * (W - 140), y = 70 + rng() * (Wh - 140);
             if (inRiver(x, y, 55)) continue;

--- a/supply-chain/js/render-network.js
+++ b/supply-chain/js/render-network.js
@@ -1096,6 +1096,38 @@
         }
     }
 
+    // Locked supplier sites — the ones the milestone track hasn't opened
+    // yet. They already exist at their final spot from world-gen (map.js's
+    // pool is created inactive, and unlockNext only flips the flag), so
+    // showing them as surveyed-but-unworked ground adds nothing to the
+    // economy and turns a lot of blank map into a plan: which material is
+    // coming, where, and — since yield follows the biome — how good that
+    // ground will be for it. Deliberately flat and dashed: a claim staked
+    // on open ground, not a building. Suppliers only; revealing every
+    // future factory and DC as well would give the whole map away.
+    function drawProspectSites() {
+        const z = clampZoom();
+        for (const n of SC.state.nodes) {
+            if (n.active || n.kind !== 'supplier') continue;
+            const g = S(n.x, n.y);
+            const { rx, ry } = footRadii(14);
+            R.ctx.save();
+            diamondPath(g.x, g.y, rx, ry);
+            R.ctx.fillStyle = 'rgba(10, 16, 26, 0.16)';
+            R.ctx.fill();
+            R.ctx.setLineDash([5 * z, 4 * z]);
+            R.ctx.strokeStyle = rgba(SC.colorOf(n.mat), 0.5);
+            R.ctx.lineWidth = Math.max(1.2, 1.6 * z);
+            R.ctx.stroke();
+            R.ctx.setLineDash([]);
+            // Enough to read what's coming at a glance, faint enough that a
+            // staked claim never competes with a site that's actually running.
+            R.ctx.globalAlpha = 0.62;
+            emoji(SC.emojiOf(n.mat), g.x, g.y - 3 * z, 16 * z);
+            R.ctx.restore();
+        }
+    }
+
     function drawYardSite(n, sp, g) {
         const z = zoom();
         drawYardParking(n, g, z, true);
@@ -1729,6 +1761,6 @@
     }
 
     Object.assign(R, { drawRoads, drawRouteFlow, nodeSpec, drawShadow, drawSupplierSite, drawJunction,
-        drawNodeBody, drawYardParking, drawYardSite, emojiPlateAt, drawOrderBubbles,
+        drawNodeBody, drawYardParking, drawYardSite, drawProspectSites, emojiPlateAt, drawOrderBubbles,
         drawHighlight, drawInspectHighlight, drawTutorialFocus, drawGhostRoad, drawGhostMarks, drawPlacementGhost, drawOffscreenArrows });
 })();

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.61.2';</script>
+    <script>window.SC_VERSION = '1.61.3';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'audio', 'sfx', 'rng', 'map', 'camera',


### PR DESCRIPTION
The map read as empty for two unrelated reasons. Both fixed here; neither touches the economy.

## 1. Decor density didn't scale with the world

Patch and tree counts were flat — 18 and 90 — no matter how far the world had been expanded. Base world is 2600×1800 and each expansion adds 900×620, so by the third expansion the world is ~4× the starting area with the same 90 trees in it: buying land actively thinned out the scenery. Both counts (and the planting retry budget, which exists to bail out of a full map rather than to cap the count) now scale with world area against the base `WORLD_W`/`WORLD_H`, holding a new game's density at any size. The decor cache key already included world size, so expansions re-bake correctly.

## 2. Locked sites were invisible rather than absent

The entire future pool — suppliers, factories, cities — has existed at its final spot since world-gen: `map.js` creates it inactive and `unlockNext` only flips the flag. It was simply never drawn.

Locked **suppliers** now render as staked claims — a dashed plot with the material's mark, flat on unworked ground, painted under everything built (`R.drawProspectSites`). Nothing is activated: no new supply, no new haul targets, no change to milestone pacing. What it buys is legibility — the blank half of the map becomes a plan you can read: what's coming, where, and (since yield follows the biome) how good that ground will be for it. Locked factories and DCs stay hidden; revealing those too would give the run away.

## Deliberately not done

Activating extra suppliers at the map edges. Order pay scales with factory→city distance, not supplier distance, so a far-edge farm is pure haul time with no upside — clutter at best, a trap for a new player at worst.

## Verification

- **1324 tests pass / 0 failed** on the merged tree (render-only change; the count jump is master's six-chains work coming in).
- Screenshots at 1× and with `&expand=3`: a grown map now carries its scenery instead of thinning out, and a close-up confirms a claim reads as staked ground without competing with a site that's actually running.
- Merge note: master shipped v1.63.0/v1.62.1 while this branch was on 1.61.3, so the merge lands on **v1.63.1** and PLAN.md keeps every Shipped entry from both sides.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R62W4DvX6itVFg6uHhFtWu)_