### PR TITLE
Only warn about a resource you need and can't reach

### DIFF
--- a/index.html
+++ b/index.html
@@ -908,7 +908,7 @@
     </header>
 
     <main class="grid">
-        <a href="supply-chain/index.html?v=1.63.1" class="card card-metal" id="card-supply-chain">
+        <a href="supply-chain/index.html?v=1.63.2" class="card card-metal" id="card-supply-chain">
             <div class="card-bg-hover"></div>
             <div>
                 <div class="card-icon">

--- a/supply-chain/DEBUG.md
+++ b/supply-chain/DEBUG.md
@@ -68,6 +68,7 @@ Adding a flag? Add the row here too — this table is the whole contract.
 | `&research=id,id` | Instantly complete those techs by id (also tops up money, so the Build section/menu are screenshotable). Ids are the keys of `SC.RESEARCH` in [js/config.js](js/config.js). |
 | `&placemode=factory:shoes` | Arm manual-placement mode. Requires `manualPlacement` researched — pass both together. |
 | `&hoverAt=x,y` | Fake a pointer position (world coords) via `SC.input._setDebugHover`, so the placement/road ghost preview renders without a real pointermove. |
+| `&gaps=1` | Put the map into both supply-gap states at once: buys (unlocking first if needed) a factory whose raw inputs have no supplier yet, so the staked claims for them appear, and demolishes the bakery's wheat road — parking the fleet first, since demolish refuses a road with a truck on it — so an owned-but-unreachable supplier shows its ⚠ ring. The way to screenshot `SC.economy.supplyGaps()`. |
 | `&inspect=<mat>\|hq\|factory\|<node id>` | Switch to inspect mode and open the tooltip on a node via `SC.input._setDebugInspect`, without a real tap — a raw material name (`wheat`, `ore`, …) picks the first active supplier of it. The way to screenshot what a site reports: stock, rate, and its biome/yield row. |
 | `&highway=1` | Complete Asphalt Paving and pave every built road (highway styling). |
 | `&capacity=1` | Max the truck-capacity upgrade, so bundled multi-item hauls (the ×N badge) show up without a long probe. |

--- a/supply-chain/PLAN.md
+++ b/supply-chain/PLAN.md
@@ -39,6 +39,16 @@ in Phase 4 — not in README.md, which now just points here. See
 
 ## Shipped
 
+- v1.63.2: **the map only speaks when it has something to say** — the
+  staked claims from v1.63.1 drew every locked supplier at once, which is
+  wallpaper, not information (and the six-chains release widened the pool
+  that draws from). `SC.economy.supplyGaps()` now splits the two ways a raw
+  material can be missing and the map says exactly one thing: a material a
+  factory of yours takes with **no supplier owned anywhere** stakes its
+  claims, while a supplier you **own but haven't roaded** keeps the claims
+  quiet and takes a pulsing ⚠ ring itself — the answer there is "build the
+  road", not "wait for another deposit". Materials nothing needs, and sites
+  that are connected, say nothing at all. Dev: `&gaps=1`.
 - v1.63.1: **the map stops reading as empty** — two causes, both fixed.
   Decor counts (ground patches, trees/rocks) were flat regardless of world
   size, so every land purchase diluted the scenery — by the third expansion

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -86,13 +86,21 @@ that ambient animation as its background — it now lives independently at
   The cap is per-difficulty (`SC.nodeMaxSpread` → `DIFFICULTIES[].nodeSpread`,
   falling back to `CONFIG.NODE_MAX_SPREAD`): tighter/tidier on Easy (520),
   real sprawl and longer supply lines on Hard (820).
-  Locked **suppliers** are drawn on the map as **staked claims** —
-  a dashed plot with the material's mark, flat on unworked ground
-  (`R.drawProspectSites`). They cost nothing and do nothing until the
-  milestone opens them; they're there so the map reads as a plan rather
-  than a void: what's coming, where, and (with yield following the biome)
-  how good that ground will be for it. Locked factories and DCs stay
-  hidden — revealing those too would give the whole run away.
+  Locked **suppliers** can surface as **staked claims** — a dashed plot
+  with the material's mark, flat on unworked ground
+  (`R.drawProspectSites`) — but only when they answer a question you
+  actually have. `SC.economy.supplyGaps()` splits the two ways a raw
+  material can be missing, and the map says exactly one thing at a time:
+  - **sourceless** (a factory you own takes it, you own no supplier of it
+    anywhere) → the claims for that material appear, so you can see where
+    it's coming and how good that ground is for it;
+  - **unroaded** (you own the supplier, nothing reaches it) → the claims
+    stay quiet and the site itself gets a pulsing ⚠ ring, because the
+    answer is "build the road", not "wait for another deposit".
+  Everything else is silent: no claims for materials nothing needs, no
+  warnings on a site that's connected. Locked factories and DCs are never
+  revealed — that would give the whole run away. Dev: `&gaps=1` puts the
+  map into both states at once.
 - **Field expansion**: the playing field only ever grows when the player buys
   it — the map never re-lays itself out mid-run. The `landSurvey` research
   unlocks the Buy land button; each purchase adds `stepW`/`stepH`

--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -9,7 +9,7 @@
          module, so a bump no longer rewrites ~40 query-string lines (which,
          under parallel agent sessions, conflict on every master merge).
          config.js copies it to SC.VERSION. See supply-chain/CLAUDE.md. -->
-    <script>window.SC_VERSION = '1.63.1';</script>
+    <script>window.SC_VERSION = '1.63.2';</script>
     <script>document.write('<link rel="stylesheet" href="style.css?v=' + SC_VERSION + '">');</script>
 </head>
 <body>

--- a/supply-chain/js/economy.js
+++ b/supply-chain/js/economy.js
@@ -13,6 +13,44 @@ SC.economy = (function() {
             n.kind === 'supplier' && n.active && !n.underConstruction && (!mat || n.mat === mat));
     }
 
+    // ── Supply gaps: what you need and can't currently get ────────
+    // A raw material is "unmet" when an operational factory takes it and
+    // no active supplier of it has a road to that factory. The map uses
+    // this to stay quiet: an unbuilt site is only worth pointing at when
+    // you need what's under it and nothing is hauling it yet, and an
+    // already-unlocked site is only worth flagging when it's the one
+    // that's missing its road.
+    //
+    // Recomputed only when the road network or the node roster changes —
+    // it runs a findPath per (supplier, factory) pair and is read from
+    // the render loop.
+    let gapCache = null, gapKey = null;
+    function supplyGaps() {
+        let actives = 0;
+        for (const n of SC.state.nodes) if (n.active && !n.underConstruction) actives++;
+        const key = (SC.state.networkVersion || 0) + ':' + SC.state.nodes.length + ':' + actives;
+        if (gapCache && gapKey === key) return gapCache;
+
+        const sourceless = new Set(); // needed, and you own no supplier of it at all
+        const unroaded = new Set();   // node ids: you own the supplier, it just has no route
+        const factories = SC.factories.all();
+        const needed = new Set();
+        for (const f of factories)
+            for (const mat of SC.GOODS[f.recipe].inputs)
+                if (SC.GOODS[mat].raw) needed.add(mat);
+
+        for (const mat of needed) {
+            const wants = factories.filter(f => SC.GOODS[f.recipe].inputs.includes(mat));
+            const mine = activeSuppliers(mat);
+            if (mine.some(s => wants.some(f => SC.roads.findPath(s, f)))) continue; // supplied
+            if (mine.length) mine.forEach(s => unroaded.add(s.id));
+            else sourceless.add(mat);
+        }
+        gapCache = { sourceless, unroaded };
+        gapKey = key;
+        return gapCache;
+    }
+
     // Can this good be produced with today's suppliers and factories?
     // (Raw: an active supplier exists. Crafted: an operational factory
     // with the recipe exists and every input can itself be sourced.)
@@ -482,7 +520,7 @@ SC.economy = (function() {
 
     return { spawnOrder, planOrder, deliverProduct, expireOrder,
              onNetworkChanged, tick, tickSuppliers, buyUpgrade, upgradeSupplier,
-             craftableProducts, bestSourceFor, maxActiveOrders,
+             craftableProducts, bestSourceFor, maxActiveOrders, supplyGaps,
              isPromoActive, promoTimeLeft, startPromotion,
              rollContractOffer, acceptContract, declineContract,
              getDeadlineRamp, getSpawnRamp };

--- a/supply-chain/js/main.js
+++ b/supply-chain/js/main.js
@@ -306,6 +306,28 @@ SC.runProbe = function(seconds) {
         SC.state.selectedNode = SC.state.nodes.find(n => String(n.id) === key) ||
             (key === 'factory' ? SC.factories.all()[0] : SC.state.nodes.find(n => n.isHQ));
     }
+    // Put the map into both supply-gap states at once (&gaps=1): buy the
+    // first for-sale factory, so its raw inputs are suddenly needed with no
+    // supplier unlocked for them (staked claims appear), and demolish the
+    // bakery's wheat road, so an owned supplier is needed with no route
+    // (warning ring on the site itself).
+    if (p.has('gaps')) {
+        // Own a factory whose raw inputs have no supplier unlocked yet.
+        let site = SC.state.nodes.find(n => n.kind === 'factory' && n.forSale && n.active);
+        if (!site) site = SC.map.unlockNext(n => n.kind === 'factory');
+        if (site) {
+            SC.state.money += SC.CONFIG.FACTORY_SITE_PRICE;
+            SC.factories.buySite(site);
+            site.underConstruction = false; // skip the build timer for the shot
+        }
+        // Strand an owned supplier: park the fleet first, since demolish
+        // (rightly) refuses a road with a truck on it.
+        for (const t of SC.state.trucks) { t.path = null; t.jobs = []; t.cargo = []; }
+        const bakery = SC.factories.all()[0];
+        const wheat = SC.state.nodes.find(n => n.kind === 'supplier' && n.mat === 'wheat' && n.active);
+        const edge = bakery && wheat && SC.roads.findEdge(bakery, wheat);
+        if (edge) SC.roads.demolish(edge);
+    }
     // Open the inspect tooltip on a node (&inspect=wheat|<mat>|hq|factory|
     // <node id>) without a real tap, so what a site actually reports —
     // stock, rate, the biome/yield row — can be screenshotted.

--- a/supply-chain/js/render-network.js
+++ b/supply-chain/js/render-network.js
@@ -986,6 +986,7 @@
         }
 
         // --- per-kind badges/bars -------------------------------------------
+        drawUnroadedWarning(n, g, sp);
         if (n.kind === 'supplier') {
             const cap = SC.supplierCap(n);
             const frac = Math.max(0, Math.min(1, (n.stock || 0) / cap));
@@ -1099,16 +1100,23 @@
     // Locked supplier sites — the ones the milestone track hasn't opened
     // yet. They already exist at their final spot from world-gen (map.js's
     // pool is created inactive, and unlockNext only flips the flag), so
-    // showing them as surveyed-but-unworked ground adds nothing to the
-    // economy and turns a lot of blank map into a plan: which material is
-    // coming, where, and — since yield follows the biome — how good that
-    // ground will be for it. Deliberately flat and dashed: a claim staked
-    // on open ground, not a building. Suppliers only; revealing every
+    // drawing them as surveyed ground costs nothing in balance terms.
+    //
+    // But drawing ALL of them turns the map into wallpaper — every future
+    // site shouting at once, which is noise, not information. A claim is
+    // only staked when it answers a question you actually have: a factory
+    // you own takes this material and you own no supplier of it anywhere
+    // (SC.economy.supplyGaps().sourceless). The moment you own one, the
+    // claims go quiet and the warning moves to that site instead — see
+    // drawUnroadedWarning: at that point the answer is "build the road",
+    // not "wait for another deposit". Suppliers only; revealing every
     // future factory and DC as well would give the whole map away.
     function drawProspectSites() {
         const z = clampZoom();
+        const gaps = SC.economy.supplyGaps();
+        if (!gaps.sourceless.size) return;
         for (const n of SC.state.nodes) {
-            if (n.active || n.kind !== 'supplier') continue;
+            if (n.active || n.kind !== 'supplier' || !gaps.sourceless.has(n.mat)) continue;
             const g = S(n.x, n.y);
             const { rx, ry } = footRadii(14);
             R.ctx.save();
@@ -1126,6 +1134,19 @@
             emoji(SC.emojiOf(n.mat), g.x, g.y - 3 * z, 16 * z);
             R.ctx.restore();
         }
+    }
+
+    // The other half of the same rule: a supplier you already own, whose
+    // material a factory of yours wants, with no road that reaches it. The
+    // order rows say "no route!" and the inspect tooltip flags the consumer,
+    // but neither helps if you haven't tapped the thing — so the site itself
+    // carries a warning ring until it's connected.
+    function drawUnroadedWarning(n, g, sp) {
+        if (n.kind !== 'supplier' || !SC.economy.supplyGaps().unroaded.has(n.id)) return;
+        const z = clampZoom();
+        const pulse = 0.55 + 0.45 * Math.sin(R.seaTime * 3);
+        groundRing(g.x, g.y, sp.fw + 7, `rgba(250, 204, 21, ${0.75 * pulse})`, 2.2);
+        emojiPlateAt('⚠️', g.x + footRadii(sp.fw).rx * 0.75, g.y - sp.h * z - 4 * z, 9 * z, 11 * z);
     }
 
     function drawYardSite(n, sp, g) {

--- a/supply-chain/tests.html
+++ b/supply-chain/tests.html
@@ -17,7 +17,7 @@
     <!-- Pure logic only: no render/input/ui/main, no canvas needed. Same
          single-token loader as index.html (see supply-chain/CLAUDE.md); the
          version here only feeds SC.VERSION and is irrelevant to the tests. -->
-    <script>window.SC_VERSION = '1.63.1';</script>
+    <script>window.SC_VERSION = '1.63.2';</script>
     <script>
     (function () {
         var mods = ['config', 'state', 'save', 'audio', 'sfx', 'rng', 'map', 'camera',
@@ -1494,6 +1494,54 @@
 
         assert('infoFor is null for inactive nodes',
             SC.inspect.infoFor(SC.map.makeNode('supplier', 900, 900, { mat: 'ore' })) === null);
+    })();
+
+    // ── Supply gaps: what you need and can't reach ──
+    (function() {
+        const { S1, S2, F } = fixture();
+        // Bakery needs wheat + water; both suppliers exist but no roads yet,
+        // so each is owned-but-unroaded, not sourceless.
+        let gaps = SC.economy.supplyGaps();
+        assert('an owned supplier with no road is flagged, not treated as missing',
+            gaps.unroaded.has(S1.id) && gaps.unroaded.has(S2.id) &&
+            gaps.sourceless.size === 0);
+
+        SC.roads.build(S1, F);
+        gaps = SC.economy.supplyGaps();
+        assert('building the road clears that supplier\'s warning', !gaps.unroaded.has(S1.id));
+        assert('the still-unroaded input keeps its warning', gaps.unroaded.has(S2.id));
+
+        SC.roads.build(S2, F);
+        gaps = SC.economy.supplyGaps();
+        assert('a fully roaded factory raises no warnings at all',
+            gaps.unroaded.size === 0 && gaps.sourceless.size === 0);
+
+        // A material no owned supplier provides is 'sourceless' — that's the
+        // only case the map stakes a claim for.
+        const shoes = SC.map.makeNode('factory', 900, 500,
+            { active: true, recipe: 'shoes', underConstruction: false });
+        gaps = SC.economy.supplyGaps();
+        const shoeInputs = SC.GOODS.shoes.inputs.filter(m => SC.GOODS[m].raw);
+        assert('a needed material with no supplier anywhere is sourceless',
+            shoeInputs.every(m => gaps.sourceless.has(m)));
+        assert('sourceless materials raise no per-node warning',
+            gaps.unroaded.size === 0);
+
+        // Unlocking a supplier for it flips the answer from "no deposit" to
+        // "no road" — the claim goes quiet and the site takes the warning.
+        const wool = SC.map.makeNode('supplier', 950, 700,
+            { active: true, mat: shoeInputs[0], underConstruction: false });
+        gaps = SC.economy.supplyGaps();
+        assert('owning a supplier of it stops it being sourceless',
+            !gaps.sourceless.has(shoeInputs[0]) && gaps.unroaded.has(wool.id));
+
+        // Nothing is "needed" until a factory that takes it is operational.
+        SC.newState();
+        SC.map._resetSeq();
+        SC.map.makeNode('supplier', 100, 100, { active: true, mat: 'wheat', underConstruction: false });
+        assert('a supplier no operational factory needs raises nothing',
+            SC.economy.supplyGaps().unroaded.size === 0 &&
+            SC.economy.supplyGaps().sourceless.size === 0);
     })();
 
     // ── Supplier stock: cap, regen, consumption, trucks wait when dry ──


### PR DESCRIPTION
Staking a claim on *every* locked supplier turned out to be wallpaper rather than information — and the six-chains release widened the pool it draws from, so a fresh map lit up with markers for materials nothing needed yet.

`SC.economy.supplyGaps()` now splits the two ways a raw material can be missing **for a factory you actually own**, and the map says exactly one thing at a time:

| State | Meaning | What the map does |
|---|---|---|
| **sourceless** | a factory you own takes it, you own no supplier of it anywhere | its staked claims appear — where it's coming, and (yield following the biome) how good that ground will be |
| **unroaded** | you own the supplier, nothing reaches it | claims stay quiet; the site itself takes a pulsing amber ring + ⚠ badge, because the answer is "build the road", not "wait for another deposit" |

Everything else is silent: no claims for materials nothing needs, nothing on a site that's already connected.

## Implementation notes

- Gaps are computed from **operational** factories only — a for-sale site needs nothing until you buy it.
- Cached against `networkVersion` + the node roster: it runs a `findPath` per (supplier, factory) pair and is read from the render loop, so it must not recompute per frame. Road builds already bump `networkVersion`, and unlocks change the roster.
- New `&gaps=1` probe flag (DEBUG.md) puts the map into both states at once — unlocks and buys a factory whose inputs have no supplier, then demolishes the bakery's wheat road, parking the fleet first since `demolish` rightly refuses a road with a truck on it.

## Verification

- **1332 tests pass / 0 failed** — 8 new: an owned-but-unroaded supplier flagged rather than treated as missing, each road built clearing exactly its own warning, sourceless↔unroaded flipping when a supplier is unlocked, and nothing raised at all for a material no operational factory takes.
- Screenshots both ways: the default probe (everything connected) is completely silent, and `&gaps=1` shows the ⚠ ring on the stranded wheat farm plus claims for the new factory's missing inputs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R62W4DvX6itVFg6uHhFtWu)_